### PR TITLE
Do not emit an unparseable client validator for a non-numeric comparison rule

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/TestValidators.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/TestValidators.cs
@@ -92,6 +92,21 @@ public class TestCommandWithConceptAndOwnValidatorValidator : BaseValidator<Test
     public TestCommandWithConceptAndOwnValidatorValidator() => RuleFor(x => x.Email).NotEmpty();
 }
 
+public class TestCommandWithDateComparison
+{
+    public DateOnly When { get; set; }
+    public int Age { get; set; }
+}
+
+public class TestCommandWithDateComparisonValidator : BaseValidator<TestCommandWithDateComparison>
+{
+    public TestCommandWithDateComparisonValidator()
+    {
+        RuleFor(x => x.When).GreaterThan(DateOnly.MinValue).WithMessage("The date must be set.");
+        RuleFor(x => x.Age).GreaterThanOrEqualTo(18);
+    }
+}
+
 public record RecordEmail(string Value) : ConceptAs<string>(Value);
 
 public class RecordEmailValidator : ConceptValidator<RecordEmail>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_a_comparison_rule_over_a_non_numeric_value.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_a_comparison_rule_over_a_non_numeric_value.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_ValidationRulesExtractor;
+
+/// <summary>
+/// A GreaterThan(DateOnly.MinValue) "must be set" sentinel has no client-side comparison the browser can evaluate,
+/// and its invariant text (01/01/0001) is not a TypeScript literal. It must be dropped, without taking the numeric
+/// rules on the same command down with it.
+/// </summary>
+public class when_extracting_a_comparison_rule_over_a_non_numeric_value : Specification
+{
+    IEnumerable<PropertyValidationDescriptor> _result;
+
+    void Because() => _result = ValidationRulesExtractor.ExtractValidationRules(
+        typeof(TestCommandWithDateComparison).Assembly,
+        typeof(TestCommandWithDateComparison));
+
+    [Fact] void should_not_project_the_date_comparison() => _result.Any(_ => _.PropertyName == "when").ShouldBeFalse();
+    [Fact] void should_still_project_the_numeric_comparison() => _result.Single(_ => _.PropertyName == "age").Rules.Single().RuleName.ShouldEqual("greaterThanOrEqual");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
@@ -85,8 +85,13 @@ public static class TemplateTypes
         null => "null",
         string text => FormatJavaScriptString(text),
         bool flag => flag ? "true" : "false",
-        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
-        _ => value.ToString() ?? string.Empty
+        byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal =>
+            ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture),
+
+        // Anything else — a date, say — has no bare TypeScript literal (its invariant text such as 01/01/0001 does
+        // not parse), so it is quoted. Numeric-only rules are the norm; this only guards an unexpected argument type.
+        IFormattable formattable => FormatJavaScriptString(formattable.ToString(null, CultureInfo.InvariantCulture)),
+        _ => FormatJavaScriptString(value.ToString())
     };
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
@@ -744,6 +744,14 @@ public static class ValidationRulesExtractor
             return null;
         }
 
+        // The client-side comparison validators operate on numbers, so a non-numeric constant comparison cannot be
+        // projected. In practice this is a "must be set" sentinel such as GreaterThan(DateOnly.MinValue), which the
+        // server still enforces; emitting it here would only produce a client rule the browser cannot evaluate.
+        if (!IsNumeric(valueToCompare))
+        {
+            return null;
+        }
+
         var comparison = comparisonProperty?.GetValue(validator);
         if (comparison == null)
         {
@@ -762,6 +770,9 @@ public static class ValidationRulesExtractor
             _ => null
         };
     }
+
+    static bool IsNumeric(object value) => value
+        is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal;
 
     static ValidationRuleDescriptor ExtractRegexRule(object validator, string? errorMessage)
     {


### PR DESCRIPTION
### Fixed

- A validation rule comparing against a non-numeric value — most often a `RuleFor(x => x.When).GreaterThan(DateOnly.MinValue)` "must be set" sentinel — generated a client validator that did not parse (`greaterThan(01/01/0001)`, an invalid TypeScript literal). The client-side comparison validators (`greaterThan`, `lessThan`, …) operate on numbers, so such a comparison is now skipped at extraction — the server still enforces it, there is simply no client rule to project. As a backstop, any non-numeric argument that still reaches the formatter is quoted, so no unparseable literal can be emitted.

---

This was latent until validator rules actually reached the generated proxies (#2363): before that, no FluentValidation rule was extracted at all, so the comparison path never ran. Verified end to end against a real application's regenerated proxies — the date-sentinel rules are dropped and the numeric comparisons (`greaterThan(0)`, `greaterThanOrEqualTo(18)`) are unchanged. Proven to have teeth by reverting the extraction guard and watching the new spec fail. Full suite green: 3,964 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)