### PR TITLE
Attribute a command's client validation rules to the command, and emit a regex rule as a RegExp literal

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ModelBound/for_CommandExtensions/TestCommands3.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ModelBound/for_CommandExtensions/TestCommands3.cs
@@ -15,8 +15,11 @@ public class ContactEmailAddressValidator : ConceptValidator<ContactEmailAddress
     public ContactEmailAddressValidator() => RuleFor(x => x.Value).NotEmpty().EmailAddress();
 }
 
-// The value Provide() resolves and Handle() consumes - it carries a validated concept, but it is not the command,
-// so its rules must not surface on the command's generated validator.
+/// <summary>
+/// The value <c>Provide()</c> resolves and <c>Handle()</c> consumes: it carries a validated concept, but it is not
+/// the command, so its rules must not surface on the command's generated validator.
+/// </summary>
+/// <param name="Email">The contact email address.</param>
 public record InvitationTarget(ContactEmailAddress Email);
 
 [Command]

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ModelBound/for_CommandExtensions/TestCommands3.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ModelBound/for_CommandExtensions/TestCommands3.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.ProxyGenerator.ModelBound.for_CommandExtensions.TestTypes.Invitations;
+
+public record ContactEmailAddress(string Value) : ConceptAs<string>(Value);
+
+public class ContactEmailAddressValidator : ConceptValidator<ContactEmailAddress>
+{
+    public ContactEmailAddressValidator() => RuleFor(x => x.Value).NotEmpty().EmailAddress();
+}
+
+// The value Provide() resolves and Handle() consumes - it carries a validated concept, but it is not the command,
+// so its rules must not surface on the command's generated validator.
+public record InvitationTarget(ContactEmailAddress Email);
+
+[Command]
+public class InviteContact
+{
+    public string OrganizationNumber { get; set; } = string.Empty;
+
+    public InvitationTarget Provide() => new(new ContactEmailAddress(string.Empty));
+
+    public void Handle(InvitationTarget target)
+    {
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ModelBound/for_CommandExtensions/when_converting_a_command_whose_handle_consumes_a_provided_value.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ModelBound/for_CommandExtensions/when_converting_a_command_whose_handle_consumes_a_provided_value.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.ModelBound.for_CommandExtensions;
+
+/// <summary>
+/// A model-bound command's Handle takes the value its Provide() resolved, not the command. When that value carries a
+/// validated concept and the command itself has no client-projectable rule, the descriptor must still be empty - the
+/// value's rules belong to the value, never to the command.
+/// </summary>
+public class when_converting_a_command_whose_handle_consumes_a_provided_value : Specification
+{
+    CommandDescriptor _result;
+
+    void Because() => _result = typeof(TestTypes.Invitations.InviteContact).GetTypeInfo().ToCommandDescriptor(
+        "/output",
+        segmentsToSkip: 5,
+        skipCommandNameInRoute: false,
+        apiPrefix: "api",
+        [typeof(TestTypes.Invitations.InviteContact).GetTypeInfo()]);
+
+    [Fact] void should_not_carry_the_provided_values_rules() => _result.ValidationRules.ShouldBeEmpty();
+    [Fact] void should_not_declare_it_has_validation_rules() => _result.HasValidationRules.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithValidation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithValidation.cs
@@ -11,6 +11,7 @@ public class CommandWithValidation
     public string Email { get; set; } = string.Empty;
     public int Age { get; set; }
     public string Name { get; set; } = string.Empty;
+    public string PostalCode { get; set; } = string.Empty;
 }
 
 public class CommandWithValidationValidator : BaseValidator<CommandWithValidation>
@@ -20,5 +21,6 @@ public class CommandWithValidationValidator : BaseValidator<CommandWithValidatio
         RuleFor(x => x.Email).NotEmpty().WithMessage("Email is required").EmailAddress();
         RuleFor(x => x.Age).GreaterThanOrEqualTo(18);
         RuleFor(x => x.Name).NotEmpty().MinimumLength(2).MaximumLength(50);
+        RuleFor(x => x.PostalCode).Matches(@"^\d{4}$");
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_validation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_validation.cs
@@ -68,6 +68,7 @@ public class when_generating_command_with_validation : Specification, IDisposabl
     [Fact] void should_contain_greater_than_or_equal_rule() => _generatedCode.ShouldContain(".greaterThanOrEqual(18)");
     [Fact] void should_contain_min_length_rule_for_name() => _generatedCode.ShouldContain(".minLength(2)");
     [Fact] void should_contain_max_length_rule_for_name() => _generatedCode.ShouldContain(".maxLength(50)");
+    [Fact] void should_emit_the_regex_rule_as_a_regular_expression_literal() => _generatedCode.ShouldContain(@".matches(/^\d{4}$/)");
     [Fact] void should_be_valid_typescript() => _typeScriptIsValid.ShouldBeTrue();
 
     public void Dispose() => _runtime?.Dispose();

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/TestValidators.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/TestValidators.cs
@@ -98,6 +98,16 @@ public class TestCommandWithDateComparison
     public int Age { get; set; }
 }
 
+public class TestCommandWithRegex
+{
+    public string PostalCode { get; set; } = string.Empty;
+}
+
+public class TestCommandWithRegexValidator : BaseValidator<TestCommandWithRegex>
+{
+    public TestCommandWithRegexValidator() => RuleFor(x => x.PostalCode).Matches(@"^\d{4}$");
+}
+
 public class TestCommandWithDateComparisonValidator : BaseValidator<TestCommandWithDateComparison>
 {
     public TestCommandWithDateComparisonValidator()

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_a_regex_rule.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_a_regex_rule.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_ValidationRulesExtractor;
+
+/// <summary>
+/// The client-side <c>matches</c> rule takes a regular expression, not a string, so the pattern is carried as a
+/// <see cref="RegularExpressionPattern"/> the formatter can emit as a regex literal.
+/// </summary>
+public class when_extracting_a_regex_rule : Specification
+{
+    ValidationRuleDescriptor _rule;
+
+    void Because() => _rule = ValidationRulesExtractor.ExtractValidationRules(
+            typeof(TestCommandWithRegex).Assembly,
+            typeof(TestCommandWithRegex))
+        .Single(_ => _.PropertyName == "postalCode").Rules.Single();
+
+    [Fact] void should_be_the_matches_rule() => _rule.RuleName.ShouldEqual("matches");
+    [Fact] void should_carry_the_pattern_as_a_regular_expression() => _rule.Arguments.Single().ShouldBeOfExactType<RegularExpressionPattern>();
+    [Fact] void should_preserve_the_pattern() => ((RegularExpressionPattern)_rule.Arguments.Single()).Pattern.ShouldEqual(@"^\d{4}$");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
@@ -74,12 +74,15 @@ public static class CommandExtensions
         // Use override documentation if provided (for model-bound commands), otherwise use method documentation
         var documentation = overrideDocumentation ?? method.GetDocumentation();
 
-        // Use provided validation rules or extract them from command type
-        var rules = validationRules ?? [];
-        if (!rules.Any())
+        // Fall back to extracting from the method's command parameter only when no rules were supplied at all. A
+        // caller that supplied an empty set - a model-bound command whose validator holds no client-projectable rule
+        // - means exactly that; treating empty as "not supplied" here would re-extract from GetCommandType, which for
+        // a model-bound Handle(target) resolves to the provided-value type rather than the command.
+        var rules = validationRules;
+        if (rules is null)
         {
             var commandType = method.GetCommandType();
-            rules = commandType != null
+            rules = commandType is not null
                 ? ValidationRulesExtractor.ExtractValidationRules(method.DeclaringType!.Assembly, commandType)
                 : [];
         }

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/RegularExpressionPattern.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/RegularExpressionPattern.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Templates;
+
+/// <summary>
+/// A regular-expression pattern carried as a rule argument, so the formatter emits it as a JavaScript regular
+/// expression literal rather than a string - the client-side <c>matches</c> rule takes a <see cref="System.Text.RegularExpressions.Regex"/>, not a string.
+/// </summary>
+/// <param name="Pattern">The regular expression pattern.</param>
+public record RegularExpressionPattern(string Pattern);

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
@@ -77,12 +77,14 @@ public static class TemplateTypes
     /// <param name="value">The argument value.</param>
     /// <returns>The formatted literal.</returns>
     /// <remarks>
-    /// A string argument — a <c>matches()</c> pattern in particular — has to be emitted as a quoted, escaped literal.
-    /// Writing it bare produces TypeScript that does not parse.
+    /// A string argument is emitted as a quoted, escaped literal; writing it bare produces TypeScript that does not
+    /// parse. A regular-expression pattern is emitted as a regex literal, which is what the client-side
+    /// <c>matches</c> rule expects.
     /// </remarks>
     static string FormatRuleArgument(object? value) => value switch
     {
         null => "null",
+        RegularExpressionPattern regex => FormatRegularExpression(regex.Pattern),
         string text => FormatJavaScriptString(text),
         bool flag => flag ? "true" : "false",
         byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal =>
@@ -93,6 +95,26 @@ public static class TemplateTypes
         IFormattable formattable => FormatJavaScriptString(formattable.ToString(null, CultureInfo.InvariantCulture)),
         _ => FormatJavaScriptString(value.ToString())
     };
+
+    /// <summary>
+    /// Formats a pattern as a JavaScript regular-expression literal.
+    /// </summary>
+    /// <param name="pattern">The pattern to format.</param>
+    /// <returns>The regular-expression literal.</returns>
+    /// <remarks>
+    /// An empty pattern becomes <c>/(?:)/</c> rather than <c>//</c>, which JavaScript reads as a line comment; a
+    /// literal slash in the pattern is escaped so it does not close the literal early.
+    /// </remarks>
+    static string FormatRegularExpression(string pattern)
+    {
+        if (string.IsNullOrEmpty(pattern))
+        {
+            return "/(?:)/";
+        }
+
+        var escaped = pattern.Replace("\r", "\\r").Replace("\n", "\\n").Replace("/", "\\/");
+        return $"/{escaped}/";
+    }
 
     /// <summary>
     /// Formats a value as a single-quoted, escaped JavaScript string literal.

--- a/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
@@ -290,7 +290,7 @@ public static class ValidationRulesExtractor
                     {
                         var pattern = GetConstructorArgument<string>(attributeData, 0) ?? string.Empty;
                         var errorMessage = GetNamedArgument<string>(attributeData, "ErrorMessage");
-                        rules.Add(new ValidationRuleDescriptor("matches", [pattern], errorMessage));
+                        rules.Add(new ValidationRuleDescriptor("matches", [new RegularExpressionPattern(pattern)], errorMessage));
                         break;
                     }
                 case "System.ComponentModel.DataAnnotations.EmailAddressAttribute":
@@ -780,6 +780,6 @@ public static class ValidationRulesExtractor
         var expressionProperty = validatorType.GetProperty("Expression");
         var pattern = expressionProperty?.GetValue(validator)?.ToString() ?? string.Empty;
 
-        return new ValidationRuleDescriptor("matches", [pattern], errorMessage);
+        return new ValidationRuleDescriptor("matches", [new RegularExpressionPattern(pattern)], errorMessage);
     }
 }


### PR DESCRIPTION
### Fixed

- **A model-bound command's client validation rules were taken from the wrong type.** When a command's own validator held no client-projectable rule, `ToCommandDescriptor` treated the supplied-but-empty rule set as "not supplied" and re-extracted from the `Handle` method's parameter — which for a model-bound command is the value `Provide()` resolves, not the command. A command whose `Provide()` returns a record carrying a validated concept (e.g. an `Email`) then had that concept's rules emitted on its own generated validator, bound to a field the command does not have — invalid TypeScript. "No rules supplied" (`null`) is now distinguished from "supplied, empty", so the fallback runs only for the controller path it was written for.
- **A regex rule was emitted as a quoted string**, but the client-side `matches` rule takes a `RegExp`. The pattern is now carried through as a `RegularExpressionPattern` and formatted as a regex literal — an empty pattern as `/(?:)/`, a literal slash escaped — so `matches(/^\d{4}$/)` is generated rather than an unassignable `matches('^\d{4}$')`.

---

Both were latent until validator rules first reached generated proxies (#2363); before that, no rule was extracted, so neither path ran. Verified end to end against a real application's regenerated proxies: the leaked command validators are gone and every `matches` rule is a valid regex literal that typechecks. New specs cover both and were confirmed to have teeth. Full suite green: 3,970 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)