### PR TITLE
Fix process crash when an observable-query client disconnects mid-emission

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_emission_arrives_after_connection_is_disposed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_emission_arrives_after_connection_is_disposed.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// Reproduces the production-crashing race where an observable-query emission is in flight (interception has
+/// not yet completed) at the moment the SSE connection ends and its per-subscription resources — the emission
+/// gate (a <see cref="SemaphoreSlim"/>) and the linked <see cref="CancellationTokenSource"/> — are disposed.
+/// When the emission then resumes it touches those disposed objects; because the emission callback is
+/// <c>async void</c>, the resulting <see cref="ObjectDisposedException"/> would previously go unhandled on a
+/// background thread and terminate the whole process. The emission must instead be handled gracefully.
+/// </summary>
+public class and_emission_arrives_after_connection_is_disposed : given.an_observable_query_demultiplexer
+{
+    const string ControllerQueryName = "Cratis.Chronicle.Api.EventStores.EventStoreQueries.AllEventStores";
+    const string QueryId = "query-1";
+
+    IQueryHealthTracker _observableHealthTracker;
+    IHttpRequestContext _connectionContext;
+    IHttpRequestContext _subscribeContext;
+    CancellationTokenSource _connectionCancellation;
+    ConcurrentQueue<string> _messages;
+    BehaviorSubject<IEnumerable<string>> _subject;
+    TaskCompletionSource<IEnumerable<object>> _interceptionGate;
+    TaskCompletionSource _dataServed;
+    string _connectionId;
+    bool _connectionCompleted;
+    Exception _thrownWhenReleasingInFlightEmission;
+
+    void Establish()
+    {
+        _connectionCancellation = new CancellationTokenSource();
+        _messages = [];
+        _connectionId = string.Empty;
+        _interceptionGate = new TaskCompletionSource<IEnumerable<object>>();
+        _dataServed = new TaskCompletionSource();
+
+        // Rebuild the hub with a health tracker we can observe: RecordDataServed is invoked by the emission
+        // path only after the transport send returns, so its call is the signal that the in-flight emission
+        // ran to completion gracefully instead of crashing.
+        _observableHealthTracker = Substitute.For<IQueryHealthTracker>();
+        _observableHealthTracker
+            .When(_ => _.RecordDataServed(Arg.Any<string>(), Arg.Any<string>()))
+            .Do(_ => _dataServed.TrySetResult());
+
+        _hub = new ObservableQueryDemultiplexer(
+            _queryPipeline,
+            _queryContextManager,
+            _httpRequestContextAccessor,
+            _hostApplicationLifetime,
+            _readModelInterceptors,
+            _serviceProvider,
+            _arcOptions,
+            _observableHealthTracker,
+            _logger);
+
+        // Hold interception open so the first emission stays in flight (holding the emission gate) while the
+        // connection is torn down underneath it.
+        _readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(_ => _interceptionGate.Task);
+
+        _subject = new BehaviorSubject<IEnumerable<string>>([]);
+        _queryPipeline.Perform(
+                Arg.Any<FullyQualifiedQueryName>(),
+                Arg.Any<QueryArguments>(),
+                Arg.Any<Paging>(),
+                Arg.Any<Sorting>(),
+                Arg.Any<IServiceProvider>())
+            .Returns(_ =>
+            {
+                var queryResult = QueryResult.Success(CorrelationId.New());
+                queryResult.Data = _subject;
+                return Task.FromResult(queryResult);
+            });
+
+        _connectionContext = Substitute.For<IHttpRequestContext>();
+        _connectionContext.RequestAborted.Returns(_connectionCancellation.Token);
+        _connectionContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _connectionContext.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _messages.Enqueue(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        _subscribeContext = Substitute.For<IHttpRequestContext>();
+        _subscribeContext.RequestAborted.Returns(CancellationToken.None);
+        _subscribeContext.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<object?>(new ObservableQuerySSESubscribeRequest(
+                _connectionId,
+                QueryId,
+                new ObservableQuerySubscriptionRequest(ControllerQueryName))));
+    }
+
+    async Task Because()
+    {
+        var connectionTask = _hub.HandleSSEConnection(_connectionContext);
+
+        await WaitFor(() => TryExtractConnectionId(out _connectionId));
+
+        // Subscribing to the BehaviorSubject immediately delivers its current value, so an emission is now in
+        // flight and suspended inside interception, holding the emission gate.
+        await _hub.HandleSSESubscribe(_subscribeContext);
+        await WaitFor(() => _readModelInterceptors.ReceivedCalls().Any());
+
+        // Tear the connection down. The finally disposes the subscription (and thus the emission gate) and,
+        // on return, the linked cancellation source — all while the emission is still in flight.
+        await _connectionCancellation.CancelAsync();
+        await connectionTask;
+        _connectionCompleted = true;
+
+        // Let the in-flight emission resume against the now-disposed resources. Before the fix this crashed
+        // the process; it must now be a graceful no-op.
+        try
+        {
+            _interceptionGate.SetResult(["item-a"]);
+            await WaitFor(() => _dataServed.Task.IsCompleted);
+        }
+        catch (Exception ex)
+        {
+            _thrownWhenReleasingInFlightEmission = ex;
+        }
+    }
+
+    [Fact] void should_complete_the_connection_cleanly() => _connectionCompleted.ShouldBeTrue();
+    [Fact] void should_not_throw_when_the_in_flight_emission_resumes() => _thrownWhenReleasingInFlightEmission.ShouldBeNull();
+    [Fact] void should_handle_the_late_emission_gracefully() => _dataServed.Task.IsCompleted.ShouldBeTrue();
+    [Fact] void should_not_write_a_query_result_to_the_disposed_connection() => HasQueryResultMessage().ShouldBeFalse();
+
+    bool HasQueryResultMessage() =>
+        _messages
+            .Select(TryParseHubMessage)
+            .Any(_ => _ is { Type: ObservableQueryHubMessageType.QueryResult } message && message.QueryId == QueryId);
+
+    bool TryExtractConnectionId(out string connectionId)
+    {
+        connectionId = string.Empty;
+
+        foreach (var hubMessage in _messages
+                     .Select(TryParseHubMessage)
+                     .Where(_ => _ is not null)
+                     .Select(_ => _!))
+        {
+            if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
+            {
+                continue;
+            }
+
+            connectionId = payload.GetString() ?? string.Empty;
+            return !string.IsNullOrEmpty(connectionId);
+        }
+
+        return false;
+    }
+
+    ObservableQueryHubMessage? TryParseHubMessage(string sseMessage)
+    {
+        if (!sseMessage.StartsWith("data: ", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var json = sseMessage["data: ".Length..].Trim();
+        return JsonSerializer.Deserialize<ObservableQueryHubMessage>(json, _arcOptions.Value.JsonSerializerOptions);
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_emission_arrives_after_connection_is_disposed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_emission_arrives_after_connection_is_disposed.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+/// <summary>
+/// Reproduces the production-crashing race on the WebSocket path where an observable-query emission is in
+/// flight when the connection ends and its per-connection resources — the write lock (a
+/// <see cref="SemaphoreSlim"/>), the emission gate and the linked <see cref="CancellationTokenSource"/> — are
+/// disposed. When the emission resumes it touches those disposed objects; because the emission callback is
+/// <c>async void</c>, the resulting <see cref="ObjectDisposedException"/> would previously terminate the whole
+/// process. The emission must instead be handled gracefully.
+/// </summary>
+public class and_emission_arrives_after_connection_is_disposed : given.an_observable_query_demultiplexer
+{
+    const string ControllerQueryName = "Cratis.Chronicle.Api.EventStores.EventStoreQueries.AllEventStores";
+    const string QueryId = "query-1";
+
+    IQueryHealthTracker _observableHealthTracker;
+    IHttpRequestContext _context;
+    IWebSocketContext _webSocketContext;
+    IWebSocket _webSocket;
+    BehaviorSubject<IEnumerable<string>> _subject;
+    ConcurrentQueue<ObservableQueryHubMessage> _sentMessages;
+    TaskCompletionSource<IEnumerable<object>> _interceptionGate;
+    TaskCompletionSource _dataServed;
+    int _receiveCount;
+    bool _closeRequested;
+    bool _connectionCompleted;
+    Exception _thrownWhenReleasingInFlightEmission;
+
+    void Establish()
+    {
+        _receiveCount = 0;
+        _sentMessages = [];
+        _interceptionGate = new TaskCompletionSource<IEnumerable<object>>();
+        _dataServed = new TaskCompletionSource();
+
+        // Rebuild the hub with a health tracker we can observe: RecordDataServed is invoked by the emission
+        // path only after the transport send returns, so its call is the signal that the in-flight emission
+        // ran to completion gracefully instead of crashing.
+        _observableHealthTracker = Substitute.For<IQueryHealthTracker>();
+        _observableHealthTracker
+            .When(_ => _.RecordDataServed(Arg.Any<string>(), Arg.Any<string>()))
+            .Do(_ => _dataServed.TrySetResult());
+
+        _hub = new ObservableQueryDemultiplexer(
+            _queryPipeline,
+            _queryContextManager,
+            _httpRequestContextAccessor,
+            _hostApplicationLifetime,
+            _readModelInterceptors,
+            _serviceProvider,
+            _arcOptions,
+            _observableHealthTracker,
+            _logger);
+
+        // Hold interception open so the first emission stays in flight (holding the emission gate) while the
+        // connection is torn down underneath it.
+        _readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(_ => _interceptionGate.Task);
+
+        _subject = new BehaviorSubject<IEnumerable<string>>([]);
+        _queryPipeline.Perform(
+                Arg.Any<FullyQualifiedQueryName>(),
+                Arg.Any<QueryArguments>(),
+                Arg.Any<Paging>(),
+                Arg.Any<Sorting>(),
+                Arg.Any<IServiceProvider>())
+            .Returns(_ =>
+            {
+                var queryResult = QueryResult.Success(CorrelationId.New());
+                queryResult.Data = _subject;
+                return Task.FromResult(queryResult);
+            });
+
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(CancellationToken.None);
+        _context.RequestServices.Returns(Substitute.For<IServiceProvider>());
+
+        _webSocketContext = Substitute.For<IWebSocketContext>();
+        _context.WebSockets.Returns(_webSocketContext);
+
+        _webSocket = Substitute.For<IWebSocket>();
+        _webSocket.State.Returns(WebSocketState.Open);
+        _webSocketContext.AcceptWebSocket(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(_webSocket));
+
+        _webSocket.Receive(Arg.Any<ArraySegment<byte>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => ReceiveNextMessage(callInfo.Arg<ArraySegment<byte>>()));
+
+        _webSocket.Send(Arg.Any<ArraySegment<byte>>(), Arg.Any<System.Net.WebSockets.WebSocketMessageType>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var data = callInfo.Arg<ArraySegment<byte>>();
+                var json = System.Text.Encoding.UTF8.GetString(data.Array!, data.Offset, data.Count);
+                var hubMessage = JsonSerializer.Deserialize<ObservableQueryHubMessage>(json, _arcOptions.Value.JsonSerializerOptions);
+                if (hubMessage is not null)
+                {
+                    _sentMessages.Enqueue(hubMessage);
+                }
+
+                return Task.CompletedTask;
+            });
+
+        _webSocket.Close(Arg.Any<WebSocketCloseStatus>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+    }
+
+    async Task Because()
+    {
+        var connectionTask = _hub.HandleWebSocketConnection(_context);
+
+        // Subscribing to the BehaviorSubject immediately delivers its current value, so an emission is now in
+        // flight and suspended inside interception, holding the emission gate.
+        await WaitFor(() => _readModelInterceptors.ReceivedCalls().Any());
+
+        // Close the socket. The finally disposes the subscription (emission gate), the write lock and the
+        // linked cancellation source — all while the emission is still in flight.
+        _closeRequested = true;
+        await connectionTask;
+        _connectionCompleted = true;
+
+        // Let the in-flight emission resume against the now-disposed resources. Before the fix this crashed
+        // the process; it must now be a graceful no-op.
+        try
+        {
+            _interceptionGate.SetResult(["item-a"]);
+            await WaitFor(() => _dataServed.Task.IsCompleted);
+        }
+        catch (Exception ex)
+        {
+            _thrownWhenReleasingInFlightEmission = ex;
+        }
+    }
+
+    [Fact] void should_complete_the_connection_cleanly() => _connectionCompleted.ShouldBeTrue();
+    [Fact] void should_not_throw_when_the_in_flight_emission_resumes() => _thrownWhenReleasingInFlightEmission.ShouldBeNull();
+    [Fact] void should_handle_the_late_emission_gracefully() => _dataServed.Task.IsCompleted.ShouldBeTrue();
+    [Fact] void should_not_send_a_query_result_over_the_disposed_socket() => HasQueryResultMessage().ShouldBeFalse();
+
+    bool HasQueryResultMessage() =>
+        _sentMessages.Any(_ => _.Type == ObservableQueryHubMessageType.QueryResult && _.QueryId == QueryId);
+
+    async Task<WebSocketReceiveResult> ReceiveNextMessage(ArraySegment<byte> buffer)
+    {
+        if (_receiveCount == 0)
+        {
+            _receiveCount++;
+
+            var subscribeMessage = new ObservableQueryHubMessage
+            {
+                Type = ObservableQueryHubMessageType.Subscribe,
+                QueryId = QueryId,
+                Payload = new ObservableQuerySubscriptionRequest(ControllerQueryName)
+            };
+
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(subscribeMessage, _arcOptions.Value.JsonSerializerOptions);
+            Array.Copy(bytes, 0, buffer.Array!, buffer.Offset, bytes.Length);
+            return new WebSocketReceiveResult(bytes.Length, System.Net.WebSockets.WebSocketMessageType.Text, true);
+        }
+
+        // Keep the connection open until the spec asks it to close, then signal a normal close so the read
+        // loop exits and the connection is torn down.
+        while (!_closeRequested)
+        {
+            await Task.Delay(10);
+        }
+
+        return new WebSocketReceiveResult(0, System.Net.WebSockets.WebSocketMessageType.Close, true, WebSocketCloseStatus.NormalClosure, "done");
+    }
+}

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -158,15 +158,18 @@ public class ObservableQueryDemultiplexer(
         {
             _sseConnections.TryRemove(connectionId, out _);
 
+            // Signal cancellation and drain the keep-alive loop before disposing the per-subscription
+            // resources, so an in-flight emission observes the cancellation and stops touching the write lock
+            // and cancellation source before they are torn down, rather than racing against their disposal.
+            await linkedCts.CancelAsync();
+            await keepAliveTask;
+
             foreach (var subscription in state.Subscriptions.Values)
             {
                 subscription.Dispose();
             }
 
             state.Subscriptions.Clear();
-
-            await linkedCts.CancelAsync();
-            await keepAliveTask;
         }
 
         logger.SseClientDisconnected(connectionId);
@@ -588,6 +591,14 @@ public class ObservableQueryDemultiplexer(
 
         return new CompositeDisposable(subscription, emissionGate);
 
+        // This is an async void callback invoked by the subject on a background (ThreadPool) thread. Any
+        // exception that escapes it is unobserved and terminates the whole process. The connection's
+        // per-subscription resources (the emission gate, the write lock and the linked cancellation source)
+        // are disposed the moment the client disconnects, and an emission already in flight then races against
+        // that disposal — touching a disposed SemaphoreSlim or CancellationTokenSource throws
+        // ObjectDisposedException. The entire body is therefore wrapped so that nothing can propagate: the
+        // expected disconnect signals (cancellation, disposal, broken transport) become no-ops, and only a
+        // genuine failure is surfaced to the subscriber.
         async void OnEmission(T data)
         {
             if (token.IsCancellationRequested)
@@ -595,9 +606,12 @@ public class ObservableQueryDemultiplexer(
                 return;
             }
 
-            await emissionGate.WaitAsync(token);
+            var gateAcquired = false;
             try
             {
+                await emissionGate.WaitAsync(token);
+                gateAcquired = true;
+
                 var interceptedData = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
 
                 var isFirstEmission = previousItems is null;
@@ -648,12 +662,24 @@ public class ObservableQueryDemultiplexer(
             }
             catch (OperationCanceledException)
             {
-                // Connection cancelled — nothing to report.
+                // The connection was cancelled — expected when the client disconnects. No-op.
+                logger.EmissionAfterDisconnect(queryId);
             }
-            catch (Exception error) when (error is not IOException)
+            catch (ObjectDisposedException)
             {
-                // Transport errors (broken pipe, reset connection) indicate the client disconnected and are
-                // ignored; anything else is a genuine failure that must be surfaced to the subscriber.
+                // A per-subscription resource (emission gate / write lock / cancellation source) was disposed
+                // while this emission was in flight — expected when the client disconnects mid-emission. This
+                // must never escape an async void callback, so it is swallowed and treated as a no-op.
+                logger.EmissionAfterDisconnect(queryId);
+            }
+            catch (IOException)
+            {
+                // Transport error (broken pipe, reset connection) — the client disconnected. Ignored.
+                logger.EmissionAfterDisconnect(queryId);
+            }
+            catch (Exception error)
+            {
+                // Anything else is a genuine failure that must be surfaced to the subscriber.
                 if (!token.IsCancellationRequested)
                 {
                     logger.SubscriptionError(queryId, error);
@@ -662,7 +688,18 @@ public class ObservableQueryDemultiplexer(
             }
             finally
             {
-                emissionGate.Release();
+                if (gateAcquired)
+                {
+                    try
+                    {
+                        emissionGate.Release();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // The emission gate was disposed while this emission was in flight — expected on
+                        // client disconnect. There is nothing to release.
+                    }
+                }
             }
         }
 
@@ -746,6 +783,10 @@ public class ObservableQueryDemultiplexer(
         {
             // Transport error — client disconnected. Do not forward to the client.
         }
+        catch (ObjectDisposedException)
+        {
+            // The connection's resources were disposed while streaming — expected on client disconnect.
+        }
         catch (Exception ex)
         {
             logger.SubscriptionError(queryId, ex);
@@ -782,6 +823,11 @@ public class ObservableQueryDemultiplexer(
         {
             // Normal shutdown or token cancelled
         }
+        catch (ObjectDisposedException)
+        {
+            // The write lock or the linked cancellation source was disposed as the connection ended —
+            // expected when the client disconnects. Nothing to send.
+        }
         catch (Exception ex)
         {
             logger.ErrorSendingMessage(ex);
@@ -790,7 +836,14 @@ public class ObservableQueryDemultiplexer(
         {
             if (lockHeld)
             {
-                writeLock.Release();
+                try
+                {
+                    writeLock.Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The write lock was disposed while sending — expected on client disconnect.
+                }
             }
         }
     }
@@ -816,22 +869,27 @@ public class ObservableQueryDemultiplexer(
         catch (HttpListenerException)
         {
             // Client disconnected — cancel the connection token source to trigger cleanup.
-            await cts.CancelAsync();
+            await CancelQuietly(cts);
         }
         catch (IOException)
         {
             // On macOS and some .NET runtimes, HttpListener throws IOException for broken-pipe
             // instead of HttpListenerException — treat identically.
-            await cts.CancelAsync();
+            await CancelQuietly(cts);
         }
         catch (ArgumentNullException ex) when (ex.ParamName == "array")
         {
             // StreamPipeWriter can throw this during response teardown when writes race with transport shutdown.
-            await cts.CancelAsync();
+            await CancelQuietly(cts);
         }
         catch (OperationCanceledException)
         {
             // Normal shutdown — nothing to report.
+        }
+        catch (ObjectDisposedException)
+        {
+            // The linked cancellation source (or write lock) was disposed as the connection ended — expected
+            // when the client disconnects mid-write. Nothing to send.
         }
         catch (Exception ex)
         {
@@ -841,7 +899,14 @@ public class ObservableQueryDemultiplexer(
         {
             if (writeLockHeld)
             {
-                writeLock.Release();
+                try
+                {
+                    writeLock.Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The write lock was disposed while sending — expected on client disconnect.
+                }
             }
         }
     }
@@ -911,6 +976,25 @@ public class ObservableQueryDemultiplexer(
     }
 
 #pragma warning disable SA1204 // Static members should appear before non-static members
+
+    /// <summary>
+    /// Cancels a <see cref="CancellationTokenSource"/> while tolerating it already having been disposed as the
+    /// connection ended — cancelling a disposed source would otherwise throw <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    /// <param name="cts">The <see cref="CancellationTokenSource"/> to cancel.</param>
+    /// <returns>Awaitable task.</returns>
+    static async Task CancelQuietly(CancellationTokenSource cts)
+    {
+        try
+        {
+            await cts.CancelAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already disposed as the connection ended — nothing to cancel.
+        }
+    }
+
     static bool IsStreamingResult(object data) =>
         data.GetType().ImplementsOpenGeneric(typeof(ISubject<>)) ||
         data.GetType().ImplementsOpenGeneric(typeof(IAsyncEnumerable<>));

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexerLogMessages.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexerLogMessages.cs
@@ -48,4 +48,7 @@ internal static partial class ObservableQueryDemultiplexerLogMessages
 
     [LoggerMessage(LogLevel.Error, "Error in observable subscription for query id '{QueryId}'")]
     internal static partial void SubscriptionError(this ILogger<ObservableQueryDemultiplexer> logger, string queryId, Exception ex);
+
+    [LoggerMessage(LogLevel.Debug, "Emission for query id '{QueryId}' arrived after the connection was disposed — dropping it as the client has disconnected")]
+    internal static partial void EmissionAfterDisconnect(this ILogger<ObservableQueryDemultiplexer> logger, string queryId);
 }


### PR DESCRIPTION
## Fixed

- Fixed a process crash in observable-query streaming (SSE and WebSocket) when a client disconnects while an emission is in flight. The emission callback is `async void` and, once the connection's write lock, emission gate and cancellation source are disposed on disconnect, the in-flight emission threw `ObjectDisposedException` on a background thread, which went unhandled and terminated the whole process. Disconnecting mid-emission is now a graceful no-op: the expected cancellation/disposal/transport signals are swallowed and only genuine failures are surfaced to the subscriber.