### PR TITLE
Add Cratis.Arc.Screenplay package for generating Screenplay from Arc source

### DIFF
--- a/Arc.slnx
+++ b/Arc.slnx
@@ -30,6 +30,8 @@
         <Project Path="Source\DotNET\Swagger\Swagger.csproj" />
         <Project Path="Source\DotNET\OpenApi\OpenApi.csproj" />
         <Project Path="Source\DotNET\OpenApi.Specs\OpenApi.Specs.csproj" />
+        <Project Path="Source\DotNET\Screenplay\Screenplay.csproj" />
+        <Project Path="Source\DotNET\Screenplay.Specs\Screenplay.Specs.csproj" />
     </Folder>
     <Folder Name="/Source/DotNET/Tools/">
         <Project Path="Source\DotNET\Tools\ProxyGenerator\ProxyGenerator.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.7.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.6" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.6" />
+    <PackageVersion Include="Cratis.Screenplay" Version="1.5.2" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />

--- a/Documentation/generating-a-screenplay.md
+++ b/Documentation/generating-a-screenplay.md
@@ -50,6 +50,26 @@ transported rather than what it is, so the query was left out (Library.Messaging
 
 Diagnostics come in three severities. **Information** means something is worth knowing but the document is complete. **Warning** means something was left out. **Error** means the document should not be trusted at all — the most common cause being source that did not compile.
 
+## Screens
+
+A [vertical slice](./vertical-slices.md) puts the React component that realizes a slice's screen in the same folder as its C#. Roslyn syntax trees carry real file paths, so the generator knows where each slice's source lives and declares a `screen` for every `.tsx` component sitting next to it, named after the file:
+
+```text
+slice StateChange Registration
+  command RegisterAuthor
+    name : AuthorName
+
+  screen AddAuthor
+    file Authors/Registration/AddAuthor.tsx
+```
+
+That is the whole of it — the `file` form and nothing else. The declarative form (`data … via query …`, `section`, `table`, `summary`, `action`, `navigate to`) is never inferred, because it would have to be read out of TypeScript rather than out of the compilation, and a guess at a screen's structure is worse than a pointer to the file that actually is it. Write those directives by hand if you want them, and expect a regeneration to leave them out.
+
+Two rules keep the result honest:
+
+- **Components only, no descending.** A file carrying a second extension — `AddAuthor.stories.tsx`, `AddAuthor.spec.tsx` — is a companion of a component, not a screen. A folder *inside* a slice folder is a slice of its own under the same convention, so its files belong to it.
+- **Anything uncertain is reported.** The relationship between a file and a slice comes entirely from where the file sits, so `SP0025` is reported whenever sitting there says less than usual: a slice whose source is spread over several folders, one folder holding the source of several slices, or two files claiming a single screen name.
+
 ## What is not expressed
 
 A `.play` is a description of an application, not a second copy of it. **It does not round-trip back to code**, and reading one will not tell you everything the code does. The losses run in both directions.
@@ -63,9 +83,8 @@ These are part of the language, but nothing in C# says them, so a generated docu
 | `capture` | Describes ingesting an external system. Nothing in an Arc application declares one. |
 | `persona` | Who uses the system is a product decision, not a code artifact. |
 | `seed` | Sample data is a modeling concern, not something the source states. |
-| `screen` | Screens are React components; their structure is not recoverable from C#. |
+| The declarative form of `screen` | What a screen shows and does is written in TypeScript and JSX. Only the `file` reference is generated — see [Screens](#screens). |
 | `@sensitive` | Only `[PII]` has a counterpart. Other sensitivity levels are not declared in Arc. |
-| Named authorization policies | `[Authorize(Policy = "…")]` names a policy whose rule lives in host configuration, not in the attribute. Roles are recovered; policy bodies are not. |
 
 ### Detail Screenplay cannot represent
 
@@ -75,7 +94,8 @@ These exist in your application and have no counterpart in the language. Each is
 |---|---|
 | Event generations, `[Tombstone]`, `[CompensationFor]` | Screenplay describes the current shape of an event. It has no notion of versioning, of a deletion marker, or of one event compensating another. |
 | Reducer folds (`IReducerFor<T>`) | The fold is code. The read model and the events it observes are recovered; the logic that combines them is not. |
-| Aggregate roots | Events are applied from inside methods. There is no honest declarative rendering of a decision that lives in a class. |
+| Aggregate roots no command reaches | The events an aggregate root applies are stated through the command that hands its work to it. One that nothing calls has nothing to state them through — a document has no construct for a class that decides on its own. |
+| Inline `policy` code and requirements built in code | `RequireAssertion(…)` and a policy registered from an `AuthorizationPolicy` built elsewhere are code. `RequireAuthenticatedUser`, `RequireRole` and `RequireClaim` are recovered; the rest is reported. |
 | The event source id from a `(TKey, TEvent)` handler | The event is recovered; the identifier saying *which* event source it goes to has no counterpart. |
 | Read model tags, query paging and sorting, custom routes | These are transport and storage concerns. The document describes the model, not how it is served. |
 | Child and nested objects declared with model-bound attributes | Not read back yet. The fluent form of the same projection is. |

--- a/Documentation/generating-a-screenplay.md
+++ b/Documentation/generating-a-screenplay.md
@@ -55,17 +55,25 @@ Diagnostics come in three severities. **Information** means something is worth k
 A [vertical slice](./vertical-slices.md) puts the React component that realizes a slice's screen in the same folder as its C#. Roslyn syntax trees carry real file paths, so the generator knows where each slice's source lives and declares a `screen` for every `.tsx` component sitting next to it, named after the file:
 
 ```text
-slice StateChange Registration
-  command RegisterAuthor
-    name : AuthorName
+slice StateView Listing
+  query AllAuthors => Author[]
+  query AuthorById(id : String) => Author
 
-  screen AddAuthor
-    file Authors/Registration/AddAuthor.tsx
+  screen AuthorList
+    file Authors/Listing/AuthorList.tsx
+    data Author[] via query AllAuthors
+    data Author via query AuthorById by id
 ```
 
-That is the whole of it — the `file` form and nothing else. The declarative form (`data … via query …`, `section`, `table`, `summary`, `action`, `navigate to`) is never inferred, because it would have to be read out of TypeScript rather than out of the compilation, and a guess at a screen's structure is worse than a pointer to the file that actually is it. Write those directives by hand if you want them, and expect a regeneration to leave them out.
+Two things about a screen are recovered, and both come from something that can be checked.
 
-Two rules keep the result honest:
+**The `file` reference** says which file realizes the screen. It is what a reader opens, and no directive replaces it, so it stays on the screen even when directives sit beside it.
+
+**The `data` directives** say which of the slice's queries the screen reads through. Arc generates a TypeScript proxy per query and a component imports that proxy by name, so the component's `import` statements name candidates — and a candidate is kept only when it matches a query the slice really declares. Nothing about the binding comes from the component beyond that name: the read model, whether there is one or many of it, and the parameter it is keyed by all come from the C# query. An import naming anything else — a package, a command, a sibling component, a type-only import — leaves nothing behind.
+
+Everything else in the declarative form — `title`, `section`, `table` and `summary` with their columns and fields, `action`, `navigate to`, `layout` — is **never inferred**. That is structure expressed in JSX and component properties, and a guessed column is worse than an absent one: it puts a confident falsehood into a document whose entire value is that it describes the real application. Every screen reports `SP0028` to say so. Write those directives by hand if you want them, and expect a regeneration to leave them out.
+
+Two more rules keep the result honest:
 
 - **Components only, no descending.** A file carrying a second extension — `AddAuthor.stories.tsx`, `AddAuthor.spec.tsx` — is a companion of a component, not a screen. A folder *inside* a slice folder is a slice of its own under the same convention, so its files belong to it.
 - **Anything uncertain is reported.** The relationship between a file and a slice comes entirely from where the file sits, so `SP0025` is reported whenever sitting there says less than usual: a slice whose source is spread over several folders, one folder holding the source of several slices, or two files claiming a single screen name.
@@ -83,7 +91,7 @@ These are part of the language, but nothing in C# says them, so a generated docu
 | `capture` | Describes ingesting an external system. Nothing in an Arc application declares one. |
 | `persona` | Who uses the system is a product decision, not a code artifact. |
 | `seed` | Sample data is a modeling concern, not something the source states. |
-| The declarative form of `screen` | What a screen shows and does is written in TypeScript and JSX. Only the `file` reference is generated — see [Screens](#screens). |
+| The widgets of a `screen` — `title`, `section`, `table`, `summary`, `action`, `navigate to`, `layout` | What a screen *shows and does* is JSX. Its `file` reference and its `data` bindings are generated; the rest would be a guess — see [Screens](#screens). |
 | `@sensitive` | Only `[PII]` has a counterpart. Other sensitivity levels are not declared in Arc. |
 
 ### Detail Screenplay cannot represent
@@ -95,6 +103,7 @@ These exist in your application and have no counterpart in the language. Each is
 | Event generations, `[Tombstone]`, `[CompensationFor]` | Screenplay describes the current shape of an event. It has no notion of versioning, of a deletion marker, or of one event compensating another. |
 | Reducer folds (`IReducerFor<T>`) | The fold is code. The read model and the events it observes are recovered; the logic that combines them is not. |
 | Aggregate roots no command reaches | The events an aggregate root applies are stated through the command that hands its work to it. One that nothing calls has nothing to state them through — a document has no construct for a class that decides on its own. |
+| A behavior deciding on the state an aggregate root holds | A `produces when` condition compares the input of the command, which is all a document knows at the moment the command is issued. A behavior refusing to act on what it has already seen is a real decision with nowhere to go, so the event is stated unconditionally and `SP0027` reports the decision. A behavior deciding on one of its own *parameters* is recovered, because the call site says which command input that parameter was given. |
 | Inline `policy` code and requirements built in code | `RequireAssertion(…)` and a policy registered from an `AuthorizationPolicy` built elsewhere are code. `RequireAuthenticatedUser`, `RequireRole` and `RequireClaim` are recovered; the rest is reported. |
 | The event source id from a `(TKey, TEvent)` handler | The event is recovered; the identifier saying *which* event source it goes to has no counterpart. |
 | Read model tags, query paging and sorting, custom routes | These are transport and storage concerns. The document describes the model, not how it is served. |

--- a/Documentation/generating-a-screenplay.md
+++ b/Documentation/generating-a-screenplay.md
@@ -1,0 +1,92 @@
+---
+title: Generating a Screenplay
+description: How Arc reads the source of your application and writes the event model it already describes — what a .play file is, what it buys you, and exactly what it does and does not say.
+---
+
+An [event model](/event-modeling/) is the picture of your system: which commands change state, which events they produce, which read models those events build, and which reactors turn one thing into another. Teams draw it on a whiteboard at the start, and then the code moves on without it. Six months later the picture is fiction and nobody trusts it enough to open.
+
+**Screenplay** is a small language for writing that picture down as text — a `.play` file — so it can live in the repository next to the code it describes. Arc can *generate* one from your application's source. The model stops being something you maintain by hand and becomes something you regenerate, the same way the [TypeScript proxies](./understanding-the-proxy-boundary.mdx) are regenerated rather than hand-written.
+
+## Generated from source, not from a running system
+
+The generator reads a Roslyn compilation of your C# — the same thing the compiler sees. It never starts your application, connects to Chronicle, or looks at a deployed instance.
+
+That choice is what makes the output useful:
+
+- **It works from a checkout.** No database, no configuration, no environment. Clone and generate.
+- **It is diffable in a pull request.** A commit that adds a command shows up as a few lines added to the `.play`. Reviewers see the model change next to the code change, and "did this alter the event model?" becomes a question the diff answers.
+- **It is reproducible.** The same source always produces byte-identical output. Everything is ordered explicitly rather than by whatever order symbols happened to arrive in, so regenerating in CI and failing on a diff is a viable check.
+
+A runtime-derived model would answer a different question — what one deployed instance looks like right now — and would vary with configuration and environment. There is one model, and its source of truth is your source code.
+
+```mermaid
+flowchart LR
+    CS["C# source — commands, events,<br/>read models, reactors"] -->|Roslyn compilation| AN["analysis"]
+    AN --> M["application model"]
+    M --> PLAY[".play document"]
+    AN -.->|"anything it cannot express"| D["diagnostics"]
+```
+
+## Running it
+
+The generator is used through the Cratis CLI, which ships separately from Arc:
+
+```shell
+cratis screenplay generate ./MyApp/MyApp.csproj --file MyApp.play
+```
+
+Point it at a project or a solution. Anything the generator could not express is reported on the way out, and a run that reports an error exits non-zero — so a broken build never quietly produces a document that looks fine.
+
+Because output is reproducible, a CI step can regenerate and fail when the committed `.play` no longer matches the source.
+
+## Nothing is dropped silently
+
+The gap between "what C# can say" and "what Screenplay can say" is real, and the worst thing a generator can do is paper over it. Every construct that cannot be expressed is reported as a located diagnostic — a stable code, a message you can act on, and where it came from — rather than quietly disappearing.
+
+```text
+Warning SP0019: The query 'Raw' returns 'IActionResult', which says how the result is
+transported rather than what it is, so the query was left out (Library.Messaging.Feed)
+```
+
+Diagnostics come in three severities. **Information** means something is worth knowing but the document is complete. **Warning** means something was left out. **Error** means the document should not be trusted at all — the most common cause being source that did not compile.
+
+## What is not expressed
+
+A `.play` is a description of an application, not a second copy of it. **It does not round-trip back to code**, and reading one will not tell you everything the code does. The losses run in both directions.
+
+### Screenplay constructs the generator cannot infer
+
+These are part of the language, but nothing in C# says them, so a generated document never contains them. Add them by hand if you want them, and expect a regeneration to leave them out:
+
+| Construct | Why it cannot be inferred |
+|---|---|
+| `capture` | Describes ingesting an external system. Nothing in an Arc application declares one. |
+| `persona` | Who uses the system is a product decision, not a code artifact. |
+| `seed` | Sample data is a modeling concern, not something the source states. |
+| `screen` | Screens are React components; their structure is not recoverable from C#. |
+| `@sensitive` | Only `[PII]` has a counterpart. Other sensitivity levels are not declared in Arc. |
+| Named authorization policies | `[Authorize(Policy = "…")]` names a policy whose rule lives in host configuration, not in the attribute. Roles are recovered; policy bodies are not. |
+
+### Detail Screenplay cannot represent
+
+These exist in your application and have no counterpart in the language. Each is reported as a diagnostic when encountered, so the document tells you it is silent about them:
+
+| In Arc or Chronicle | Why it is not in the document |
+|---|---|
+| Event generations, `[Tombstone]`, `[CompensationFor]` | Screenplay describes the current shape of an event. It has no notion of versioning, of a deletion marker, or of one event compensating another. |
+| Reducer folds (`IReducerFor<T>`) | The fold is code. The read model and the events it observes are recovered; the logic that combines them is not. |
+| Aggregate roots | Events are applied from inside methods. There is no honest declarative rendering of a decision that lives in a class. |
+| The event source id from a `(TKey, TEvent)` handler | The event is recovered; the identifier saying *which* event source it goes to has no counterpart. |
+| Read model tags, query paging and sorting, custom routes | These are transport and storage concerns. The document describes the model, not how it is served. |
+| Child and nested objects declared with model-bound attributes | Not read back yet. The fluent form of the same projection is. |
+
+If a generated `.play` is missing something you expected, the diagnostics are the first place to look — the omission is almost always reported.
+
+## When this is the wrong fit
+
+If you maintain a `.play` by hand as the *design* your code is written against — modeling first, then implementing — generation is the wrong direction and will overwrite your intent. Generation suits the opposite flow: code exists, and you want the model it already describes, kept honest automatically.
+
+## Related
+
+- [Vertical slices](./vertical-slices.md) — the folder shape the generator recovers slices from. A slice per namespace produces a far better document than artifacts sitting in the root namespace.
+- [Understanding the proxy boundary](./understanding-the-proxy-boundary.mdx) — the other thing Arc generates from the same source of truth.

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -14,6 +14,8 @@
   href: understanding-the-proxy-boundary.mdx
 - name: Understanding identity and access
   href: understanding-identity-and-access.mdx
+- name: Generating a Screenplay
+  href: generating-a-screenplay.md
 - name: Scenarios
   href: scenarios/toc.yml
 - name: Backend

--- a/Source/DotNET/Screenplay.Specs/Analyzed.cs
+++ b/Source/DotNET/Screenplay.Specs/Analyzed.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Compiles C# source and recovers the model it describes.
+/// </summary>
+/// <remarks>
+/// This is what makes every source analysis specification hermetic - a compilation is built from source strings in
+/// memory, so there is no project file, no build output, no workspace and nothing mocked. What is asserted is what
+/// a real compilation of that source would yield.
+/// </remarks>
+public static class Analyzed
+{
+    /// <summary>
+    /// The name given to the assembly every specification compiles into.
+    /// </summary>
+    public const string AssemblyName = "Library";
+
+    /// <summary>
+    /// The file every compilation carries so that paths in the document start at the root of the project.
+    /// </summary>
+    /// <remarks>
+    /// Paths are written relative to the deepest directory every source file shares, which for a real project is
+    /// its root. A compilation of a single file would make that file's own folder the root, so the entry point
+    /// every project has stands in for the rest of it.
+    /// </remarks>
+    public static readonly (string Path, string Text) Root = ("Library/Program.cs", "namespace Library;");
+
+    static readonly MetadataReference[] _references =
+    [
+        .. ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(_ => MetadataReference.CreateFromFile(_))
+    ];
+
+    /// <summary>
+    /// Compiles source and recovers the model it describes.
+    /// </summary>
+    /// <param name="sources">The source files, keyed by the path each one is compiled as.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    public static ApplicationModelAnalysis Source(params (string Path, string Text)[] sources) =>
+        new ApplicationModelAnalyzer().Analyze(Compile(sources), new ScreenplayOptions().WithDefaults(AssemblyName));
+
+    /// <summary>
+    /// Compiles a single source file and recovers the model it describes.
+    /// </summary>
+    /// <param name="text">The source.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    public static ApplicationModelAnalysis Source(string text) => Source(("Library/Feature/Slice/Slice.cs", text));
+
+    /// <summary>
+    /// Compiles source into a compilation.
+    /// </summary>
+    /// <param name="sources">The source files, keyed by the path each one is compiled as.</param>
+    /// <returns>The <see cref="Compilation"/>.</returns>
+    public static Compilation Compile(params (string Path, string Text)[] sources) =>
+        CSharpCompilation.Create(
+            AssemblyName,
+            sources.Append(Root).Select(_ => CSharpSyntaxTree.ParseText(
+                _.Text,
+                new CSharpParseOptions(documentationMode: DocumentationMode.Parse),
+                path: _.Path)),
+            _references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+    /// <summary>
+    /// Gets everything the compiler itself reported, so that a specification never asserts against broken source.
+    /// </summary>
+    /// <param name="sources">The source files, keyed by the path each one is compiled as.</param>
+    /// <returns>The errors, empty when the source compiles.</returns>
+    public static IEnumerable<string> ErrorsIn(params (string Path, string Text)[] sources) =>
+        Compile(sources)
+            .GetDiagnostics()
+            .Where(_ => _.Severity == DiagnosticSeverity.Error)
+            .Select(_ => _.ToString());
+
+    /// <summary>
+    /// Gets the single slice a model describes.
+    /// </summary>
+    /// <param name="analysis">The analysis to read.</param>
+    /// <returns>The slice.</returns>
+    public static SliceModel Slice(this ApplicationModelAnalysis analysis) => analysis.Model.Slices.First();
+}

--- a/Source/DotNET/Screenplay.Specs/Analyzed.cs
+++ b/Source/DotNET/Screenplay.Specs/Analyzed.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Screens;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -24,6 +25,11 @@ public static class Analyzed
     public const string AssemblyName = "Library";
 
     /// <summary>
+    /// The path a single source file is compiled as.
+    /// </summary>
+    public const string SlicePath = "Library/Feature/Slice/Slice.cs";
+
+    /// <summary>
     /// The file every compilation carries so that paths in the document start at the root of the project.
     /// </summary>
     /// <remarks>
@@ -41,19 +47,40 @@ public static class Analyzed
     ];
 
     /// <summary>
-    /// Compiles source and recovers the model it describes.
+    /// Compiles source and recovers the model it describes, with nothing sitting alongside it.
     /// </summary>
     /// <param name="sources">The source files, keyed by the path each one is compiled as.</param>
     /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
     public static ApplicationModelAnalysis Source(params (string Path, string Text)[] sources) =>
-        new ApplicationModelAnalyzer().Analyze(Compile(sources), new ScreenplayOptions().WithDefaults(AssemblyName));
+        Source(DeclaredUserInterfaceFiles.None, sources);
+
+    /// <summary>
+    /// Compiles source and recovers the model it describes.
+    /// </summary>
+    /// <param name="files">The user interface files sitting alongside the source.</param>
+    /// <param name="sources">The source files, keyed by the path each one is compiled as.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    /// <remarks>
+    /// The files a screen is recovered from are declared rather than written to a disk, so that a specification
+    /// about screens is exactly as hermetic as every other one.
+    /// </remarks>
+    public static ApplicationModelAnalysis Source(IUserInterfaceFiles files, params (string Path, string Text)[] sources) =>
+        new ApplicationModelAnalyzer(files).Analyze(Compile(sources), new ScreenplayOptions().WithDefaults(AssemblyName));
+
+    /// <summary>
+    /// Compiles a single source file and recovers the model it describes, with nothing sitting alongside it.
+    /// </summary>
+    /// <param name="text">The source.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    public static ApplicationModelAnalysis Source(string text) => Source((SlicePath, text));
 
     /// <summary>
     /// Compiles a single source file and recovers the model it describes.
     /// </summary>
+    /// <param name="files">The user interface files sitting alongside the source.</param>
     /// <param name="text">The source.</param>
     /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
-    public static ApplicationModelAnalysis Source(string text) => Source(("Library/Feature/Slice/Slice.cs", text));
+    public static ApplicationModelAnalysis Source(IUserInterfaceFiles files, string text) => Source(files, (SlicePath, text));
 
     /// <summary>
     /// Compiles source into a compilation.

--- a/Source/DotNET/Screenplay.Specs/DeclaredUserInterfaceFiles.cs
+++ b/Source/DotNET/Screenplay.Specs/DeclaredUserInterfaceFiles.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Screens;
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// The user interface files a specification says sit alongside the source it compiles.
+/// </summary>
+/// <param name="paths">The paths of the files, exactly as the specification declares them.</param>
+/// <remarks>
+/// This is what keeps every source analysis specification hermetic once screens are in play - no folder is created,
+/// no file is written, and nothing is read from a disk. Files are returned in the order they were declared rather
+/// than sorted, so that a specification declaring them out of order proves the reader orders them itself.
+/// </remarks>
+public class DeclaredUserInterfaceFiles(params string[] paths) : IUserInterfaceFiles
+{
+    /// <summary>
+    /// Declares that nothing sits alongside the source.
+    /// </summary>
+    public static readonly DeclaredUserInterfaceFiles None = new();
+
+    /// <inheritdoc/>
+    public IEnumerable<string> In(string directory) =>
+        paths.Where(_ => ScreenFiles.IsUserInterfaceFile(_) &&
+            string.Equals(ScreenFiles.DirectoryOf(_), directory, StringComparison.Ordinal));
+}

--- a/Source/DotNET/Screenplay.Specs/DeclaredUserInterfaceFiles.cs
+++ b/Source/DotNET/Screenplay.Specs/DeclaredUserInterfaceFiles.cs
@@ -6,23 +6,48 @@ using Cratis.Arc.Screenplay.Analysis.Screens;
 namespace Cratis.Arc.Screenplay;
 
 /// <summary>
-/// The user interface files a specification says sit alongside the source it compiles.
+/// The user interface files a specification says sit alongside the source it compiles, and what they hold.
 /// </summary>
-/// <param name="paths">The paths of the files, exactly as the specification declares them.</param>
 /// <remarks>
 /// This is what keeps every source analysis specification hermetic once screens are in play - no folder is created,
-/// no file is written, and nothing is read from a disk. Files are returned in the order they were declared rather
-/// than sorted, so that a specification declaring them out of order proves the reader orders them itself.
+/// no file is written, and nothing is read from a disk, including the text a component's imports are read out of.
+/// Files are returned in the order they were declared rather than sorted, so that a specification declaring them out
+/// of order proves the reader orders them itself.
 /// </remarks>
-public class DeclaredUserInterfaceFiles(params string[] paths) : IUserInterfaceFiles
+public class DeclaredUserInterfaceFiles : IUserInterfaceFiles
 {
     /// <summary>
     /// Declares that nothing sits alongside the source.
     /// </summary>
     public static readonly DeclaredUserInterfaceFiles None = new();
 
+    readonly List<(string Path, string? Text)> _files;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeclaredUserInterfaceFiles"/> class holding files whose text no
+    /// specification asks for.
+    /// </summary>
+    /// <param name="paths">The paths of the files, exactly as the specification declares them.</param>
+    public DeclaredUserInterfaceFiles(params string[] paths) => _files = [.. paths.Select(_ => (_, (string?)null))];
+
+    DeclaredUserInterfaceFiles(IEnumerable<(string Path, string? Text)> files) => _files = [.. files];
+
+    /// <summary>
+    /// Declares files together with the text each one holds.
+    /// </summary>
+    /// <param name="files">The files, keyed by the path each one sits at.</param>
+    /// <returns>The <see cref="DeclaredUserInterfaceFiles"/>.</returns>
+    public static DeclaredUserInterfaceFiles Holding(params (string Path, string Text)[] files) =>
+        new(files.Select(_ => (_.Path, (string?)_.Text)));
+
     /// <inheritdoc/>
     public IEnumerable<string> In(string directory) =>
-        paths.Where(_ => ScreenFiles.IsUserInterfaceFile(_) &&
-            string.Equals(ScreenFiles.DirectoryOf(_), directory, StringComparison.Ordinal));
+        _files
+            .Select(_ => _.Path)
+            .Where(_ => ScreenFiles.IsUserInterfaceFile(_) &&
+                string.Equals(ScreenFiles.DirectoryOf(_), directory, StringComparison.Ordinal));
+
+    /// <inheritdoc/>
+    public string? Contents(string path) =>
+        _files.Find(_ => string.Equals(_.Path, path, StringComparison.Ordinal)).Text;
 }

--- a/Source/DotNET/Screenplay.Specs/Library/Declare.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/Declare.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Library;
+
+/// <summary>
+/// Shorthands for declaring the parts of a model, so that the fixtures read like the application they describe.
+/// </summary>
+public static class Declare
+{
+    /// <summary>
+    /// Declares a reference to a single value of a type.
+    /// </summary>
+    /// <param name="name">The name of the type.</param>
+    /// <returns>The type reference.</returns>
+    public static TypeReferenceModel Type(string name) => new(name, false, false);
+
+    /// <summary>
+    /// Declares a reference to a collection of a type.
+    /// </summary>
+    /// <param name="name">The name of the type.</param>
+    /// <returns>The type reference.</returns>
+    public static TypeReferenceModel Many(string name) => new(name, true, false);
+
+    /// <summary>
+    /// Declares a reference to an optional value of a type.
+    /// </summary>
+    /// <param name="name">The name of the type.</param>
+    /// <returns>The type reference.</returns>
+    public static TypeReferenceModel Maybe(string name) => new(name, false, true);
+
+    /// <summary>
+    /// Declares a property.
+    /// </summary>
+    /// <param name="name">The name of the property.</param>
+    /// <param name="type">The name of the type of the property.</param>
+    /// <returns>The property.</returns>
+    public static PropertyModel Property(string name, string type) => new(name, Type(type));
+
+    /// <summary>
+    /// Declares a mapping taking its value from a property of the command.
+    /// </summary>
+    /// <param name="property">The property being mapped onto.</param>
+    /// <param name="path">The path the value is taken from.</param>
+    /// <returns>The mapping.</returns>
+    public static PropertyMappingModel From(string property, string path) => new(property, new PropertyPathSource(path));
+
+    /// <summary>
+    /// Declares a property map for a projection block.
+    /// </summary>
+    /// <param name="pairs">The read model property to event expression pairs.</param>
+    /// <returns>The property map.</returns>
+    public static IReadOnlyDictionary<string, string> Map(params (string Property, string Expression)[] pairs) =>
+        pairs.ToDictionary(_ => _.Property, _ => _.Expression, StringComparer.Ordinal);
+}

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryApplication.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryApplication.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Library;
+
+/// <summary>
+/// A library shaped application, expressed purely as a model.
+/// </summary>
+/// <remarks>
+/// This is what a source analysis of a real Arc application is expected to recover. Building it by hand keeps every
+/// emission specification honest about the one thing it is testing - what the document says - without dragging in a
+/// compiler, a container or a mocked runtime.
+/// </remarks>
+public static class LibraryApplication
+{
+    /// <summary>
+    /// The name of the domain and module the application declares.
+    /// </summary>
+    public const string Name = "Library";
+
+    /// <summary>
+    /// Builds the model of the application.
+    /// </summary>
+    /// <returns>The <see cref="ApplicationModel"/>.</returns>
+    public static ApplicationModel Build() =>
+        new(
+            Name,
+            Name,
+            LibraryConcepts.All(),
+            LibraryConcepts.Policies(),
+            Slices());
+
+    /// <summary>
+    /// Declares every slice of the application.
+    /// </summary>
+    /// <returns>The slices.</returns>
+    public static IEnumerable<SliceModel> Slices() =>
+    [
+        LibraryAuthors.Registration(),
+        LibraryAuthors.Listing(),
+        LibraryInventory.Adding(),
+        LibraryInventory.Listing(),
+        LibraryLending.Reserving(),
+        LibraryLending.Notifications(),
+        LibraryLending.Restocking()
+    ];
+}

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryAuthors.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryAuthors.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Library;
+
+/// <summary>
+/// The slices of the authors feature.
+/// </summary>
+public static class LibraryAuthors
+{
+    /// <summary>
+    /// Declares the slice registering an author.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    public static SliceModel Registration() =>
+        new(
+            "Library.Authors.Registration",
+            "Registration",
+            SliceKind.StateChange,
+            "Registers a new author in the library.",
+            [
+                new CommandModel(
+                    "RegisterAuthor",
+                    "Registers a new author.",
+                    [Declare.Property("Name", "AuthorName")],
+                    null,
+                    [
+                        new("Name", ValidationRuleKind.NotEmpty, null, "An author must have a name"),
+                        new("Name", ValidationRuleKind.Max, 100, null)
+                    ],
+                    [new ProducesModel("AuthorRegistered", null, [Declare.From("Name", "Name")])],
+                    null,
+                    "Authors/Registration/Registration.cs")
+            ],
+            [new EventModel("AuthorRegistered", [Declare.Property("Name", "AuthorName")], ["audit", "authors"])],
+            [],
+            null,
+            [],
+            [new UniquePropertyConstraintModel("UniqueAuthorName", "Name", "AuthorRegistered")]);
+
+    /// <summary>
+    /// Declares the slice listing the registered authors.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    public static SliceModel Listing() =>
+        new(
+            "Library.Authors.Listing",
+            "Listing",
+            SliceKind.StateView,
+            null,
+            [],
+            [],
+            [
+                new QueryModel("AllAuthors", Declare.Many("Author"), null, [], null),
+                new QueryModel(
+                    "AuthorById",
+                    Declare.Maybe("Author"),
+                    Declare.Property("Id", "AuthorId"),
+                    [],
+                    null)
+            ],
+            new ProjectionModel(
+                "Library.Authors.Listing.AuthorProjection",
+                "Author",
+                "event-log",
+                ProjectionAutoMapMode.Enabled,
+                false,
+                ProjectionScopeModel.Empty with
+                {
+                    From = [new(["AuthorRegistered"], "$eventSourceId", null, Declare.Map(("name", "name")))]
+                }),
+            [],
+            []);
+}

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryConcepts.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryConcepts.cs
@@ -43,6 +43,6 @@ public static class LibraryConcepts
     /// </remarks>
     public static IEnumerable<PolicyModel> Policies() =>
     [
-        new("Librarian", true, "Librarian")
+        PolicyModel.ForRole("Librarian")
     ];
 }

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryConcepts.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryConcepts.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Library;
+
+/// <summary>
+/// The concepts and policies a library application declares at the document level.
+/// </summary>
+public static class LibraryConcepts
+{
+    /// <summary>
+    /// Declares every concept of the application.
+    /// </summary>
+    /// <returns>The concepts.</returns>
+    public static IEnumerable<ConceptModel> All() =>
+    [
+        new("AuthorId", ScreenplayPrimitive.Uuid, false, [], []),
+        new(
+            "AuthorName",
+            ScreenplayPrimitive.String,
+            true,
+            [],
+            [
+                new("Value", ValidationRuleKind.NotEmpty, null, "An author name is required"),
+                new("Value", ValidationRuleKind.Max, 200, null)
+            ]),
+        new("BookTitle", ScreenplayPrimitive.String, false, [], []),
+        new("CopyCount", ScreenplayPrimitive.Int, false, [], []),
+        new("ISBN", ScreenplayPrimitive.String, false, [], []),
+        new("MemberId", ScreenplayPrimitive.Uuid, false, [], []),
+        new("MembershipTier", ScreenplayPrimitive.Enum, false, ["Standard", "Premium"], [])
+    ];
+
+    /// <summary>
+    /// Declares every policy of the application.
+    /// </summary>
+    /// <returns>The policies.</returns>
+    /// <remarks>
+    /// Only the role a slice actually names is declared here. The policy an authenticated caller alone satisfies is
+    /// left out on purpose, so that emission has to keep the document self consistent by declaring it itself.
+    /// </remarks>
+    public static IEnumerable<PolicyModel> Policies() =>
+    [
+        new("Librarian", true, "Librarian")
+    ];
+}

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryInventory.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryInventory.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Library;
+
+/// <summary>
+/// The slices of the inventory feature.
+/// </summary>
+public static class LibraryInventory
+{
+    /// <summary>
+    /// Declares the slice adding copies of a book title to the inventory.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    public static SliceModel Adding() =>
+        new(
+            "Library.Inventory.Adding",
+            "Adding",
+            SliceKind.StateChange,
+            null,
+            [
+                new CommandModel(
+                    "AddBookTitleToInventory",
+                    "Adds copies of a book title to the inventory.",
+                    [
+                        Declare.Property("Title", "BookTitle"),
+                        Declare.Property("Isbn", "ISBN"),
+                        Declare.Property("AuthorId", "AuthorId"),
+                        Declare.Property("Count", "CopyCount")
+                    ],
+                    new AuthorizationModel(true, ["Librarian"]),
+                    [],
+                    [
+                        new ProducesModel(
+                            "BookAddedToInventory",
+                            null,
+                            [
+                                Declare.From("Title", "Title"),
+                                Declare.From("AuthorId", "AuthorId"),
+                                Declare.From("Count", "Count")
+                            ])
+                    ],
+                    new ConcurrencyModel(false, null, "Inventory", null, []),
+                    "Inventory/Adding/Adding.cs")
+            ],
+            [
+                new EventModel(
+                    "BookAddedToInventory",
+                    [
+                        Declare.Property("Title", "BookTitle"),
+                        Declare.Property("AuthorId", "AuthorId"),
+                        Declare.Property("Count", "CopyCount")
+                    ],
+                    [])
+            ],
+            [],
+            null,
+            [],
+            []);
+
+    /// <summary>
+    /// Declares the slice listing the book titles held in the inventory.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    public static SliceModel Listing() =>
+        new(
+            "Library.Inventory.Listing",
+            "Listing",
+            SliceKind.StateView,
+            null,
+            [],
+            [],
+            [new QueryModel("AllBooks", Declare.Many("Book"), null, [], null)],
+            new ProjectionModel(
+                "Library.Inventory.Listing.BookProjection",
+                "Book",
+                "event-log",
+                ProjectionAutoMapMode.Enabled,
+                false,
+                ProjectionScopeModel.Empty with
+                {
+                    From =
+                    [
+                        new(
+                            ["BookAddedToInventory"],
+                            "$eventSourceId",
+                            null,
+                            Declare.Map(("title", "title"), ("available", "count")))
+                    ]
+                }),
+            [],
+            []);
+}

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryLending.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryLending.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Library;
+
+/// <summary>
+/// The slices of the lending feature.
+/// </summary>
+public static class LibraryLending
+{
+    /// <summary>
+    /// Declares the slice reserving a copy of a book for a member.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    public static SliceModel Reserving() =>
+        new(
+            "Library.Lending.Reserving",
+            "Reserving",
+            SliceKind.StateChange,
+            null,
+            [ReserveBook()],
+            [
+                new EventModel(
+                    "BookReserved",
+                    [
+                        Declare.Property("Isbn", "ISBN"),
+                        Declare.Property("MemberId", "MemberId"),
+                        Declare.Property("Tier", "MembershipTier")
+                    ],
+                    []),
+                new EventModel("PremiumReservationGranted", [Declare.Property("MemberId", "MemberId")], [])
+            ],
+            [],
+            Availability(),
+            [],
+            []);
+
+    /// <summary>
+    /// Declares the slice notifying a member that their reservation is ready.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    public static SliceModel Notifications() =>
+        new(
+            "Library.Lending.Notifications",
+            "Notifications",
+            SliceKind.Automation,
+            null,
+            [],
+            [],
+            [],
+            null,
+            [
+                new ReactorModel(
+                    "ReservationNotifier",
+                    ["BookReserved"],
+                    false,
+                    "Lending/Notifications/Notifications.cs")
+            ],
+            []);
+
+    /// <summary>
+    /// Declares the slice turning a reservation into a restock request.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    /// <remarks>
+    /// The reactor carries no source file path, which is what an artifact living in a referenced package looks like.
+    /// Emission has to fall back to the vertical slice convention rather than emit a trigger with no body.
+    /// </remarks>
+    public static SliceModel Restocking() =>
+        new(
+            "Library.Lending.Restocking",
+            "Restocking",
+            SliceKind.Translate,
+            null,
+            [],
+            [new EventModel("RestockRequested", [Declare.Property("Isbn", "ISBN")], [])],
+            [],
+            null,
+            [new ReactorModel("RestockRequester", ["BookReserved"], true, null)],
+            []);
+
+    /// <summary>
+    /// Declares the command reserving a book, which produces one event always and another only for a premium member.
+    /// </summary>
+    /// <returns>The command.</returns>
+    static CommandModel ReserveBook() =>
+        new(
+            "ReserveBook",
+            "Reserves a copy of a book for a member.",
+            [
+                Declare.Property("Isbn", "ISBN"),
+                Declare.Property("MemberId", "MemberId"),
+                Declare.Property("Tier", "MembershipTier")
+            ],
+            new AuthorizationModel(true, []),
+            [],
+            [
+                new ProducesModel(
+                    "BookReserved",
+                    null,
+                    [
+                        Declare.From("Isbn", "Isbn"),
+                        Declare.From("MemberId", "MemberId"),
+                        Declare.From("Tier", "Tier")
+                    ]),
+                new ProducesModel(
+                    "PremiumReservationGranted",
+                    new ComparisonCondition("Tier", ComparisonKind.Equal, new LiteralSource("premium")),
+                    [Declare.From("MemberId", "MemberId")])
+            ],
+            null,
+            "Lending/Reserving/Reserving.cs");
+
+    /// <summary>
+    /// Declares the projection counting how many copies of a title are available.
+    /// </summary>
+    /// <returns>The projection.</returns>
+    static ProjectionModel Availability() =>
+        new(
+            "Library.Lending.Reserving.AvailabilityProjection",
+            "Availability",
+            "event-log",
+            ProjectionAutoMapMode.Disabled,
+            false,
+            ProjectionScopeModel.Empty with
+            {
+                From =
+                [
+                    new(["BookAddedToInventory"], "$eventSourceId", null, Declare.Map(("available", "$increment"))),
+                    new(["BookReserved"], "$eventSourceId", null, Declare.Map(("available", "$decrement")))
+                ]
+            });
+}

--- a/Source/DotNET/Screenplay.Specs/Library/OrderingSlice.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/OrderingSlice.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Library;
+
+/// <summary>
+/// A slice whose projection exercises every block the projection definition language has.
+/// </summary>
+/// <remarks>
+/// The library application is what a real application looks like; this is what the hardest corner of the language
+/// looks like. Every event the projection names is declared, so that a round trip has nothing to warn about.
+/// </remarks>
+public static class OrderingSlice
+{
+    /// <summary>
+    /// Declares the slice.
+    /// </summary>
+    /// <returns>The slice.</returns>
+    public static SliceModel Build() =>
+        new(
+            "Library.Ordering.Tracking",
+            "Tracking",
+            SliceKind.StateView,
+            null,
+            [],
+            [.. Events()],
+            [new QueryModel("AllOrders", Declare.Many("Order"), null, [], null)],
+            Projection(),
+            [],
+            []);
+
+    /// <summary>
+    /// Declares every event the projection observes.
+    /// </summary>
+    /// <returns>The events.</returns>
+    static IEnumerable<EventModel> Events() =>
+    [
+        new("OrderPlaced", [Declare.Property("CustomerId", "Uuid")], []),
+        new("OrderShipped", [Declare.Property("Carrier", "String")], []),
+        new("OrderCancelled", [], []),
+        new("CustomerRegistered", [Declare.Property("Name", "String")], []),
+        new("CustomerAccountClosed", [], []),
+        new("LineItemAdded", [Declare.Property("Amount", "Decimal")], []),
+        new("LineItemRemoved", [], [])
+    ];
+
+    /// <summary>
+    /// Declares the projection.
+    /// </summary>
+    /// <returns>The projection.</returns>
+    static ProjectionModel Projection() =>
+        new(
+            "Library.Ordering.Tracking.OrderProjection",
+            "Order",
+            "orders",
+            ProjectionAutoMapMode.Disabled,
+            false,
+            new ProjectionScopeModel(
+                [
+                    new(
+                        ["OrderPlaced", "OrderShipped"],
+                        "$composite(OrderKey, CustomerId=customerId, Number=orderNumber)",
+                        "customerId",
+                        Declare.Map(
+                            ("placedBy", "$causedBy.name"),
+                            ("anonymous", "$causedBy"),
+                            ("id", "$eventSourceId"),
+                            ("status", "$value(placed)"),
+                            ("versions", "$increment"),
+                            ("pending", "$decrement")))
+                ],
+                new ProjectionEveryModel(
+                    Declare.Map(("lastUpdated", "$eventContext(occurred)")),
+                    false,
+                    ProjectionAutoMapMode.Enabled),
+                [new("Customer", "CustomerRegistered", "customerId", Declare.Map(("customerName", "name")))],
+                [Items()],
+                [Shipping()],
+                [new("OrderCancelled", null, null)],
+                [new("CustomerAccountClosed", null, null)]));
+
+    /// <summary>
+    /// Declares the child collection of line items.
+    /// </summary>
+    /// <returns>The child scope.</returns>
+    static ProjectionChildScopeModel Items() =>
+        new(
+            "Items",
+            "lineNumber",
+            ProjectionAutoMapMode.Enabled,
+            ProjectionScopeModel.Empty with
+            {
+                From =
+                [
+                    new(
+                        ["LineItemAdded"],
+                        "lineNumber",
+                        "orderId",
+                        Declare.Map(("total", "$add(amount)"), ("occurrences", "$count"), ("refunded", "$subtract(amount)")))
+                ],
+                RemovedWith = [new("LineItemRemoved", "lineNumber", "orderId")]
+            });
+
+    /// <summary>
+    /// Declares the nested shipping details.
+    /// </summary>
+    /// <returns>The nested scope.</returns>
+    static ProjectionChildScopeModel Shipping() =>
+        new(
+            "Shipping",
+            string.Empty,
+            ProjectionAutoMapMode.Inherit,
+            ProjectionScopeModel.Empty with
+            {
+                From = [new(["OrderShipped"], null, null, Declare.Map(("carrier", "carrier")))]
+            });
+}

--- a/Source/DotNET/Screenplay.Specs/RoundTrip.cs
+++ b/Source/DotNET/Screenplay.Specs/RoundTrip.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+using Cratis.Screenplay.Printing;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Prints a document, compiles the printed source and prints the result again.
+/// </summary>
+/// <remarks>
+/// This is the correctness gate for everything the generator produces. Output that does not compile means the
+/// generator is wrong, and output that does not print identically the second time means information was lost.
+/// </remarks>
+public static class RoundTrip
+{
+    /// <summary>
+    /// Runs the round trip for a document.
+    /// </summary>
+    /// <param name="application">The document to round trip.</param>
+    /// <returns>The result of the round trip.</returns>
+    public static RoundTripResult For(ApplicationSyntax application)
+    {
+        var printer = new ScreenplayPrinter();
+        var compiler = new ScreenplayCompiler();
+        var printed = printer.Print(application);
+        var compilation = compiler.Compile(printed);
+        var reprinted = compilation.Value is null ? string.Empty : printer.Print(compilation.Value);
+
+        return new(printed, reprinted, [.. compilation.Diagnostics]);
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/RoundTripResult.cs
+++ b/Source/DotNET/Screenplay.Specs/RoundTripResult.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Diagnostics;
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Represents the outcome of printing, compiling and reprinting a document.
+/// </summary>
+/// <param name="Printed">The printed source.</param>
+/// <param name="Reprinted">The source printed from the recompiled document.</param>
+/// <param name="Diagnostics">Everything the compiler reported.</param>
+public record RoundTripResult(string Printed, string Reprinted, IEnumerable<Diagnostic> Diagnostics)
+{
+    /// <summary>
+    /// Gets everything the compiler reported as an error.
+    /// </summary>
+    public IEnumerable<Diagnostic> Errors => Diagnostics.Where(_ => _.Severity == DiagnosticSeverity.Error);
+
+    /// <summary>
+    /// Gets a value indicating whether the printed source compiles.
+    /// </summary>
+    public bool Compiles => !Errors.Any();
+
+    /// <summary>
+    /// Gets a value indicating whether the second print is identical to the first.
+    /// </summary>
+    public bool IsStable => string.Equals(Printed, Reprinted, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Gets a description of everything the compiler reported, for use in assertion output.
+    /// </summary>
+    public string Report => string.Join('\n', Diagnostics.Select(_ => $"{_.Severity} {_.Location.Line}:{_.Location.Column} {_.Message}"));
+}

--- a/Source/DotNET/Screenplay.Specs/Screenplay.Specs.csproj
+++ b/Source/DotNET/Screenplay.Specs/Screenplay.Specs.csproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.Screenplay.Specs</AssemblyName>
+        <RootNamespace>Cratis.Arc.Screenplay</RootNamespace>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <!-- The source every analysis specification compiles is written as raw string literals, which carry line
+             endings implicitly and are handed to the compiler exactly as written. -->
+        <NoWarn>$(NoWarn);MA0136</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- The shared spec global usings pull in Cratis.Types, which the package under specification does not need. -->
+        <PackageReference Include="Cratis.Fundamentals" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../Screenplay/Screenplay.csproj" />
+        <!-- Source analysis is specified against the real Arc and Chronicle artifacts, so the assemblies declaring
+             them have to be loadable as metadata references. The package under specification references neither. -->
+        <ProjectReference Include="../Chronicle/Chronicle.csproj" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/PolicySource.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/PolicySource.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The source of an application whose commands name authorization policies rather than roles.
+/// </summary>
+public static class PolicySource
+{
+    /// <summary>
+    /// The part of the authorization framework a registration is written against.
+    /// </summary>
+    public const string Framework = """
+        using System;
+
+        namespace Microsoft.AspNetCore.Authorization;
+
+        public class AuthorizationPolicyBuilder
+        {
+            public AuthorizationPolicyBuilder RequireAuthenticatedUser() => this;
+
+            public AuthorizationPolicyBuilder RequireRole(params string[] roles) => this;
+
+            public AuthorizationPolicyBuilder RequireClaim(string claimType, params string[] allowedValues) => this;
+
+            public AuthorizationPolicyBuilder RequireAssertion(Func<object, bool> handler) => this;
+        }
+
+        public class AuthorizationOptions
+        {
+            public void AddPolicy(string name, Action<AuthorizationPolicyBuilder> configurePolicy)
+            {
+            }
+        }
+
+        public class AuthorizationBuilder
+        {
+            public AuthorizationBuilder AddPolicy(string name, Action<AuthorizationPolicyBuilder> configurePolicy) => this;
+        }
+        """;
+
+    /// <summary>
+    /// Where the application says what each of its policies means.
+    /// </summary>
+    public const string Composition = """
+        using Microsoft.AspNetCore.Authorization;
+
+        namespace Library;
+
+        public static class Composition
+        {
+            public static void Authorization(AuthorizationOptions options, AuthorizationBuilder builder)
+            {
+                options.AddPolicy("CanReserve", policy => policy.RequireRole("Librarian").RequireClaim("branch", "central"));
+                options.AddPolicy("Trusted", policy => policy.RequireAssertion(caller => true));
+                builder.AddPolicy("SeniorStaff", policy => policy.RequireRole("Librarian", "Archivist"));
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The slice whose commands name the policies.
+    /// </summary>
+    public const string Slice = """
+        using Cratis.Arc.Authorization;
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Lending.Reserving;
+
+        [Command]
+        [Authorize(Policy = "CanReserve")]
+        public record ReserveBook(string Isbn)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        [Command]
+        [Authorize(Policy = "SeniorStaff", Roles = "Librarian")]
+        public record ForceReturn(string Isbn)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        [Command]
+        [Authorize(Policy = "Trusted")]
+        public record OverrideLoan(string Isbn)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        [Command]
+        [Authorize(Policy = "Unregistered")]
+        public record AuditLoan(string Isbn)
+        {
+            public void Handle()
+            {
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Gets every source file of the application, keyed by the path each one is compiled as.
+    /// </summary>
+    /// <returns>The source files.</returns>
+    public static (string Path, string Text)[] All() =>
+    [
+        ("Library/Composition.cs", Composition),
+        ("Library/Authorization.cs", Framework),
+        ("Library/Lending/Reserving/Reserving.cs", Slice)
+    ];
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_of_the_type_holding_it.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_of_the_type_holding_it.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A type holding itself describes a hierarchy of no fixed depth, which a document writes out one level at a time
+/// and therefore cannot express. The level that is expressible is kept and the rest is reported, because a reader
+/// that followed the declaration would never come back.
+/// </summary>
+public class a_child_collection_of_the_type_holding_it : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Modeling.Slices;
+
+        [EventType]
+        public record SliceAdded(Guid SliceId, Guid ParentSliceId, string Name);
+
+        [ReadModel]
+        [FromEvent<SliceAdded>]
+        public record Slice(
+            Guid Id,
+            string Name,
+            [ChildrenFrom<SliceAdded>(
+                key: nameof(SliceAdded.SliceId),
+                parentKey: nameof(SliceAdded.ParentSliceId))]
+            IEnumerable<Slice> Children);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    Model.ProjectionChildScopeModel _children;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _children = _analysis.Slice().Projection!.Scope.Children.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_keep_the_level_it_can_express() => _children.Scope.From.Single().Key.ShouldEqual("sliceId");
+    [Fact] void should_stop_before_holding_itself_again() => _children.Scope.Children.ShouldBeEmpty();
+    [Fact] void should_report_what_it_left_out() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableProjectionScope);
+    [Fact] void should_say_a_document_cannot_nest_without_end() => _analysis.Diagnostics.Any(_ => _.Message.Contains("cannot nest without end", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_that_names_no_parent_key.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_that_names_no_parent_key.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A declaration naming no parent key does not mean the parent is the event source - the event is searched for a
+/// property carrying the same kind of value the parent is identified by, and that is what the child is attached by.
+/// A document saying nothing here would describe a hierarchy assembled differently from the one that really runs.
+/// </summary>
+public class a_child_collection_that_names_no_parent_key : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Inventory.Shelving;
+
+        [EventType]
+        public record ShelfInstalled(string Name);
+
+        [EventType]
+        public record BookPlacedOnShelf(Guid ShelfId, Guid BookId, string Title);
+
+        public record ShelvedBook(
+            Guid Id,
+            [SetFrom<BookPlacedOnShelf>(nameof(BookPlacedOnShelf.Title))] string Title);
+
+        [ReadModel]
+        [FromEvent<ShelfInstalled>]
+        public record Shelf(
+            Guid Id,
+            string Name,
+            [ChildrenFrom<BookPlacedOnShelf>(key: nameof(BookPlacedOnShelf.BookId))]
+            IEnumerable<ShelvedBook> Books);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    Model.ProjectionFromModel _from;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _from = _analysis.Slice().Projection!.Scope.Children.Single().Scope.From.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_find_the_parent_by_the_property_carrying_its_identifier() => _from.ParentKey.ShouldEqual("shelfId");
+    [Fact] void should_still_key_the_child_on_what_the_declaration_names() => _from.Key.ShouldEqual("bookId");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_whose_parent_carries_no_identifier.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_whose_parent_carries_no_identifier.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// There is nothing to search an event for when the parent carries no identifier of its own, and inventing one from
+/// whichever property happened to look right would attach children to the wrong parent. The event source is what
+/// remains, which is also what really happens, so nothing is written out at all.
+/// </summary>
+public class a_child_collection_whose_parent_carries_no_identifier : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Inventory.Shelving;
+
+        [EventType]
+        public record ShelfInstalled(string Name);
+
+        [EventType]
+        public record BookPlacedOnShelf(Guid BookId, string Title);
+
+        public record ShelvedBook(
+            Guid Id,
+            [SetFrom<BookPlacedOnShelf>(nameof(BookPlacedOnShelf.Title))] string Title);
+
+        [ReadModel]
+        [FromEvent<ShelfInstalled>]
+        public record Shelf(
+            string Name,
+            [ChildrenFrom<BookPlacedOnShelf>(key: nameof(BookPlacedOnShelf.BookId))]
+            IEnumerable<ShelvedBook> Books);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    Model.ProjectionFromModel _from;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _from = _analysis.Slice().Projection!.Scope.Children.Single().Scope.From.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_leave_the_parent_to_the_event_source() => _from.ParentKey.ShouldBeNull();
+    [Fact] void should_still_key_the_child_on_what_the_declaration_names() => _from.Key.ShouldEqual("bookId");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_removed_by_an_event.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_removed_by_an_event.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// What removes an instance is read from the type of the instance, alongside the events that fill it in. The same
+/// removal written beside the collection instead is a form nothing reads yet, and a child collection nothing ever
+/// removes anything from is exactly the sort of quiet difference a document is supposed to make impossible.
+/// </summary>
+public class a_child_removed_by_an_event : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Inventory.Shelving;
+
+        [EventType]
+        public record ShelfInstalled(string Name);
+
+        [EventType]
+        public record BookPlacedOnShelf(Guid ShelfId, Guid BookId, string Title);
+
+        [EventType]
+        public record BookTakenOffShelf(Guid BookId);
+
+        [RemovedWith<BookTakenOffShelf>(key: nameof(BookTakenOffShelf.BookId))]
+        public record ShelvedBook(
+            Guid Id,
+            [SetFrom<BookPlacedOnShelf>(nameof(BookPlacedOnShelf.Title))] string Title);
+
+        [ReadModel]
+        [FromEvent<ShelfInstalled>]
+        public record Shelf(
+            Guid Id,
+            string Name,
+            [ChildrenFrom<BookPlacedOnShelf>(
+                key: nameof(BookPlacedOnShelf.BookId),
+                parentKey: nameof(BookPlacedOnShelf.ShelfId))]
+            [RemovedWith<BookTakenOffShelf>(key: nameof(BookTakenOffShelf.BookId))]
+            IEnumerable<ShelvedBook> Books);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    Model.ProjectionChildScopeModel _children;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _children = _analysis.Slice().Projection!.Scope.Children.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_remove_a_child_when_the_type_of_the_child_says_so() => _children.Scope.RemovedWith.Single().EventType.ShouldEqual("BookTakenOffShelf");
+    [Fact] void should_key_the_removal_on_what_the_declaration_names() => _children.Scope.RemovedWith.Single().Key.ShouldEqual("bookId");
+    [Fact] void should_report_the_removal_declared_beside_the_collection() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableProjectionScope);
+    [Fact] void should_say_where_the_removal_is_read_from_instead() => _analysis.Diagnostics.Any(_ => _.Message.Contains("only when the type of the child declares it", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_scope_declared_in_both_shapes.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_scope_declared_in_both_shapes.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Attributes and a builder are two ways of saying the same thing, and a projection saying the same thing twice has
+/// to be recovered as the same thing twice - otherwise which shape an application happened to be written in would
+/// show up in the document, which describes the application rather than the code.
+/// </summary>
+public class a_child_scope_declared_in_both_shapes : Specification
+{
+    const string Attributed = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Catalog.Attributed;
+
+        [EventType]
+        public record ShelfInstalled(string Name);
+
+        [EventType]
+        public record BookPlacedOnShelf(Guid ShelfId, Guid BookId, string Title);
+
+        public record AttributedBook(
+            Guid Id,
+            [SetFrom<BookPlacedOnShelf>(nameof(BookPlacedOnShelf.Title))] string Title);
+
+        [ReadModel]
+        [FromEvent<ShelfInstalled>]
+        public record AttributedShelf(
+            Guid Id,
+            string Name,
+            [ChildrenFrom<BookPlacedOnShelf>(
+                key: nameof(BookPlacedOnShelf.BookId),
+                identifiedBy: nameof(AttributedBook.Id),
+                parentKey: nameof(BookPlacedOnShelf.ShelfId))]
+            IEnumerable<AttributedBook> Books);
+        """;
+
+    const string Fluent = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Projections;
+        using Library.Catalog.Attributed;
+
+        namespace Library.Catalog.Fluent;
+
+        public record FluentBook
+        {
+            public Guid Id { get; init; }
+
+            public string Title { get; init; } = string.Empty;
+        }
+
+        [ReadModel]
+        public record FluentShelf
+        {
+            public Guid Id { get; init; }
+
+            public string Name { get; init; } = string.Empty;
+
+            public IEnumerable<FluentBook> Books { get; init; } = [];
+        }
+
+        public class FluentShelfProjection : IProjectionFor<FluentShelf>
+        {
+            public void Define(IProjectionBuilderFor<FluentShelf> builder) => builder
+                .AutoMap()
+                .From<ShelfInstalled>(_ => _.Set(m => m.Name).To(e => e.Name))
+                .Children(m => m.Books, c => c
+                    .IdentifiedBy(b => b.Id)
+                    .From<BookPlacedOnShelf>(_ => _
+                        .UsingKey(e => e.BookId)
+                        .UsingParentKey(e => e.ShelfId)
+                        .Set(m => m.Title).To(e => e.Title)));
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Catalog/Attributed/Attributed.cs", Attributed),
+        ("Library/Catalog/Fluent/Fluent.cs", Fluent)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    ProjectionChildScopeModel _attributed;
+    ProjectionChildScopeModel _fluent;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _attributed = ChildrenOf("Library.Catalog.Attributed");
+        _fluent = ChildrenOf("Library.Catalog.Fluent");
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_hold_the_children_in_the_same_property() => _attributed.Property.ShouldEqual(_fluent.Property);
+    [Fact] void should_identify_a_child_the_same_way() => _attributed.IdentifiedBy.ShouldEqual(_fluent.IdentifiedBy);
+    [Fact] void should_map_automatically_the_same_way() => _attributed.AutoMap.ShouldEqual(_fluent.AutoMap);
+    [Fact] void should_observe_the_same_events() => Block(_attributed).EventTypes.ShouldContainOnly(Block(_fluent).EventTypes);
+    [Fact] void should_key_a_child_the_same_way() => Block(_attributed).Key.ShouldEqual(Block(_fluent).Key);
+    [Fact] void should_find_the_parent_the_same_way() => Block(_attributed).ParentKey.ShouldEqual(Block(_fluent).ParentKey);
+    [Fact] void should_map_the_same_properties() => Mappings(_attributed).ShouldContainOnly(Mappings(_fluent));
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+
+    static ProjectionFromModel Block(ProjectionChildScopeModel children) => children.Scope.From.Single();
+
+    static IEnumerable<string> Mappings(ProjectionChildScopeModel children) =>
+        Block(children).Properties.Select(_ => $"{_.Key}={_.Value}").Order(StringComparer.Ordinal);
+
+    ProjectionChildScopeModel ChildrenOf(string @namespace) =>
+        _analysis.Model.Slices
+            .Single(_ => string.Equals(_.Namespace, @namespace, StringComparison.Ordinal))
+            .Projection!.Scope.Children.Single();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_authorized_by_a_named_policy.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_authorized_by_a_named_policy.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A policy is named on the artifact and declared where the application is composed. Flattening it to "somebody has
+/// to be there" loses the only thing the attribute actually says, so the name survives and the rule behind it is
+/// looked up in the registration - a role, a claim, or several of them combined.
+/// </summary>
+/// <remarks>
+/// The authorization framework is declared alongside the application rather than referenced, because the recognizer
+/// matches on the names of the types the registration is written against and never on the assembly they came from.
+/// </remarks>
+public class a_command_authorized_by_a_named_policy : Specification
+{
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(PolicySource.All());
+
+    PolicyModel Policy(string name) => _analysis.Model.Policies.First(_ => _.Name == name);
+
+    CommandModel Command(string name) => _analysis.Model.Slices.SelectMany(_ => _.Commands).First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(PolicySource.All()).ShouldBeEmpty();
+    [Fact] void should_carry_the_name_of_the_policy_the_command_names() => Command("ReserveBook").Authorization!.Policies.ShouldContainOnly(["CanReserve"]);
+    [Fact] void should_still_require_an_authenticated_caller() => Command("ReserveBook").Authorization!.RequiresAuthentication.ShouldBeTrue();
+    [Fact] void should_keep_a_role_apart_from_a_policy() => Command("ForceReturn").Authorization!.Roles.ShouldContainOnly(["Librarian"]);
+    [Fact] void should_declare_a_policy_for_every_name_the_application_refers_to() => _analysis.Model.Policies.Select(_ => _.Name).ShouldContainOnly(["CanReserve", "Librarian", "SeniorStaff", "Trusted", "Unregistered"]);
+    [Fact] void should_recover_requirements_declared_one_after_the_other_as_all_having_to_hold() => Policy("CanReserve").Requirement.ShouldEqual(new CombinedRequirement(new RoleRequirement("Librarian"), false, new ClaimRequirement("branch", "central")));
+    [Fact] void should_recover_the_several_values_of_one_requirement_as_alternatives() => Policy("SeniorStaff").Requirement.ShouldEqual(new CombinedRequirement(new RoleRequirement("Librarian"), true, new RoleRequirement("Archivist")));
+    [Fact] void should_recover_a_role_named_by_an_artifact_as_the_policy_it_implies() => Policy("Librarian").Requirement.ShouldEqual(new RoleRequirement("Librarian"));
+    [Fact] void should_recover_nothing_from_a_requirement_that_lives_in_code() => Policy("Trusted").Requirement.ShouldBeNull();
+    [Fact] void should_recover_nothing_from_a_policy_the_application_never_registers() => Policy("Unregistered").Requirement.ShouldBeNull();
+    [Fact] void should_report_both_policies_it_could_not_recover() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable, ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable]);
+    [Fact] void should_say_which_requirement_lives_in_code() => _analysis.Diagnostics.Any(_ => _.Message.Contains("'RequireAssertion'", StringComparison.Ordinal)).ShouldBeTrue();
+    [Fact] void should_say_which_policy_is_never_registered() => _analysis.Diagnostics.Any(_ => _.Message.Contains("'Unregistered'", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_authorized_in_both_shapes.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_authorized_in_both_shapes.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Roles are declared in two shapes - the constructor form and the named argument form - and reading only one of them
+/// silently drops half the authorization in an application. Both are read, which is the bug in Arc's own proxy
+/// generator that this deliberately does not repeat.
+/// </summary>
+public class a_command_authorized_in_both_shapes : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Authorization;
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Inventory.Adding;
+
+        [Command]
+        [Roles("Librarian")]
+        public record AddBookByRolesAttribute(string Title)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        [Command]
+        [Authorize(Roles = "Archivist")]
+        public record AddBookByNamedArgument(string Title)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        [Command]
+        [Authorize]
+        public record AddBookByAuthenticationAlone(string Title)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        [Command]
+        public record AddBookAnonymously(string Title)
+        {
+            public void Handle()
+            {
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    CommandModel Command(string name) => _analysis.Slice().Commands.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_read_the_constructor_form() => Command("AddBookByRolesAttribute").Authorization!.Roles.ShouldContainOnly(["Librarian"]);
+    [Fact] void should_read_the_named_argument_form() => Command("AddBookByNamedArgument").Authorization!.Roles.ShouldContainOnly(["Archivist"]);
+    [Fact] void should_require_an_authenticated_caller_when_no_role_is_named() => Command("AddBookByAuthenticationAlone").Authorization!.RequiresAuthentication.ShouldBeTrue();
+    [Fact] void should_name_no_role_when_none_was_declared() => Command("AddBookByAuthenticationAlone").Authorization!.Roles.ShouldBeEmpty();
+    [Fact] void should_require_nothing_of_a_command_that_declares_nothing() => Command("AddBookAnonymously").Authorization.ShouldBeNull();
+    [Fact] void should_declare_a_policy_for_every_role() => _analysis.Model.Policies.Select(_ => _.Name).ShouldContainOnly(["Archivist", "Librarian"]);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_declaring_a_concurrency_scope.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_declaring_a_concurrency_scope.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The three dimensions a command's appends can be checked for concurrent writers within are declared with the same
+/// attributes that name them, and only take part in the scope when the second argument says so. An attribute naming
+/// a dimension without opting in is metadata about where events go, not a scope, and stating it as one would
+/// describe a stricter application than the source does.
+/// </summary>
+public class a_command_declaring_a_concurrency_scope : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Inventory.Adding;
+
+        [EventType]
+        public record BookAdded(string Title);
+
+        [Command]
+        [EventStreamType("Inventory", true)]
+        [EventSourceType("Book")]
+        public record AddBook(string Title)
+        {
+            public BookAdded Handle() => new(Title);
+        }
+
+        [Command]
+        public record AddBookWithoutAScope(string Title)
+        {
+            public BookAdded Handle() => new(Title);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    Model.CommandModel Command(string name) => _analysis.Slice().Commands.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_the_scope() => Command("AddBook").Concurrency.ShouldNotBeNull();
+    [Fact] void should_narrow_by_the_dimension_that_opted_in() => Command("AddBook").Concurrency!.StreamType.ShouldEqual("Inventory");
+    [Fact] void should_leave_out_the_dimension_that_did_not() => Command("AddBook").Concurrency!.SourceType.ShouldBeNull();
+    [Fact] void should_declare_no_scope_when_the_command_declares_none() => Command("AddBookWithoutAScope").Concurrency.ShouldBeNull();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_governed_by_an_aggregate_root.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_command_governed_by_an_aggregate_root.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A command that hands its work to an aggregate root constructs no event of its own, so reading only the handler
+/// would describe a command that produces nothing. The behavior the handler calls is read as well, and the input the
+/// handler passed along stands in for the parameters the aggregate root named it, so the mappings say where each
+/// value really comes from rather than that it came from code.
+/// </summary>
+public class a_command_governed_by_an_aggregate_root : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Aggregates;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(string Isbn, string Member, string Branch);
+
+        public class Reservation : AggregateRoot
+        {
+            public Task Reserve(string isbn, string member) => Apply(new BookReserved(isbn, member, "central"));
+
+            public void OnBookReserved(BookReserved @event)
+            {
+            }
+        }
+
+        [Command]
+        public record ReserveBook(string Isbn, string MemberId)
+        {
+            public async Task Handle(Reservation reservation)
+            {
+                await reservation.Reserve(Isbn, MemberId);
+                await reservation.Commit();
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProducesModel _produces;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _produces = _analysis.Slice().Commands.First().Produces.First();
+    }
+
+    MappingSourceModel Mapping(string property) => _produces.Mappings.First(_ => _.Property == property).Source;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_state_what_the_command_produces() => _analysis.Slice().Commands.First().Produces.Select(_ => _.EventName).ShouldContainOnly(["BookReserved"]);
+    [Fact] void should_produce_it_unconditionally() => _produces.When.ShouldBeNull();
+    [Fact] void should_follow_the_first_value_back_to_the_command_input() => Mapping("Isbn").ShouldEqual(new PropertyPathSource("Isbn"));
+    [Fact] void should_follow_the_second_value_back_to_the_command_input() => Mapping("Member").ShouldEqual(new PropertyPathSource("MemberId"));
+    [Fact] void should_keep_a_value_the_aggregate_root_decides_on_its_own() => Mapping("Branch").ShouldEqual(new LiteralSource("central"));
+    [Fact] void should_call_the_slice_a_state_change() => _analysis.Slice().Kind.ShouldEqual(SliceKind.StateChange);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_constraint_declared_in_code.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_constraint_declared_in_code.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Screenplay knows exactly two constraint rules - a property of an event has to be unique, and an event may occur
+/// once. Reading the chain recovers both of them from the code that declares them.
+/// </summary>
+public class a_constraint_declared_in_code : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Events.Constraints;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [EventType]
+        public record AuthorRetired(string Name);
+
+        public class AuthorConstraints : IConstraint
+        {
+            public void Define(IConstraintBuilder builder)
+            {
+                builder.Unique(_ => _.WithName("UniqueAuthorName").On<AuthorRegistered>(e => e.Name));
+                builder.Unique<AuthorRetired>("Only one retirement");
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    ConstraintModel Constraint(string name) => _analysis.Slice().Constraints.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_the_rule_on_a_property() => Constraint("UniqueAuthorName").ShouldBeOfExactType<UniquePropertyConstraintModel>();
+    [Fact] void should_name_the_property_it_constrains() => ((UniquePropertyConstraintModel)Constraint("UniqueAuthorName")).Property.ShouldEqual("Name");
+    [Fact] void should_name_the_event_it_constrains() => ((UniquePropertyConstraintModel)Constraint("UniqueAuthorName")).EventName.ShouldEqual("AuthorRegistered");
+    [Fact] void should_recover_the_rule_on_a_whole_event() => _analysis.Slice().Constraints.OfType<UniqueEventConstraintModel>().Single().EventName.ShouldEqual("AuthorRetired");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_controller_exposing_commands_and_queries.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_controller_exposing_commands_and_queries.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Not every application is model-bound. A controller method that changes state is a command whose shape is its
+/// request body, and one that reads state is a query - a whole category of application that was previously invisible.
+/// </summary>
+/// <remarks>
+/// The web framework is declared alongside the application rather than referenced, because the recognizer matches on
+/// the names of the base type and the verb attributes and never on the assembly they came from.
+/// </remarks>
+public class a_controller_exposing_commands_and_queries : Specification
+{
+    const string WebFramework = """
+        using System;
+
+        namespace Microsoft.AspNetCore.Mvc;
+
+        public abstract class ControllerBase;
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class HttpPostAttribute : Attribute;
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class HttpGetAttribute : Attribute;
+
+        [AttributeUsage(AttributeTargets.Parameter)]
+        public sealed class FromBodyAttribute : Attribute;
+        """;
+
+    const string Source = """
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Cratis.Arc.Authorization;
+        using Cratis.Chronicle.Events;
+        using Microsoft.AspNetCore.Mvc;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        public record RegisterAuthor(string Name, int Age);
+
+        public record Author(string Id, string Name);
+
+        public class AuthorsController : ControllerBase
+        {
+            /// <summary>
+            /// Registers a new author.
+            /// </summary>
+            [HttpPost]
+            [Roles("Librarian")]
+            public Task<AuthorRegistered> Register([FromBody] RegisterAuthor command) =>
+                Task.FromResult(new AuthorRegistered(command.Name));
+
+            [HttpGet]
+            public IEnumerable<Author> AllAuthors() => [];
+
+            [HttpGet]
+            public Author AuthorById(string id) => new(id, string.Empty);
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Web/Mvc.cs", WebFramework),
+        ("Library/Authors/Registration/AuthorsController.cs", Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    SliceModel _slice;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _slice = _analysis.Model.Slices.First(_ => _.Namespace == "Library.Authors.Registration");
+    }
+
+    QueryModel Query(string name) => _slice.Queries.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_name_the_command_after_its_request_body() => _slice.Commands.Single().Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_take_the_input_from_the_request_body() => _slice.Commands.Single().Properties.Select(_ => _.Name).ShouldContainOnly(["Name", "Age"]);
+    [Fact] void should_take_the_description_from_the_method() => _slice.Commands.Single().Description.ShouldEqual("Registers a new author.");
+    [Fact] void should_read_what_the_method_requires_of_the_caller() => _slice.Commands.Single().Authorization!.Roles.ShouldContainOnly(["Librarian"]);
+    [Fact] void should_produce_the_event_the_method_constructs() => _slice.Commands.Single().Produces.Single().EventName.ShouldEqual("AuthorRegistered");
+    [Fact] void should_recover_both_queries() => _slice.Queries.Select(_ => _.Name).ShouldContainOnly(["AllAuthors", "AuthorById"]);
+    [Fact] void should_return_many_from_the_listing_query() => Query("AllAuthors").ReturnType.ShouldEqual(new TypeReferenceModel("Author", true, false));
+    [Fact] void should_identify_an_instance_by_the_required_parameter() => Query("AuthorById").By!.Name.ShouldEqual("id");
+    [Fact] void should_infer_a_state_change_slice() => _slice.Kind.ShouldEqual(SliceKind.StateChange);
+    [Fact] void should_point_at_the_file_the_controller_lives_in() => _slice.Commands.Single().SourceFilePath.ShouldEqual("Authors/Registration/AuthorsController.cs");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_controller_returning_a_transport_type.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_controller_returning_a_transport_type.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A controller method's return type says two different things at once - what was read, and how it is carried back.
+/// Only the first belongs in a document. A result that still carries its value is unwrapped; one that has thrown the
+/// value away at the type level cannot be recovered by anything, so the query is left out and reported rather than
+/// emitted with a type from the web framework standing in for a read model.
+/// </summary>
+public class a_controller_returning_a_transport_type : Specification
+{
+    const string WebFramework = """
+        using System;
+        using System.Collections.Generic;
+
+        namespace Microsoft.AspNetCore.Mvc;
+
+        public abstract class ControllerBase;
+
+        public interface IActionResult;
+
+        public abstract class ActionResult : IActionResult;
+
+        public sealed class JsonResult : ActionResult;
+
+        public sealed class ActionResult<TValue>
+        {
+            public static implicit operator ActionResult<TValue>(TValue value) => new();
+        }
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class HttpGetAttribute : Attribute;
+        """;
+
+    const string Source = """
+        using System.Collections.Generic;
+        using Microsoft.AspNetCore.Mvc;
+
+        namespace Library.Messaging.Feed;
+
+        public record Message(string Text);
+
+        public class MessagesController : ControllerBase
+        {
+            [HttpGet]
+            public ActionResult<IEnumerable<Message>> Carried() => new();
+
+            [HttpGet]
+            public ActionResult Bare() => new JsonResult();
+
+            [HttpGet]
+            public IActionResult BareInterface() => new JsonResult();
+
+            [HttpGet]
+            public JsonResult Derived() => new();
+
+            [HttpGet]
+            public IEnumerable<Message> Plain() => [];
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Web/Mvc.cs", WebFramework),
+        ("Library/Messaging/Feed/MessagesController.cs", Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    SliceModel _slice;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _slice = _analysis.Model.Slices.First(_ => _.Namespace == "Library.Messaging.Feed");
+    }
+
+    QueryModel Query(string name) => _slice.Queries.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_keep_only_the_queries_whose_read_model_is_knowable() => _slice.Queries.Select(_ => _.Name).ShouldContainOnly(["Carried", "Plain"]);
+    [Fact] void should_unwrap_a_result_that_still_carries_its_value() => Query("Carried").ReturnType.ShouldEqual(new TypeReferenceModel("Message", true, false));
+    [Fact] void should_leave_a_plain_return_type_alone() => Query("Plain").ReturnType.ShouldEqual(new TypeReferenceModel("Message", true, false));
+    [Fact] void should_never_emit_a_transport_type_as_a_read_model() => _slice.Queries.Any(_ => _.ReturnType.Name.Contains("ActionResult", StringComparison.Ordinal) || _.ReturnType.Name == "JsonResult").ShouldBeFalse();
+    [Fact] void should_report_every_query_it_left_out() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableQuery).ShouldEqual(3);
+    [Fact] void should_say_what_was_returned_instead() => _analysis.Diagnostics.Any(_ => _.Message.Contains("says how the result is transported", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_fluent_projection.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_fluent_projection.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Reading the chain from the source is what makes a fluent projection expressible at all - at runtime it is an
+/// expression tree that has already been compiled down to something a document cannot be recovered from.
+/// </summary>
+public class a_fluent_projection : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections;
+
+        namespace Library.Authors.Listing;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [EventType]
+        public record AuthorRetired(string Name);
+
+        [ReadModel]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public string Name { get; init; } = string.Empty;
+
+            public int Registrations { get; init; }
+        }
+
+        public class AuthorProjection : IProjectionFor<Author>
+        {
+            public void Define(IProjectionBuilderFor<Author> builder) => builder
+                .AutoMap()
+                .From<AuthorRegistered>(_ => _
+                    .Set(m => m.Name).To(e => e.Name)
+                    .Set(m => m.Id).ToEventSourceId()
+                    .Increment(m => m.Registrations))
+                .RemovedWith<AuthorRetired>();
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProjectionModel _projection;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _projection = _analysis.Slice().Projection!;
+    }
+
+    ProjectionFromModel From => _projection.Scope.From.Single();
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_build_the_read_model_the_interface_names() => _projection.ReadModel.ShouldEqual("Author");
+    [Fact] void should_recover_that_mapping_is_automatic() => _projection.AutoMap.ShouldEqual(ProjectionAutoMapMode.Enabled);
+    [Fact] void should_observe_the_event_the_chain_names() => From.EventTypes.ShouldContainOnly(["AuthorRegistered"]);
+    [Fact] void should_map_a_property_from_an_event_property() => From.Properties["Name"].ShouldEqual("name");
+    [Fact] void should_map_a_property_from_the_event_source() => From.Properties["Id"].ShouldEqual("$eventSourceId");
+    [Fact] void should_map_a_property_that_increments() => From.Properties["Registrations"].ShouldEqual("$increment");
+    [Fact] void should_remove_the_instance_when_the_removing_event_occurs() => _projection.Scope.RemovedWith.Single().EventType.ShouldEqual("AuthorRetired");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_folder_holding_the_source_of_several_slices.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_folder_holding_the_source_of_several_slices.cs
@@ -45,8 +45,13 @@ public class a_folder_holding_the_source_of_several_slices : Specification
     static readonly DeclaredUserInterfaceFiles _files = new("Library/Authors/Authors.tsx");
 
     ApplicationModelAnalysis _analysis;
+    IReadOnlyList<ScreenplayDiagnostic> _shared;
 
-    void Establish() => _analysis = Analyzed.Source(_files, ("Library/Authors/Authors.cs", Source));
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_files, ("Library/Authors/Authors.cs", Source));
+        _shared = [.. _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.AmbiguousScreenFile)];
+    }
 
     IEnumerable<ScreenModel> ScreensOf(string @namespace) =>
         _analysis.Model.Slices.Single(_ => _.Namespace == @namespace).Screens;
@@ -54,8 +59,8 @@ public class a_folder_holding_the_source_of_several_slices : Specification
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Authors.cs", Source)).ShouldBeEmpty();
     [Fact] void should_end_the_first_slice_in_the_screen() => ScreensOf("Library.Authors.Registration").Select(_ => _.Name).ShouldContainOnly(["Authors"]);
     [Fact] void should_end_the_second_slice_in_the_screen_as_well() => ScreensOf("Library.Authors.Retirement").Select(_ => _.Name).ShouldContainOnly(["Authors"]);
-    [Fact] void should_report_the_folder_as_shared() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AmbiguousScreenFile]);
-    [Fact] void should_report_it_once() => _analysis.Diagnostics.Count.ShouldEqual(1);
-    [Fact] void should_locate_the_report_at_the_slice_that_found_it_taken() => _analysis.Diagnostics.Single().Location.ShouldEqual("Library.Authors.Retirement");
-    [Fact] void should_name_the_slice_that_claimed_it_first() => _analysis.Diagnostics.Single().Message.Contains("Library.Authors.Registration", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_report_the_folder_as_shared() => _shared.ShouldNotBeEmpty();
+    [Fact] void should_report_it_once() => _shared.Count.ShouldEqual(1);
+    [Fact] void should_locate_the_report_at_the_slice_that_found_it_taken() => _shared[0].Location.ShouldEqual("Library.Authors.Retirement");
+    [Fact] void should_name_the_slice_that_claimed_it_first() => _shared[0].Message.Contains("Library.Authors.Registration", StringComparison.Ordinal).ShouldBeTrue();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_folder_holding_the_source_of_several_slices.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_folder_holding_the_source_of_several_slices.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A slice is a namespace and a screen is a folder, so two namespaces in one folder leave a component that could
+/// belong to either. Both slices are told they end in it, because leaving it out of one of them would be a guess,
+/// and the guess is reported instead.
+/// </summary>
+public class a_folder_holding_the_source_of_several_slices : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration
+        {
+            [EventType]
+            public record AuthorRegistered(string Name);
+
+            [Command]
+            public record RegisterAuthor(string Name)
+            {
+                public AuthorRegistered Handle() => new(Name);
+            }
+        }
+
+        namespace Library.Authors.Retirement
+        {
+            [EventType]
+            public record AuthorRetired(string Name);
+
+            [Command]
+            public record RetireAuthor(string Name)
+            {
+                public AuthorRetired Handle() => new(Name);
+            }
+        }
+        """;
+
+    static readonly DeclaredUserInterfaceFiles _files = new("Library/Authors/Authors.tsx");
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_files, ("Library/Authors/Authors.cs", Source));
+
+    IEnumerable<ScreenModel> ScreensOf(string @namespace) =>
+        _analysis.Model.Slices.Single(_ => _.Namespace == @namespace).Screens;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Authors.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_end_the_first_slice_in_the_screen() => ScreensOf("Library.Authors.Registration").Select(_ => _.Name).ShouldContainOnly(["Authors"]);
+    [Fact] void should_end_the_second_slice_in_the_screen_as_well() => ScreensOf("Library.Authors.Retirement").Select(_ => _.Name).ShouldContainOnly(["Authors"]);
+    [Fact] void should_report_the_folder_as_shared() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AmbiguousScreenFile]);
+    [Fact] void should_report_it_once() => _analysis.Diagnostics.Count.ShouldEqual(1);
+    [Fact] void should_locate_the_report_at_the_slice_that_found_it_taken() => _analysis.Diagnostics.Single().Location.ShouldEqual("Library.Authors.Retirement");
+    [Fact] void should_name_the_slice_that_claimed_it_first() => _analysis.Diagnostics.Single().Message.Contains("Library.Authors.Registration", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_choosing_with_a_conditional_expression.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_choosing_with_a_conditional_expression.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The same decision written as a conditional expression has to read the same way, and the branch taken when the
+/// condition does not hold has to carry the opposite condition rather than none - otherwise both events would look
+/// as if they were always produced.
+/// </summary>
+public class a_handler_choosing_with_a_conditional_expression : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record ReservationRefused(string Isbn);
+
+        [Command]
+        public record ReserveBook(string Isbn, bool InStock)
+        {
+            public object Handle() => InStock ? new BookReserved(Isbn) : (object)new ReservationRefused(Isbn);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ProducesModel> _produces;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _produces = _analysis.Slice().Commands.First().Produces;
+    }
+
+    ProducesModel Produced(string name) => _produces.First(_ => _.EventName == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_produce_both_events() => _produces.Select(_ => _.EventName).ShouldContainOnly(["BookReserved", "ReservationRefused"]);
+    [Fact] void should_guard_the_branch_taken_when_it_holds() => Produced("BookReserved").When.ShouldEqual(new ComparisonCondition("InStock", ComparisonKind.Equal, new LiteralSource(true)));
+    [Fact] void should_guard_the_other_branch_with_the_opposite() => Produced("ReservationRefused").When.ShouldEqual(new ComparisonCondition("InStock", ComparisonKind.NotEqual, new LiteralSource(true)));
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_deciding_between_events.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_deciding_between_events.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A handler that decides between two events is the whole reason a produces block can carry a condition. Reading the
+/// branch the construction sits in recovers the decision, and what follows a guard clause that returns is reached
+/// only when the guard did not hold - stating it unconditionally would describe a different application.
+/// </summary>
+public class a_handler_deciding_between_events : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record PremiumReservationGranted(string Isbn);
+
+        [Command]
+        public record ReserveBook(string Isbn, int Tier)
+        {
+            public object Handle()
+            {
+                if (Tier > 1)
+                {
+                    return new PremiumReservationGranted(Isbn);
+                }
+
+                return new BookReserved(Isbn);
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ProducesModel> _produces;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _produces = _analysis.Slice().Commands.First().Produces;
+    }
+
+    ProducesModel Produced(string name) => _produces.First(_ => _.EventName == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_produce_both_events() => _produces.Select(_ => _.EventName).ShouldContainOnly(["PremiumReservationGranted", "BookReserved"]);
+    [Fact] void should_guard_the_branch_it_was_written_in() => Produced("PremiumReservationGranted").When.ShouldEqual(new ComparisonCondition("Tier", ComparisonKind.GreaterThan, new LiteralSource(1)));
+    [Fact] void should_guard_the_fall_through_with_the_opposite() => Produced("BookReserved").When.ShouldEqual(new ComparisonCondition("Tier", ComparisonKind.LessThanOrEqual, new LiteralSource(1)));
+    [Fact] void should_map_from_the_command_input() => Produced("BookReserved").Mappings.Single().Source.ShouldEqual(new PropertyPathSource("Isbn"));
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_naming_members_of_an_enumeration.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_naming_members_of_an_enumeration.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The compiler hands a constant of an enumeration over as the number behind the member, so a mapping and a guard
+/// both arrive as numbers unless the type they were written as is read alongside them. A document saying
+/// <c>role = 6</c> while the concept it refers to declares <c>clientContact</c> describes nothing anyone can follow.
+/// </summary>
+public class a_handler_naming_members_of_an_enumeration : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Access.Inviting;
+
+        public enum UserRole
+        {
+            None,
+            CustomerAdvisor,
+            ClientContact
+        }
+
+        [EventType]
+        public record ClientContactInvited(UserRole Role, int Attempt);
+
+        [EventType]
+        public record AccessGranted(UserRole Role);
+
+        [Command]
+        public record InviteUser(UserRole Role)
+        {
+            public object Handle()
+            {
+                if (Role == UserRole.ClientContact)
+                {
+                    return new ClientContactInvited(UserRole.ClientContact, 6);
+                }
+
+                return new AccessGranted(Role);
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ProducesModel> _produces;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _produces = _analysis.Slice().Commands.First().Produces;
+    }
+
+    ProducesModel Produced(string name) => _produces.First(_ => _.EventName == name);
+
+    MappingSourceModel MappedOnto(string name, string property) => Produced(name).Mappings.First(_ => _.Property == property).Source;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_name_the_member_a_mapping_is_given() => MappedOnto("ClientContactInvited", "Role").ShouldEqual(new LiteralSource(new EnumValue("ClientContact")));
+    [Fact] void should_name_the_member_a_guard_compares_against() => Produced("ClientContactInvited").When.ShouldEqual(new ComparisonCondition("Role", ComparisonKind.Equal, new LiteralSource(new EnumValue("ClientContact"))));
+    [Fact] void should_name_the_member_the_opposite_guard_compares_against() => Produced("AccessGranted").When.ShouldEqual(new ComparisonCondition("Role", ComparisonKind.NotEqual, new LiteralSource(new EnumValue("ClientContact"))));
+    [Fact] void should_leave_a_number_belonging_to_no_enumeration_as_a_number() => MappedOnto("ClientContactInvited", "Attempt").ShouldEqual(new LiteralSource(6));
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_producing_a_value_no_member_is_declared_with.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_producing_a_value_no_member_is_declared_with.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A value of an enumeration that no member is declared with is a cast or several flags combined into one. There is
+/// no name to write for it, and inventing one would describe a value the application does not have - so the number
+/// stands as it is and the reader is told which value went unnamed rather than being left to wonder.
+/// </summary>
+public class a_handler_producing_a_value_no_member_is_declared_with : Specification
+{
+    const string Source = """
+        using System;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Access.Granting;
+
+        [Flags]
+        public enum Access
+        {
+            None = 0,
+            Read = 1,
+            Write = 2
+        }
+
+        [EventType]
+        public record AccessGranted(Access Access);
+
+        [Command]
+        public record GrantAccess(string Subject)
+        {
+            public object Handle() => new AccessGranted(Access.Read | Access.Write);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProducesModel _produced;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _produced = _analysis.Slice().Commands.First().Produces.First();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_fall_back_to_the_number_behind_the_value() => _produced.Mappings.Single().Source.ShouldEqual(new LiteralSource(3));
+    [Fact] void should_report_the_value_it_could_not_name() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.UnnamedEnumerationValue]);
+    [Fact] void should_say_which_enumeration_it_was() => _analysis.Diagnostics.Single().Message.Contains("'Access'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_say_which_value_went_unnamed() => _analysis.Diagnostics.Single().Message.Contains("'3'", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_whose_body_cannot_be_read.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_whose_body_cannot_be_read.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A handler that builds its event somewhere else gives the reader nothing to map from. The signature still promises
+/// which event comes out, so that much is stated and the missing mappings are reported - which is exactly the
+/// fidelity an artifact living in a referenced package degrades to, where there is metadata but no body at all.
+/// </summary>
+public class a_handler_whose_body_cannot_be_read : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        public static class Events
+        {
+            public static AuthorRegistered For(string name) => new(name);
+        }
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => Events.For(Name);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_state_the_event_the_signature_promises() => _analysis.Slice().Commands.First().Produces.Single().EventName.ShouldEqual("AuthorRegistered");
+    [Fact] void should_state_it_without_mappings() => _analysis.Slice().Commands.First().Produces.Single().Mappings.ShouldBeEmpty();
+    [Fact] void should_state_it_unconditionally() => _analysis.Slice().Commands.First().Produces.Single().When.ShouldBeNull();
+    [Fact] void should_report_that_the_mappings_are_missing() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.UnmappableCommandProduction]);
+    [Fact] void should_say_why() => _analysis.Diagnostics.Single().Message.Contains("never constructed in a body that could be read", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_yielding_the_event_source_id.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_yielding_the_event_source_id.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A handler can decide which event source it appends to by returning the identifier alongside the event. Screenplay
+/// has no way of saying that, so the event still has to be recovered and the part that is lost has to be reported
+/// rather than quietly dropped.
+/// </summary>
+public class a_handler_yielding_the_event_source_id : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Id, string Name)
+        {
+            public (EventSourceId, AuthorRegistered) Handle() => (Id, new AuthorRegistered(Name));
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_produce_the_event() => _analysis.Slice().Commands.First().Produces.Single().EventName.ShouldEqual("AuthorRegistered");
+    [Fact] void should_still_map_its_properties() => _analysis.Slice().Commands.First().Produces.Single().Mappings.ShouldNotBeEmpty();
+    [Fact] void should_report_what_it_cannot_say() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.UnmappableEventSourceIdResult]);
+    [Fact] void should_report_it_as_information_only() => _analysis.Diagnostics.Single().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Information);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_command.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_command.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The input of a command is what the record itself declares. The parameters of its handler are infrastructure -
+/// here a read model carrying current state - and are never something a caller sends.
+/// </summary>
+public class a_model_bound_command : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        /// <summary>
+        /// Registers a new author.
+        /// </summary>
+        [Command]
+        public record RegisterAuthor(string Name, int Age)
+        {
+            public AuthorRegistered Handle(AuthorRegistered current) => new(Name);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    CommandModel _command;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(("Library/Authors/Registration/Registration.cs", Source));
+        _command = _analysis.Slice().Commands.First();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Registration/Registration.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_one_slice() => _analysis.Model.Slices.Count().ShouldEqual(1);
+    [Fact] void should_name_the_slice_after_the_last_namespace_segment() => _analysis.Slice().Name.ShouldEqual("Registration");
+    [Fact] void should_recover_the_namespace() => _analysis.Slice().Namespace.ShouldEqual("Library.Authors.Registration");
+    [Fact] void should_infer_a_state_change_slice() => _analysis.Slice().Kind.ShouldEqual(SliceKind.StateChange);
+    [Fact] void should_name_the_command() => _command.Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_take_the_description_from_the_documentation() => _command.Description.ShouldEqual("Registers a new author.");
+    [Fact] void should_recover_only_the_declared_properties() => _command.Properties.Select(_ => _.Name).ShouldContainOnly(["Name", "Age"]);
+    [Fact] void should_resolve_the_property_types() => _command.Properties.Select(_ => _.Type.Name).ShouldContainOnly(["String", "Int"]);
+    [Fact] void should_recover_the_real_file_path() => _command.SourceFilePath.ShouldEqual("Authors/Registration/Registration.cs");
+    [Fact] void should_produce_the_event_the_body_constructs() => _command.Produces.Single().EventName.ShouldEqual("AuthorRegistered");
+    [Fact] void should_map_the_event_property_from_the_constructor_argument() => _command.Produces.Single().Mappings.Single().ShouldEqual(new PropertyMappingModel("Name", new PropertyPathSource("Name")));
+    [Fact] void should_produce_it_unconditionally() => _command.Produces.Single().When.ShouldBeNull();
+    [Fact] void should_declare_the_event() => _analysis.Slice().Events.Single().Name.ShouldEqual("AuthorRegistered");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A model-bound projection is declared upside down compared to a fluent one - the read model's properties say which
+/// event they come from, rather than the event saying which properties it fills in. Regrouping them by event is what
+/// turns the declaration back into the blocks a document is written in.
+/// </summary>
+public class a_model_bound_projection : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Inventory.Listing;
+
+        [EventType]
+        public record BookAddedToInventory(string Title, int Count);
+
+        [EventType]
+        public record BookRemovedFromInventory(string Title);
+
+        [ReadModel]
+        [FromEvent<BookAddedToInventory>]
+        [RemovedWith<BookRemovedFromInventory>]
+        public record Book
+        {
+            [SetFrom<BookAddedToInventory>("title")]
+            public string Title { get; init; } = string.Empty;
+
+            [AddFrom<BookAddedToInventory>("count")]
+            public int Available { get; init; }
+
+            [Count<BookAddedToInventory>]
+            public int Additions { get; init; }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProjectionModel _projection;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _projection = _analysis.Slice().Projection!;
+    }
+
+    ProjectionFromModel From => _projection.Scope.From.Single();
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_a_projection() => _projection.ShouldNotBeNull();
+    [Fact] void should_build_the_read_model_it_is_declared_on() => _projection.ReadModel.ShouldEqual("Book");
+    [Fact] void should_map_automatically_by_default() => _projection.AutoMap.ShouldEqual(ProjectionAutoMapMode.Enabled);
+    [Fact] void should_observe_the_event_the_read_model_names() => From.EventTypes.ShouldContainOnly(["BookAddedToInventory"]);
+    [Fact] void should_map_a_property_from_the_event() => From.Properties["Title"].ShouldEqual("title");
+    [Fact] void should_map_a_property_that_accumulates() => From.Properties["Available"].ShouldEqual("$add(count)");
+    [Fact] void should_map_a_property_that_counts() => From.Properties["Additions"].ShouldEqual("$count");
+    [Fact] void should_remove_the_instance_when_the_removing_event_occurs() => _projection.Scope.RemovedWith.Single().EventType.ShouldEqual("BookRemovedFromInventory");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_a_nested_object.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_a_nested_object.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A nested object carries no key of its own - there is only ever one of it - and the property declaring it says
+/// nothing beyond where it lives, so everything about it has to be read from the type it holds.
+/// </summary>
+public class a_model_bound_projection_with_a_nested_object : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Lending.Delivery;
+
+        [EventType]
+        public record LoanRequested(string Reference);
+
+        [EventType]
+        public record LoanShipped(string Carrier, string TrackingNumber);
+
+        [FromEvent<LoanShipped>]
+        public record Shipment(
+            [SetFrom<LoanShipped>(nameof(LoanShipped.Carrier))] string Carrier,
+            [SetFrom<LoanShipped>(nameof(LoanShipped.TrackingNumber))] string TrackingNumber);
+
+        [ReadModel]
+        [FromEvent<LoanRequested>]
+        public record Loan(
+            string Reference,
+            [Nested] Shipment? Shipping);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProjectionChildScopeModel _nested;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _nested = _analysis.Slice().Projection!.Scope.Nested.Single();
+    }
+
+    ProjectionFromModel From => _nested.Scope.From.Single();
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_hold_the_object_in_the_property_declaring_it() => _nested.Property.ShouldEqual("Shipping");
+    [Fact] void should_identify_it_by_nothing_at_all() => _nested.IdentifiedBy.ShouldEqual(string.Empty);
+    [Fact] void should_leave_automatic_mapping_to_the_enclosing_scope() => _nested.AutoMap.ShouldEqual(ProjectionAutoMapMode.Inherit);
+    [Fact] void should_observe_the_event_its_type_names() => From.EventTypes.ShouldContainOnly(["LoanShipped"]);
+    [Fact] void should_map_what_its_type_declares() => From.Properties["Carrier"].ShouldEqual("carrier");
+    [Fact] void should_map_every_property_its_type_declares() => From.Properties["TrackingNumber"].ShouldEqual("trackingNumber");
+    [Fact] void should_declare_no_children_alongside_it() => _analysis.Slice().Projection!.Scope.Children.ShouldBeEmpty();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_children.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_children.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A child collection is only half declared where it is written - the property says which event brings an instance
+/// into being and how it is keyed, while the type it holds says what that event fills in. Both halves describe the
+/// same block, so reading only the property would yield children that are never given any content.
+/// </summary>
+public class a_model_bound_projection_with_children : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Inventory.Shelving;
+
+        [EventType]
+        public record ShelfInstalled(string Name);
+
+        [EventType]
+        public record BookPlacedOnShelf(Guid ShelfId, Guid BookId, string Title);
+
+        public record ShelvedBook(
+            Guid Id,
+            [SetFrom<BookPlacedOnShelf>(nameof(BookPlacedOnShelf.Title))] string Title);
+
+        [ReadModel]
+        [FromEvent<ShelfInstalled>]
+        public record Shelf(
+            Guid Id,
+            string Name,
+            [ChildrenFrom<BookPlacedOnShelf>(
+                key: nameof(BookPlacedOnShelf.BookId),
+                parentKey: nameof(BookPlacedOnShelf.ShelfId))]
+            IEnumerable<ShelvedBook> Books);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProjectionChildScopeModel _children;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _children = _analysis.Slice().Projection!.Scope.Children.Single();
+    }
+
+    ProjectionFromModel From => _children.Scope.From.Single();
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_hold_the_children_in_the_property_declaring_them() => _children.Property.ShouldEqual("Books");
+    [Fact] void should_identify_a_child_by_the_property_its_type_names() => _children.IdentifiedBy.ShouldEqual("id");
+    [Fact] void should_leave_automatic_mapping_to_the_enclosing_scope() => _children.AutoMap.ShouldEqual(ProjectionAutoMapMode.Inherit);
+    [Fact] void should_observe_the_event_bringing_a_child_into_being() => From.EventTypes.ShouldContainOnly(["BookPlacedOnShelf"]);
+    [Fact] void should_key_a_child_on_the_property_the_declaration_names() => From.Key.ShouldEqual("bookId");
+    [Fact] void should_find_the_parent_by_the_property_the_declaration_names() => From.ParentKey.ShouldEqual("shelfId");
+    [Fact] void should_map_what_the_type_of_the_child_declares() => From.Properties["Title"].ShouldEqual("title");
+    [Fact] void should_still_observe_the_event_the_read_model_names() => _analysis.Slice().Projection!.Scope.From.Single().EventTypes.ShouldContainOnly(["ShelfInstalled"]);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_nested_object_emptied_by_an_event.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_nested_object_emptied_by_an_event.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A nested object can be emptied again, which the model a projection is built from carries nowhere. Saying so is
+/// what keeps the rest of the nested object trustworthy - the reader that quietly drops one half of a declaration is
+/// the reader nobody can tell apart from one that read it wrong.
+/// </summary>
+public class a_nested_object_emptied_by_an_event : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Lending.Delivery;
+
+        [EventType]
+        public record LoanRequested(string Reference);
+
+        [EventType]
+        public record LoanShipped(string Carrier);
+
+        [EventType]
+        public record LoanShipmentCancelled();
+
+        [FromEvent<LoanShipped>]
+        [ClearWith<LoanShipmentCancelled>]
+        public record Shipment(
+            [SetFrom<LoanShipped>(nameof(LoanShipped.Carrier))] string Carrier);
+
+        [ReadModel]
+        [FromEvent<LoanRequested>]
+        public record Loan(
+            string Reference,
+            [Nested] Shipment? Shipping);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_recover_the_nested_object() => _analysis.Slice().Projection!.Scope.Nested.Single().Property.ShouldEqual("Shipping");
+    [Fact] void should_still_recover_what_fills_it_in() => _analysis.Slice().Projection!.Scope.Nested.Single().Scope.From.Single().Properties["Carrier"].ShouldEqual("carrier");
+    [Fact] void should_report_what_it_left_out() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableProjectionConstruct);
+    [Fact] void should_name_the_event_emptying_it() => _analysis.Diagnostics.Any(_ => _.Message.Contains("LoanShipmentCancelled", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_keyed_on_several_properties.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_keyed_on_several_properties.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A key made of several properties is the hardest thing to recover from a fluent projection, because the type it
+/// identifies comes from the type argument while its parts come from a nested chain. A key that identified a read
+/// model by fewer properties than it really does would be worse than no key at all.
+/// </summary>
+public class a_projection_keyed_on_several_properties : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections;
+
+        namespace Library.Ordering.Tracking;
+
+        [EventType]
+        public record OrderPlaced(string CustomerId, int OrderNumber, string Status);
+
+        public record OrderKey(string CustomerId, int Number);
+
+        [ReadModel]
+        public record Order
+        {
+            public string Status { get; init; } = string.Empty;
+        }
+
+        public class OrderProjection : IProjectionFor<Order>
+        {
+            public void Define(IProjectionBuilderFor<Order> builder) => builder
+                .NoAutoMap()
+                .From<OrderPlaced>(_ => _
+                    .UsingCompositeKey<OrderKey>(k => k
+                        .Set(m => m.CustomerId).To(e => e.CustomerId)
+                        .Set(m => m.Number).To(e => e.OrderNumber))
+                    .Set(m => m.Status).To(e => e.Status));
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    Model.ProjectionFromModel From => _analysis.Slice().Projection!.Scope.From.Single();
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_turn_automatic_mapping_off() => _analysis.Slice().Projection!.AutoMap.ShouldEqual(Model.ProjectionAutoMapMode.Disabled);
+    [Fact] void should_name_the_type_the_key_identifies() => From.Key!.Contains("$composite(OrderKey,", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_carry_every_part_of_the_key() => From.Key!.Contains("CustomerId=customerId", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_carry_the_second_part_too() => From.Key!.Contains("Number=orderNumber", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_still_map_the_ordinary_properties() => From.Properties["Status"].ShouldEqual("status");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_member_of_an_enumeration.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_member_of_an_enumeration.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A projection setting a property to a constant reaches the document through a mini language, and a member of an
+/// enumeration is written into it as a member rather than as a constant - a constant is read back as whichever kind
+/// its text looks like, and a member is always the name the concept declares.
+/// </summary>
+public class a_projection_setting_a_member_of_an_enumeration : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Access.Listing;
+
+        public enum UserRole
+        {
+            None,
+            CustomerAdvisor,
+            ClientContact
+        }
+
+        [EventType]
+        public record ClientContactInvited(string Subject);
+
+        [ReadModel]
+        [FromEvent<ClientContactInvited>]
+        public record Invitation
+        {
+            [SetFrom<ClientContactInvited>("subject")]
+            public string Subject { get; init; } = string.Empty;
+
+            [SetValue<ClientContactInvited>(UserRole.ClientContact)]
+            public UserRole Role { get; init; }
+
+            [SetValue<ClientContactInvited>(6)]
+            public int Attempt { get; init; }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProjectionFromModel _from;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _from = _analysis.Slice().Projection!.Scope.From.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_name_the_member_the_property_is_set_to() => _from.Properties["Role"].ShouldEqual("$enum(clientContact)");
+    [Fact] void should_leave_a_number_belonging_to_no_enumeration_as_a_number() => _from.Properties["Attempt"].ShouldEqual("$value(6)");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_value_no_member_is_declared_with.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_value_no_member_is_declared_with.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The fall back a projection makes when nothing names a value has to be the same one a command makes - the number
+/// as it stands, and a diagnostic saying so. A projection quietly writing a number while a command reports one would
+/// leave the same mistake visible in one half of the document and invisible in the other.
+/// </summary>
+public class a_projection_setting_a_value_no_member_is_declared_with : Specification
+{
+    const string Source = """
+        using System;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Access.Listing;
+
+        [Flags]
+        public enum Access
+        {
+            None = 0,
+            Read = 1,
+            Write = 2
+        }
+
+        [EventType]
+        public record AccessRequested(string Subject);
+
+        [ReadModel]
+        [FromEvent<AccessRequested>]
+        public record Request
+        {
+            [SetFrom<AccessRequested>("subject")]
+            public string Subject { get; init; } = string.Empty;
+
+            [SetValue<AccessRequested>(Access.Read | Access.Write)]
+            public Access Granted { get; init; }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ProjectionFromModel _from;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _from = _analysis.Slice().Projection!.Scope.From.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_fall_back_to_the_number_behind_the_value() => _from.Properties["Granted"].ShouldEqual("$value(3)");
+    [Fact] void should_report_the_value_it_could_not_name() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.UnnamedEnumerationValue]);
+    [Fact] void should_say_which_property_it_was_given_to() => _analysis.Diagnostics.Single().Message.Contains("'Granted'", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_no_type_reference_can_name.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_no_type_reference_can_name.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A Screenplay type reference is a single identifier, so a constructed generic loses its arguments the moment it is
+/// written as one - a map of names to values comes out as the bare word <c>KeyValuePair</c>, which says nothing and
+/// which the document never declares. Nothing better can be written, so what was lost is said instead of passed off
+/// as an answer.
+/// </summary>
+public class a_property_no_type_reference_can_name : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name, IDictionary<string, string> Extras);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_report_what_the_name_loses() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableTypeReference);
+    [Fact] void should_name_the_type_it_could_not_express() => _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableTypeReference).Message.ShouldContain("KeyValuePair");
+    [Fact] void should_say_nothing_about_the_property_it_could_express() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableTypeReference).ShouldEqual(1);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_causing_an_effect.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_causing_an_effect.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A reactor that only causes an effect outside the system is an automation. Holding a command pipeline without ever
+/// using it does not change that, which is exactly what a constructor-dependency heuristic would get wrong.
+/// </summary>
+public class a_reactor_causing_an_effect : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Commands;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+
+        namespace Library.Lending.Notifications;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record ReservationExpired(string Isbn);
+
+        public class ReservationNotifier(ICommandPipeline pipeline) : IReactor
+        {
+            public Task BookReserved(BookReserved @event, EventContext context) => Task.CompletedTask;
+
+            public Task ReservationExpired(ReservationExpired @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ReactorModel _reactor;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _reactor = _analysis.Slice().Reactors.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_name_the_reactor() => _reactor.Name.ShouldEqual("ReservationNotifier");
+    [Fact] void should_observe_the_events_its_methods_take() => _reactor.ObservedEvents.ShouldContainOnly(["BookReserved", "ReservationExpired"]);
+    [Fact] void should_not_call_it_translating() => _reactor.IsTranslating.ShouldBeFalse();
+    [Fact] void should_recover_the_file_it_lives_in() => _reactor.SourceFilePath.ShouldEqual("Feature/Slice/Slice.cs");
+    [Fact] void should_infer_an_automation_slice() => _analysis.Slice().Kind.ShouldEqual(SliceKind.Automation);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_executing_a_command.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_executing_a_command.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A reactor that turns what happened into something else that happens is translating. Reading the actual call into
+/// the command pipeline is what tells that apart from a reactor that merely holds one, which is the distinction a
+/// dependency-based guess cannot make.
+/// </summary>
+public class a_reactor_executing_a_command : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+
+        namespace Library.Lending.Restocking;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [Command]
+        public record DecreaseStock(string Isbn)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        public class StockKeeping(ICommandPipeline pipeline) : IReactor
+        {
+            public async Task BookReserved(BookReserved @event, EventContext context) =>
+                await pipeline.Execute(new DecreaseStock(@event.Isbn));
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_call_it_translating() => _analysis.Slice().Reactors.Single().IsTranslating.ShouldBeTrue();
+    [Fact] void should_infer_a_translate_slice() => _analysis.Slice().Kind.ShouldEqual(SliceKind.Translate);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_returning_further_events.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_returning_further_events.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Returning an event rather than nothing is the other way a reactor translates, and it needs no body reading at all
+/// - the signature already says the reaction produces something.
+/// </summary>
+public class a_reactor_returning_further_events : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+
+        namespace Library.Lending.Restocking;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record RestockRequested(string Isbn);
+
+        public class Restocking : IReactor
+        {
+            public Task<RestockRequested> BookReserved(BookReserved @event, EventContext context) =>
+                Task.FromResult(new RestockRequested(@event.Isbn));
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_call_it_translating() => _analysis.Slice().Reactors.Single().IsTranslating.ShouldBeTrue();
+    [Fact] void should_infer_a_translate_slice() => _analysis.Slice().Kind.ShouldEqual(SliceKind.Translate);
+    [Fact] void should_observe_the_event_it_reacts_to() => _analysis.Slice().Reactors.Single().ObservedEvents.ShouldContainOnly(["BookReserved"]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_whose_handlers_are_not_public.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reactor_whose_handlers_are_not_public.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Chronicle dispatches to every instance method whose first parameter is an event type, public or not. A reactor
+/// keeping its handlers to itself therefore observes those events at runtime, and a document leaving them out would
+/// describe a reactor that reacts to nothing.
+/// </summary>
+public class a_reactor_whose_handlers_are_not_public : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+
+        namespace Library.Lending.Notifications;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record ReservationExpired(string Isbn);
+
+        public class ReservationNotifier : IReactor
+        {
+            public Task BookReserved(BookReserved @event, EventContext context) => Task.CompletedTask;
+
+            internal Task ReservationExpired(ReservationExpired @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ReactorModel _reactor;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _reactor = _analysis.Slice().Reactors.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_observe_every_event_it_handles() => _reactor.ObservedEvents.ShouldContainOnly(["BookReserved", "ReservationExpired"]);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_read_model_carrying_more_than_its_queries.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_read_model_carrying_more_than_its_queries.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Arc serves a static method on a read model as a query when it returns that read model, and its accessibility
+/// never enters into it. Both halves matter: a helper returning something else is not a route, and stating it as one
+/// puts an endpoint in the document that no application serves, while a query that happens not to be public is a
+/// route the application really does serve.
+/// </summary>
+public class a_read_model_carrying_more_than_its_queries : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        public record Author(string Id, string Name)
+        {
+            public static IEnumerable<Author> AllAuthors() => [];
+
+            internal static Author AuthorById(string id) => new(id, string.Empty);
+
+            public static int CountOf(IEnumerable<Author> authors) => 0;
+
+            public static string DisplayNameOf(Author author) => author.Name;
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_only_what_returns_the_read_model() => _analysis.Slice().Queries.Select(_ => _.Name).ShouldContainOnly(["AllAuthors", "AuthorById"]);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_read_model_exposing_queries.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_read_model_exposing_queries.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Awaiting, streaming, observing and querying are all how a result arrives, never what it is. A document says what
+/// a query returns and whether there is one or many of it, so every wrapper has to be peeled away until that is all
+/// that is left.
+/// </summary>
+public class a_read_model_exposing_queries : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using System.Linq;
+        using System.Threading.Tasks;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        public record Author(string Id, string Name)
+        {
+            public static IEnumerable<Author> AllAuthors() => [];
+
+            public static Task<Author> AuthorById(string id) => Task.FromResult(new Author(id, string.Empty));
+
+            public static IQueryable<Author> AuthorsByName(string name, int take = 10) => Enumerable.Empty<Author>().AsQueryable();
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    QueryModel Query(string name) => _analysis.Slice().Queries.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_every_query() => _analysis.Slice().Queries.Select(_ => _.Name).ShouldContainOnly(["AllAuthors", "AuthorById", "AuthorsByName"]);
+    [Fact] void should_return_many_from_a_sequence() => Query("AllAuthors").ReturnType.ShouldEqual(new TypeReferenceModel("Author", true, false));
+    [Fact] void should_return_one_from_behind_an_await() => Query("AuthorById").ReturnType.ShouldEqual(new TypeReferenceModel("Author", false, false));
+    [Fact] void should_return_many_from_behind_a_queryable() => Query("AuthorsByName").ReturnType.IsCollection.ShouldBeTrue();
+    [Fact] void should_take_the_required_parameter_as_the_one_identifying_an_instance() => Query("AuthorById").By!.Name.ShouldEqual("id");
+    [Fact] void should_take_no_parameter_when_the_query_needs_none() => Query("AllAuthors").By.ShouldBeNull();
+    [Fact] void should_narrow_with_the_remaining_parameters() => Query("AuthorsByName").Filters.Select(_ => _.Name).ShouldContainOnly(["take"]);
+    [Fact] void should_infer_a_state_view_slice() => _analysis.Slice().Kind.ShouldEqual(SliceKind.StateView);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reducer.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reducer.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A reducer folds events into a read model with code, and Screenplay has no construct for a fold. The events it
+/// observes and the read model it builds are still worth stating, so those are recovered and the fold itself is
+/// reported as lost rather than silently invented.
+/// </summary>
+public class a_reducer : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reducers;
+
+        namespace Library.Lending.Balances;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record BookReturned(string Isbn);
+
+        [ReadModel]
+        public record Balance(int Outstanding);
+
+        public class BalanceReducer : IReducerFor<Balance>
+        {
+            public Task<Balance> Reserved(BookReserved @event, Balance? current, EventContext context) =>
+                Task.FromResult(new Balance((current?.Outstanding ?? 0) + 1));
+
+            public Task<Balance> Returned(BookReturned @event, Balance? current, EventContext context) =>
+                Task.FromResult(new Balance((current?.Outstanding ?? 0) - 1));
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    ProjectionModel Projection => _analysis.Slice().Projection!;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_state_the_read_model_it_builds() => Projection.ReadModel.ShouldEqual("Balance");
+    [Fact] void should_still_state_the_events_it_observes() => Projection.Scope.From.SelectMany(_ => _.EventTypes).ShouldContainOnly(["BookReserved", "BookReturned"]);
+    [Fact] void should_state_no_mappings_since_the_fold_is_code() => Projection.Scope.From.SelectMany(_ => _.Properties).ShouldBeEmpty();
+    [Fact] void should_report_the_fold_as_lost() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.ReducerWithoutCounterpart);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_screen_importing_names_that_are_no_query_of_its_slice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_screen_importing_names_that_are_no_query_of_its_slice.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An import is only evidence because it is checked against the model, so every import that does not name a query
+/// the slice declares has to leave nothing behind. A package, a component, a command, a type erased before anything
+/// runs and a name that merely resembles a query all fail that check for different reasons and all say nothing.
+/// </summary>
+public class a_screen_importing_names_that_are_no_query_of_its_slice : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Listing;
+
+        [EventType]
+        public record AuthorRetired(string Name);
+
+        [Command]
+        public record RetireAuthor(string Name)
+        {
+            public AuthorRetired Handle() => new(Name);
+        }
+
+        [ReadModel]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public static IEnumerable<Author> AllAuthors() => [];
+        }
+        """;
+
+    const string Component = """
+        import { DataTable } from 'primereact/datatable';
+        import type { AllAuthors } from './AllAuthors';
+        import { RetireAuthor } from './RetireAuthor';
+        import { AllAuthors as Everyone } from '@cratis/somewhere-else';
+        import AllAuthors from './DefaultExport';
+        import * as AllAuthors from './Namespace';
+
+        export const AuthorList = () => <DataTable value={[]} />;
+        """;
+
+    static readonly DeclaredUserInterfaceFiles _files = DeclaredUserInterfaceFiles.Holding(
+        ("Library/Authors/Listing/AuthorList.tsx", Component));
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_files, ("Library/Authors/Listing/Listing.cs", Source));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Listing/Listing.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_recover_the_screen() => _analysis.Slice().Screens.Select(_ => _.Name).ShouldContainOnly(["AuthorList"]);
+    [Fact] void should_bind_nothing() => _analysis.Slice().Screens.Single().Data.ShouldBeEmpty();
+    [Fact] void should_report_only_what_no_screen_states() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.ScreenStructureNotInferred]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_screen_importing_the_queries_of_its_slice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_screen_importing_the_queries_of_its_slice.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Arc generates a proxy per query and a component imports it by name, so an import is not a reading of a user
+/// interface - it is a name the model already holds and can be held against what the slice really declares. What the
+/// binding is then described with comes from the query rather than from the component: the type it returns, and the
+/// parameter it is keyed by.
+/// </summary>
+/// <remarks>
+/// The two imports are written differently on purpose. A clause spanning several lines and one renaming what it
+/// brings in are both ordinary in a component, and what matters either way is the name the module exports rather
+/// than the one the component happens to call it by.
+/// </remarks>
+public class a_screen_importing_the_queries_of_its_slice : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public static IEnumerable<Author> AllAuthors() => [];
+
+            public static Author AuthorById(string id) => new();
+
+            public static IEnumerable<Author> RetiredAuthors() => [];
+        }
+        """;
+
+    const string Component = """
+        import { DataTable } from 'primereact/datatable';
+        import { AllAuthors } from './AllAuthors';
+        import {
+            AuthorById as ById
+        } from './index';
+
+        export const AuthorList = () => <DataTable value={AllAuthors.use()} />;
+        """;
+
+    static readonly DeclaredUserInterfaceFiles _files = DeclaredUserInterfaceFiles.Holding(
+        ("Library/Authors/Listing/AuthorList.tsx", Component));
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ScreenDataModel> _data;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_files, ("Library/Authors/Listing/Listing.cs", Source));
+        _data = _analysis.Slice().Screens.Single().Data;
+    }
+
+    ScreenDataModel Binding(string query) => _data.Single(_ => _.Query == query);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Listing/Listing.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_bind_every_query_the_component_imports() => _data.Select(_ => _.Query).ShouldEqual(["AllAuthors", "AuthorById"]);
+    [Fact] void should_leave_out_a_query_the_component_never_imports() => _data.Select(_ => _.Query).ShouldNotContain("RetiredAuthors");
+    [Fact] void should_take_the_type_from_the_query_returning_many() => Binding("AllAuthors").Type.ShouldEqual(new TypeReferenceModel("Author", true, false));
+    [Fact] void should_take_the_type_from_the_query_returning_one() => Binding("AuthorById").Type.ShouldEqual(new TypeReferenceModel("Author", false, false));
+    [Fact] void should_key_a_binding_by_what_the_query_requires() => Binding("AuthorById").By.ShouldEqual("id");
+    [Fact] void should_leave_a_binding_that_requires_nothing_unkeyed() => Binding("AllAuthors").By.ShouldBeNull();
+    [Fact] void should_still_point_at_the_file_realizing_the_screen() => _analysis.Slice().Screens.Single().FilePath.ShouldEqual("Authors/Listing/AuthorList.tsx");
+    [Fact] void should_report_only_what_no_screen_states() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.ScreenStructureNotInferred]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_screen_whose_file_cannot_be_read.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_screen_whose_file_cannot_be_read.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A host may know which files sit alongside the source without holding their text - a compilation carried from
+/// another machine, a file removed between being listed and being opened. That is not an error and never stops a
+/// document being generated: the screen keeps the one thing that is still known, which is the file realizing it.
+/// </summary>
+public class a_screen_whose_file_cannot_be_read : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public static IEnumerable<Author> AllAuthors() => [];
+        }
+        """;
+
+    static readonly DeclaredUserInterfaceFiles _files = new("Library/Authors/Listing/AuthorList.tsx");
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_files, ("Library/Authors/Listing/Listing.cs", Source));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Listing/Listing.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_recover_the_screen() => _analysis.Slice().Screens.Select(_ => _.Name).ShouldContainOnly(["AuthorList"]);
+    [Fact] void should_still_point_at_the_file_realizing_it() => _analysis.Slice().Screens.Single().FilePath.ShouldEqual("Authors/Listing/AuthorList.tsx");
+    [Fact] void should_bind_nothing() => _analysis.Slice().Screens.Single().Data.ShouldBeEmpty();
+    [Fact] void should_report_only_what_no_screen_states() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.ScreenStructureNotInferred]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_declaring_a_second_projection.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_declaring_a_second_projection.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A slice may declare at most one projection, and a document declaring two does not compile at all. Keeping the
+/// first and reporting the second is what keeps the rest of the document valid, where emitting both would lose
+/// everything.
+/// </summary>
+public class a_slice_declaring_a_second_projection : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [ReadModel]
+        [FromEvent<AuthorRegistered>]
+        public record Author
+        {
+            [SetFrom<AuthorRegistered>("name")]
+            public string Name { get; init; } = string.Empty;
+        }
+
+        [ReadModel]
+        [FromEvent<AuthorRegistered>]
+        public record AuthorSummary
+        {
+            [SetFrom<AuthorRegistered>("name")]
+            public string Name { get; init; } = string.Empty;
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_keep_exactly_one_projection() => _analysis.Slice().Projection.ShouldNotBeNull();
+    [Fact] void should_keep_the_first_one_it_read() => _analysis.Slice().Projection!.ReadModel.ShouldEqual("Author");
+    [Fact] void should_report_the_one_it_left_out() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableProjectionConstruct);
+    [Fact] void should_say_a_slice_may_declare_only_one() => _analysis.Diagnostics.Any(_ => _.Message.Contains("a slice may declare at most one", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_whose_source_is_spread_over_several_folders.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_whose_source_is_spread_over_several_folders.cs
@@ -47,17 +47,20 @@ public class a_slice_whose_source_is_spread_over_several_folders : Specification
 
     ApplicationModelAnalysis _analysis;
     IEnumerable<ScreenModel> _screens;
+    ScreenplayDiagnostic _ambiguity;
 
     void Establish()
     {
         _analysis = Analyzed.Source(_files, _sources);
         _screens = _analysis.Slice().Screens;
+        _ambiguity = _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.AmbiguousScreenFile);
     }
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
     [Fact] void should_recover_a_screen_from_every_folder() => _screens.Select(_ => _.Name).ShouldContainOnly(["AddAuthor", "AuthorSummary"]);
-    [Fact] void should_report_the_folders_it_took_them_from() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AmbiguousScreenFile]);
-    [Fact] void should_report_it_as_worth_knowing_rather_than_as_a_loss() => _analysis.Diagnostics.Single().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Information);
-    [Fact] void should_locate_the_report_at_the_slice() => _analysis.Diagnostics.Single().Location.ShouldEqual("Library.Authors.Registration");
-    [Fact] void should_name_both_folders_in_the_report() => _analysis.Diagnostics.Single().Message.Contains("Library/Api/Authors/Registration", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_report_the_folders_it_took_them_from() => _ambiguity.ShouldNotBeNull();
+    [Fact] void should_report_it_as_worth_knowing_rather_than_as_a_loss() => _ambiguity.Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Information);
+    [Fact] void should_locate_the_report_at_the_slice() => _ambiguity.Location.ShouldEqual("Library.Authors.Registration");
+    [Fact] void should_name_both_folders_in_the_report() => _ambiguity.Message.Contains("Library/Api/Authors/Registration", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_report_nothing_else_beyond_what_no_screen_states() => _analysis.Diagnostics.Select(_ => _.Code).Distinct().ShouldContainOnly([ScreenplayDiagnosticCodes.AmbiguousScreenFile, ScreenplayDiagnosticCodes.ScreenStructureNotInferred]);
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_whose_source_is_spread_over_several_folders.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_whose_source_is_spread_over_several_folders.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A screen is recovered from where a file sits rather than from anything the source states, so the answer is only
+/// as good as the folder structure. One namespace declared in two folders is exactly the case where sitting next to
+/// the source says less than usual, and saying so is the difference between a document a reader can act on and one
+/// they have to double check.
+/// </summary>
+public class a_slice_whose_source_is_spread_over_several_folders : Specification
+{
+    const string Events = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+        """;
+
+    const string Commands = """
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Authors.Registration;
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Domain/Authors/Registration/Events.cs", Events),
+        ("Library/Api/Authors/Registration/Commands.cs", Commands)
+    ];
+
+    static readonly DeclaredUserInterfaceFiles _files = new(
+        "Library/Api/Authors/Registration/AddAuthor.tsx",
+        "Library/Domain/Authors/Registration/AuthorSummary.tsx");
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ScreenModel> _screens;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_files, _sources);
+        _screens = _analysis.Slice().Screens;
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_recover_a_screen_from_every_folder() => _screens.Select(_ => _.Name).ShouldContainOnly(["AddAuthor", "AuthorSummary"]);
+    [Fact] void should_report_the_folders_it_took_them_from() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AmbiguousScreenFile]);
+    [Fact] void should_report_it_as_worth_knowing_rather_than_as_a_loss() => _analysis.Diagnostics.Single().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Information);
+    [Fact] void should_locate_the_report_at_the_slice() => _analysis.Diagnostics.Single().Location.ShouldEqual("Library.Authors.Registration");
+    [Fact] void should_name_both_folders_in_the_report() => _analysis.Diagnostics.Single().Message.Contains("Library/Api/Authors/Registration", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_with_user_interface_files_alongside_it.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_with_user_interface_files_alongside_it.cs
@@ -56,5 +56,6 @@ public class a_slice_with_user_interface_files_alongside_it : Specification
     [Fact] void should_leave_out_the_companions_of_a_component() => _screens.Select(_ => _.Name).ShouldNotContain("AddAuthor.stories");
     [Fact] void should_leave_out_a_file_belonging_to_the_feature_above() => _screens.Select(_ => _.Name).ShouldNotContain("Authors");
     [Fact] void should_leave_out_a_file_belonging_to_a_folder_below() => _screens.Select(_ => _.Name).ShouldNotContain("Step");
-    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_report_only_what_no_screen_states() => _analysis.Diagnostics.Select(_ => _.Code).Distinct().ShouldContainOnly([ScreenplayDiagnosticCodes.ScreenStructureNotInferred]);
+    [Fact] void should_say_so_once_per_screen() => _analysis.Diagnostics.Count.ShouldEqual(2);
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_with_user_interface_files_alongside_it.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_with_user_interface_files_alongside_it.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A syntax tree carries a real path, which is the whole reason a screen can be recovered at all - the vertical
+/// slice convention puts the component realizing a screen in the same folder as the C# it belongs to.
+/// </summary>
+/// <remarks>
+/// Only a component is a screen. A companion carrying a second extension is tooling, a file in the folder above
+/// belongs to another slice, and a file in a folder below belongs to a slice of its own.
+/// </remarks>
+public class a_slice_with_user_interface_files_alongside_it : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    static readonly DeclaredUserInterfaceFiles _files = new(
+        "Library/Authors/Registration/RegisteredAuthors.tsx",
+        "Library/Authors/Registration/AddAuthor.tsx",
+        "Library/Authors/Registration/AddAuthor.stories.tsx",
+        "Library/Authors/Registration/AddAuthor.spec.tsx",
+        "Library/Authors/Registration/Wizard/Step.tsx",
+        "Library/Authors/Authors.tsx");
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ScreenModel> _screens;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_files, ("Library/Authors/Registration/Registration.cs", Source));
+        _screens = _analysis.Slice().Screens;
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Registration/Registration.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_a_screen_per_component() => _screens.Select(_ => _.Name).ShouldContainOnly(["AddAuthor", "RegisteredAuthors"]);
+    [Fact] void should_order_the_screens_by_name() => _screens.Select(_ => _.Name).ShouldEqual(["AddAuthor", "RegisteredAuthors"]);
+    [Fact] void should_point_at_the_file_realizing_the_screen() => _screens.First().FilePath.ShouldEqual("Authors/Registration/AddAuthor.tsx");
+    [Fact] void should_leave_out_the_companions_of_a_component() => _screens.Select(_ => _.Name).ShouldNotContain("AddAuthor.stories");
+    [Fact] void should_leave_out_a_file_belonging_to_the_feature_above() => _screens.Select(_ => _.Name).ShouldNotContain("Authors");
+    [Fact] void should_leave_out_a_file_belonging_to_a_folder_below() => _screens.Select(_ => _.Name).ShouldNotContain("Step");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_unique_property_of_an_event.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_unique_property_of_an_event.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The shortest way to say a property has to be unique is to say so on the property, and it is the shape Screenplay
+/// has an exact counterpart for.
+/// </summary>
+public class a_unique_property_of_an_event : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Events.Constraints;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered([property: Unique("UniqueAuthorName")] string Name);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_the_constraint() => _analysis.Slice().Constraints.Single().ShouldBeOfExactType<UniquePropertyConstraintModel>();
+    [Fact] void should_name_it_what_the_source_named_it() => _analysis.Slice().Constraints.Single().Name.ShouldEqual("UniqueAuthorName");
+    [Fact] void should_constrain_the_property_it_was_declared_on() => ((UniquePropertyConstraintModel)_analysis.Slice().Constraints.Single()).Property.ShouldEqual("Name");
+    [Fact] void should_constrain_it_on_the_event_declaring_it() => ((UniquePropertyConstraintModel)_analysis.Slice().Constraints.Single()).EventName.ShouldEqual("AuthorRegistered");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_comparing_against_a_member_of_an_enumeration.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_comparing_against_a_member_of_an_enumeration.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A rule comparing a property against a member of an enumeration is handed the number behind the member, exactly as
+/// a mapping is. A validate block reading <c>role == 6</c> against a concept declaring names is as unreadable there
+/// as it is anywhere else, so the member is named here too.
+/// </summary>
+public class a_validator_comparing_against_a_member_of_an_enumeration : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using FluentValidation;
+
+        namespace Library.Access.Inviting;
+
+        public enum UserRole
+        {
+            None,
+            CustomerAdvisor,
+            ClientContact
+        }
+
+        [Command]
+        public record InviteUser(UserRole Role, int Attempt)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        public class InviteUserValidator : CommandValidator<InviteUser>
+        {
+            public InviteUserValidator()
+            {
+                RuleFor(_ => _.Role).Equal(UserRole.ClientContact);
+                RuleFor(_ => _.Attempt).GreaterThan(0);
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ValidationRuleModel> _rules;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _rules = _analysis.Slice().Commands.First().Validations;
+    }
+
+    ValidationRuleModel Rule(ValidationRuleKind kind) => _rules.First(_ => _.Kind == kind);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_name_the_member_the_rule_compares_against() => Rule(ValidationRuleKind.Equal).Value.ShouldEqual(new EnumValue("ClientContact"));
+    [Fact] void should_leave_a_number_belonging_to_no_enumeration_as_a_number() => Rule(ValidationRuleKind.GreaterThan).Value.ShouldEqual(0);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_declaring_a_length_range.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_declaring_a_length_range.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A length range is one rule to the developer and two to the document - a lower bound and an upper bound - so the
+/// message written after it was written about both. Attaching it to the upper bound alone would leave the lower bound
+/// reporting a message nobody wrote, which is the kind of wrong a reader cannot see.
+/// </summary>
+public class a_validator_declaring_a_length_range : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using FluentValidation;
+
+        namespace Library.Authors.Registration;
+
+        [Command]
+        public record RegisterAuthor(string Name, string Pen)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+        {
+            public RegisterAuthorValidator()
+            {
+                RuleFor(_ => _.Name).Length(2, 100).WithMessage("A name is between 2 and 100 characters");
+                RuleFor(_ => _.Pen).NotEmpty().WithMessage("A pen name is required").MaximumLength(20);
+            }
+        }
+        """;
+
+    const string RangeMessage = "A name is between 2 and 100 characters";
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ValidationRuleModel> _rules;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _rules = _analysis.Slice().Commands.First().Validations;
+    }
+
+    ValidationRuleModel Rule(string property, ValidationRuleKind kind) =>
+        _rules.First(_ => _.Property == property && _.Kind == kind);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_split_the_range_into_a_lower_and_an_upper_bound() => _rules.Where(_ => _.Property == "Name").Select(_ => _.Kind).ShouldContainOnly([ValidationRuleKind.Min, ValidationRuleKind.Max]);
+    [Fact] void should_carry_the_lower_bound() => Rule("Name", ValidationRuleKind.Min).Value.ShouldEqual(2);
+    [Fact] void should_carry_the_upper_bound() => Rule("Name", ValidationRuleKind.Max).Value.ShouldEqual(100);
+    [Fact] void should_carry_the_message_on_the_lower_bound() => Rule("Name", ValidationRuleKind.Min).Message.ShouldEqual(RangeMessage);
+    [Fact] void should_carry_the_message_on_the_upper_bound() => Rule("Name", ValidationRuleKind.Max).Message.ShouldEqual(RangeMessage);
+    [Fact] void should_carry_a_message_on_the_single_rule_it_was_written_after() => Rule("Pen", ValidationRuleKind.NotEmpty).Message.ShouldEqual("A pen name is required");
+    [Fact] void should_leave_a_later_rule_without_a_message_of_its_own() => Rule("Pen", ValidationRuleKind.Max).Message.ShouldBeNull();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_declaring_rules.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_declaring_rules.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Reading the constructor recovers what the runtime rule descriptor loses - which rules were declared for each
+/// element of a collection, and which rules live in code and can only be reported.
+/// </summary>
+public class a_validator_declaring_rules : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using FluentValidation;
+
+        namespace Library.Authors.Registration;
+
+        [Command]
+        public record RegisterAuthor(string Name, string Email, IEnumerable<int> Ratings)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+        {
+            public RegisterAuthorValidator()
+            {
+                RuleFor(_ => _.Name).NotEmpty().WithMessage("An author must have a name");
+                RuleFor(_ => _.Name).MaximumLength(100);
+                RuleFor(_ => _.Email).EmailAddress();
+                RuleForEach(_ => _.Ratings).GreaterThan(0);
+                RuleFor(_ => _.Name).Must(name => name.Length > 2);
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ValidationRuleModel> _rules;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _rules = _analysis.Slice().Commands.First().Validations;
+    }
+
+    ValidationRuleModel Rule(ValidationRuleKind kind) => _rules.First(_ => _.Kind == kind);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_every_declarative_rule() => _rules.Select(_ => _.Kind).ShouldContainOnly([ValidationRuleKind.NotEmpty, ValidationRuleKind.Max, ValidationRuleKind.Matches, ValidationRuleKind.AllGreaterThan]);
+    [Fact] void should_name_the_property_each_rule_applies_to() => Rule(ValidationRuleKind.NotEmpty).Property.ShouldEqual("Name");
+    [Fact] void should_carry_the_message_written_after_a_rule() => Rule(ValidationRuleKind.NotEmpty).Message.ShouldEqual("An author must have a name");
+    [Fact] void should_carry_the_operand_of_a_rule_that_takes_one() => Rule(ValidationRuleKind.Max).Value.ShouldEqual(100);
+    [Fact] void should_express_an_email_rule_as_the_pattern_the_grammar_knows() => Rule(ValidationRuleKind.Matches).Value.ShouldEqual("email");
+    [Fact] void should_tell_a_rule_on_each_element_from_one_on_the_collection() => Rule(ValidationRuleKind.AllGreaterThan).Property.ShouldEqual("Ratings");
+    [Fact] void should_report_the_rule_that_lives_in_code() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.UnmappableValidationRule]);
+    [Fact] void should_say_which_rule_it_was() => _analysis.Diagnostics.Single().Message.Contains("'Must'", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_for_a_concept.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_for_a_concept.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A concept validator is written against the concept's own value, and a concept declaration takes its rules against
+/// its own implied value, so the two line up exactly. Declaring the rule once on the concept is what keeps every
+/// command using it from having to repeat it.
+/// </summary>
+public class a_validator_for_a_concept : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Validation;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+        using FluentValidation;
+
+        namespace Library.Authors.Registration;
+
+        public record AuthorName(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        public record AuthorRegistered(AuthorName Name);
+
+        public class AuthorNameValidator : ConceptValidator<AuthorName>
+        {
+            public AuthorNameValidator()
+            {
+                RuleFor(_ => _.Value).NotEmpty().WithMessage("An author name is required");
+                RuleFor(_ => _.Value).MaximumLength(200);
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    ConceptModel _concept;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _concept = _analysis.Model.Concepts.First(_ => _.Name == "AuthorName");
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_attach_the_rules_to_the_concept() => _concept.Validations.Select(_ => _.Kind).ShouldContainOnly([ValidationRuleKind.NotEmpty, ValidationRuleKind.Max]);
+    [Fact] void should_carry_the_message() => _concept.Validations.First(_ => _.Kind == ValidationRuleKind.NotEmpty).Message.ShouldEqual("An author name is required");
+    [Fact] void should_carry_the_operand() => _concept.Validations.First(_ => _.Kind == ValidationRuleKind.Max).Value.ShouldEqual(200);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An aggregate root decides what happened in code, applying events from inside its own methods. A document says what
+/// a command produces declaratively, and there is no honest way to state a decision that lives in a class. Saying so
+/// is the difference between a document that is incomplete and one that is quietly wrong.
+/// </summary>
+public class an_aggregate_root : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Aggregates;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        public class Reservation : AggregateRoot
+        {
+            public Task Reserve(string isbn) => Apply(new BookReserved(isbn));
+
+            public void On(BookReserved @event)
+            {
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_declare_the_event_it_applies() => _analysis.Slice().Events.Single().Name.ShouldEqual("BookReserved");
+    [Fact] void should_report_that_what_it_produces_is_not_stated() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AggregateRootWithoutCounterpart]);
+    [Fact] void should_name_the_aggregate_root_in_the_report() => _analysis.Diagnostics.Single().Message.Contains("Reservation", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root.cs
@@ -2,13 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
 
 namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
 
 /// <summary>
-/// An aggregate root decides what happened in code, applying events from inside its own methods. A document says what
-/// a command produces declaratively, and there is no honest way to state a decision that lives in a class. Saying so
-/// is the difference between a document that is incomplete and one that is quietly wrong.
+/// An aggregate root states what it produces through the command that hands its work to it. One that no command
+/// reaches has nothing to state it through - a document has no construct for a class that decides on its own - so
+/// what it applies is reported rather than left unsaid. The slice is still a state change, because governing a change
+/// is what an aggregate root is for.
 /// </summary>
 public class an_aggregate_root : Specification
 {
@@ -38,6 +40,7 @@ public class an_aggregate_root : Specification
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
     [Fact] void should_still_declare_the_event_it_applies() => _analysis.Slice().Events.Single().Name.ShouldEqual("BookReserved");
-    [Fact] void should_report_that_what_it_produces_is_not_stated() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AggregateRootWithoutCounterpart]);
+    [Fact] void should_call_the_slice_a_state_change() => _analysis.Slice().Kind.ShouldEqual(SliceKind.StateChange);
+    [Fact] void should_report_that_nothing_states_what_it_produces() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AggregateRootWithoutCounterpart]);
     [Fact] void should_name_the_aggregate_root_in_the_report() => _analysis.Diagnostics.Single().Message.Contains("Reservation", StringComparison.Ordinal).ShouldBeTrue();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root_deciding_on_a_behavior_parameter.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root_deciding_on_a_behavior_parameter.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A behavior decides between two events on a value the handler passed it, and the aggregate root named that value
+/// whatever it liked. Without the substitution the call site declares, the decision would look like code and both
+/// events would be stated as always produced - which describes an application that emits both every time.
+/// </summary>
+public class an_aggregate_root_deciding_on_a_behavior_parameter : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Aggregates;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record ReservationRefused(string Isbn);
+
+        public class Reservation : AggregateRoot
+        {
+            public Task Reserve(string isbn, int copies)
+            {
+                if (copies > 0)
+                {
+                    return Apply(new BookReserved(isbn));
+                }
+
+                return Apply(new ReservationRefused(isbn));
+            }
+
+            public void OnBookReserved(BookReserved @event)
+            {
+            }
+
+            public void OnReservationRefused(ReservationRefused @event)
+            {
+            }
+        }
+
+        [Command]
+        public record ReserveBook(string Isbn, int CopiesWanted)
+        {
+            public async Task Handle(Reservation reservation)
+            {
+                await reservation.Reserve(Isbn, CopiesWanted);
+                await reservation.Commit();
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    ConditionModel? ConditionFor(string @event) =>
+        _analysis.Slice().Commands.First().Produces.First(_ => _.EventName == @event).When;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn((Analyzed.SlicePath, Source)).ShouldBeEmpty();
+    [Fact] void should_state_both_events() => _analysis.Slice().Commands.First().Produces.Select(_ => _.EventName).ShouldContainOnly(["BookReserved", "ReservationRefused"]);
+    [Fact] void should_resolve_the_guard_back_to_the_command_input() => ConditionFor("BookReserved").ShouldEqual(new ComparisonCondition("CopiesWanted", ComparisonKind.GreaterThan, new LiteralSource(0)));
+    [Fact] void should_invert_the_guard_for_the_other_outcome() => ConditionFor("ReservationRefused").ShouldEqual(new ComparisonCondition("CopiesWanted", ComparisonKind.LessThanOrEqual, new LiteralSource(0)));
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root_deciding_on_its_own_state.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root_deciding_on_its_own_state.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A behavior refusing to act on what it has already seen is a real decision that a produces condition has nowhere
+/// to put - the condition compares the input of the command, and the state an aggregate root holds is not input.
+/// The production is therefore stated unconditionally and the decision is reported, so that the reader knows the
+/// document is silent about it rather than that the generator missed it.
+/// </summary>
+public class an_aggregate_root_deciding_on_its_own_state : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Aggregates;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        public class Reservation : AggregateRoot
+        {
+            bool _reserved;
+
+            public Task Reserve(string isbn)
+            {
+                if (_reserved)
+                {
+                    return Task.CompletedTask;
+                }
+
+                return Apply(new BookReserved(isbn));
+            }
+
+            public void OnBookReserved(BookReserved @event) => _reserved = true;
+        }
+
+        [Command]
+        public record ReserveBook(string Isbn)
+        {
+            public async Task Handle(Reservation reservation)
+            {
+                await reservation.Reserve(Isbn);
+                await reservation.Commit();
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn((Analyzed.SlicePath, Source)).ShouldBeEmpty();
+    [Fact] void should_still_state_what_the_command_produces() => _analysis.Slice().Commands.First().Produces.Select(_ => _.EventName).ShouldContainOnly(["BookReserved"]);
+    [Fact] void should_state_it_unconditionally() => _analysis.Slice().Commands.First().Produces.First().When.ShouldBeNull();
+    [Fact] void should_report_the_decision_it_could_not_carry() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.UnmappableAggregateStateCondition]);
+    [Fact] void should_name_the_aggregate_root_holding_the_state() => _analysis.Diagnostics[0].Message.ShouldContain("Reservation");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root_declared_away_from_the_command.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_aggregate_root_declared_away_from_the_command.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An aggregate root does not have to live beside the command that uses it. The behavior is then read from one file
+/// while the values it was given were written in another, so the model that can make sense of each expression has to
+/// travel with it - reading both through the wrong one would lose every mapping.
+/// </summary>
+public class an_aggregate_root_declared_away_from_the_command : Specification
+{
+    const string Aggregate = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Aggregates;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reservations;
+
+        [EventType]
+        public record BookReserved(string Isbn, string Member);
+
+        public class Reservation : AggregateRoot
+        {
+            public Task Reserve(string isbn, string member) => Apply(new BookReserved(isbn, member));
+        }
+        """;
+
+    const string Command = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Commands.ModelBound;
+        using Library.Lending.Reservations;
+
+        namespace Library.Lending.Reserving;
+
+        [Command]
+        public record ReserveBook(string Isbn, string MemberId)
+        {
+            public async Task Handle(Reservation reservation)
+            {
+                await reservation.Reserve(Isbn, MemberId);
+                await reservation.Commit();
+            }
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Lending/Reservations/Reservations.cs", Aggregate),
+        ("Library/Lending/Reserving/Reserving.cs", Command)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    ProducesModel _produces;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _produces = _analysis.Model.Slices.SelectMany(_ => _.Commands).Single().Produces.Single();
+    }
+
+    MappingSourceModel Mapping(string property) => _produces.Mappings.First(_ => _.Property == property).Source;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_state_what_the_command_produces() => _produces.EventName.ShouldEqual("BookReserved");
+    [Fact] void should_follow_the_first_value_back_across_the_file_boundary() => Mapping("Isbn").ShouldEqual(new PropertyPathSource("Isbn"));
+    [Fact] void should_follow_the_second_value_back_across_the_file_boundary() => Mapping("Member").ShouldEqual(new PropertyPathSource("MemberId"));
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_artifact_inheriting_what_it_carries.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_artifact_inheriting_what_it_carries.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A property declared on a base type is part of what the artifact carries just as much as one declared on the type
+/// itself - it is serialized, it is sent, and it is what a caller has to fill in. Reading only what the type itself
+/// declares would describe a shape that does not exist, and say nothing about the difference.
+/// </summary>
+public class an_artifact_inheriting_what_it_carries : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        public abstract record Audited
+        {
+            public string CorrelationId { get; init; } = string.Empty;
+        }
+
+        [EventType]
+        public record AuthorRegistered(string Name) : Audited;
+
+        [Command]
+        public record RegisterAuthor(string Name) : Audited
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_carry_the_inherited_property_on_the_event() => _analysis.Slice().Events.Single().Properties.Select(_ => _.Name).ShouldContainOnly(["CorrelationId", "Name"]);
+    [Fact] void should_carry_the_inherited_property_on_the_command() => _analysis.Slice().Commands.Single().Properties.Select(_ => _.Name).ShouldContainOnly(["CorrelationId", "Name"]);
+    [Fact] void should_declare_the_inherited_property_first() => _analysis.Slice().Events.Single().Properties.First().Name.ShouldEqual("CorrelationId");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_enumeration_whose_members_share_a_value.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_enumeration_whose_members_share_a_value.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Two members declared with one value are indistinguishable by the time the compiler hands the value over, and the
+/// order the members come back in follows where they were read from rather than anything about the source. Ordering
+/// the candidates by name is what keeps the same compilation producing the same document, which is the whole reason
+/// a generated document is worth committing.
+/// </summary>
+public class an_enumeration_whose_members_share_a_value : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Members.Upgrading;
+
+        public enum Tier
+        {
+            Standard = 1,
+            Entry = 1,
+            Basic = 1,
+            Premium = 2
+        }
+
+        [EventType]
+        public record TierAssigned(Tier Tier);
+
+        [Command]
+        public record UpgradeMember(string MemberId)
+        {
+            public object Handle() => new TierAssigned(Tier.Standard);
+        }
+        """;
+
+    MappingSourceModel _source;
+    MappingSourceModel _again;
+
+    void Establish()
+    {
+        _source = Mapped();
+        _again = Mapped();
+    }
+
+    static MappingSourceModel Mapped() =>
+        Analyzed.Source(Source).Slice().Commands.First().Produces.Single().Mappings.Single().Source;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_name_the_first_of_the_members_in_ordinal_order() => _source.ShouldEqual(new LiteralSource(new EnumValue("Basic")));
+    [Fact] void should_name_the_same_member_every_time() => _again.ShouldEqual(_source);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_carrying_tags.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_carrying_tags.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Tags classify an event and are the one piece of event metadata Screenplay has a counterpart for. They can be
+/// written in either shape and more than once, so all of them are collected and ordered.
+/// </summary>
+public class an_event_carrying_tags : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        [Tag("audit")]
+        [Tags("authors", "audit")]
+        public record AuthorRegistered(string Name, int Age);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    EventModel _event;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _event = _analysis.Slice().Events.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_name_the_event() => _event.Name.ShouldEqual("AuthorRegistered");
+    [Fact] void should_recover_its_properties() => _event.Properties.Select(_ => _.Name).ShouldContainOnly(["Name", "Age"]);
+    [Fact] void should_collect_every_tag_once() => _event.Tags.ShouldContainOnly(["audit", "authors"]);
+    [Fact] void should_order_the_tags() => _event.Tags.First().ShouldEqual("audit");
+    [Fact] void should_infer_a_state_view_slice() => _analysis.Slice().Kind.ShouldEqual(SliceKind.StateView);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_declared_across_several_files.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_declared_across_several_files.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Roslyn hands over the members of a type split across partial declarations in the order the syntax trees arrived,
+/// and the order a build globs its files in is not something anyone controls. A document meant to be committed and
+/// diffed cannot reorder itself because the file system did, so the declarations are read in the order of the files
+/// they live in rather than the order they were handed over.
+/// </summary>
+public class an_event_declared_across_several_files : Specification
+{
+    const string First = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public partial record AuthorRegistered
+        {
+            public string Alpha { get; init; } = string.Empty;
+        }
+        """;
+
+    const string Second = """
+        namespace Library.Authors.Registration;
+
+        public partial record AuthorRegistered
+        {
+            public string Beta { get; init; } = string.Empty;
+        }
+        """;
+
+    IEnumerable<string> _inOneOrder;
+    IEnumerable<string> _inTheOther;
+
+    void Establish()
+    {
+        _inOneOrder = PropertiesOf(
+            ("Library/Authors/Registration/A.cs", First),
+            ("Library/Authors/Registration/B.cs", Second));
+
+        _inTheOther = PropertiesOf(
+            ("Library/Authors/Registration/B.cs", Second),
+            ("Library/Authors/Registration/A.cs", First));
+    }
+
+    static IEnumerable<string> PropertiesOf(params (string Path, string Text)[] sources) =>
+        [.. Analyzed.Source(sources).Slice().Events.Single().Properties.Select(_ => _.Name)];
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Registration/A.cs", First), ("Library/Authors/Registration/B.cs", Second)).ShouldBeEmpty();
+    [Fact] void should_read_the_declarations_in_the_order_of_the_files() => _inOneOrder.ShouldEqual(["Alpha", "Beta"]);
+    [Fact] void should_read_them_the_same_way_whatever_order_they_arrived_in() => _inTheOther.ShouldEqual(_inOneOrder);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_marking_a_positional_parameter_as_personal_data.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_marking_a_positional_parameter_as_personal_data.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An event is canonically a positional record, and an attribute written on a positional parameter belongs to the
+/// parameter rather than to the property it produces. Chronicle reads <c>[PII]</c> from the constructor parameter
+/// for exactly that reason, so a document that read only the property would say a value is not sensitive while the
+/// runtime encrypts it.
+/// </summary>
+public class an_event_marking_a_positional_parameter_as_personal_data : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle.Compliance.GDPR;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration;
+
+        public record AuthorName(string Value) : ConceptAs<string>(Value);
+
+        public record AuthorEmail(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        public record AuthorRegistered([PII] AuthorName Name, AuthorEmail Email);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    bool IsPii(string name) => _analysis.Model.Concepts.Single(_ => _.Name == name).IsPii;
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_mark_the_marked_concept_as_personal_data() => IsPii("AuthorName").ShouldBeTrue();
+    [Fact] void should_leave_the_unmarked_concept_alone() => IsPii("AuthorEmail").ShouldBeFalse();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_with_no_screenplay_counterpart.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/an_event_with_no_screenplay_counterpart.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Generations, tombstones and compensations are all first class in Chronicle and have no counterpart in Screenplay
+/// at all. Inventing syntax for them would be worse than saying nothing, so each is reported once for the event
+/// declaring it and the event is otherwise recovered as usual.
+/// </summary>
+public class an_event_with_no_screenplay_counterpart : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType(generation: 2)]
+        public record AuthorRegistered(string Name);
+
+        [EventType]
+        [Tombstone]
+        public record AuthorForgotten(string Name);
+
+        [EventType]
+        [CompensationFor<AuthorRegistered>]
+        public record AuthorRegistrationReversed(string Name);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    IEnumerable<string> Reported => _analysis.Diagnostics.Select(_ => _.Message);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_declare_every_event() => _analysis.Slice().Events.Select(_ => _.Name).ShouldContainOnly(["AuthorRegistered", "AuthorForgotten", "AuthorRegistrationReversed"]);
+    [Fact] void should_report_all_three_losses() => _analysis.Diagnostics.Count.ShouldEqual(3);
+    [Fact] void should_report_only_the_one_code() => _analysis.Diagnostics.Select(_ => _.Code).Distinct(StringComparer.Ordinal).ShouldContainOnly([ScreenplayDiagnosticCodes.EventFeatureWithoutCounterpart]);
+    [Fact] void should_say_which_generation_was_lost() => Reported.Any(_ => _.Contains("generation 2", StringComparison.Ordinal)).ShouldBeTrue();
+    [Fact] void should_say_the_tombstone_was_lost() => Reported.Any(_ => _.Contains("tombstone", StringComparison.Ordinal)).ShouldBeTrue();
+    [Fact] void should_say_the_compensation_was_lost() => Reported.Any(_ => _.Contains("compensates", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/artifacts_in_the_root_namespace.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/artifacts_in_the_root_namespace.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Artifacts sitting in the root namespace leave the module, the feature and the slice with nothing to be named
+/// after but the assembly, so all of them end up saying the same word. Naming them anything else would be fiction -
+/// the source really does say nothing about where they belong - so the document is left honest and what would fix
+/// it is reported instead.
+/// </summary>
+public class artifacts_in_the_root_namespace : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library;
+
+        [EventType]
+        public record StuffDone(string What);
+
+        [Command]
+        public record DoStuff(string What)
+        {
+            public StuffDone Handle() => new(What);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_recover_the_slice() => _analysis.Slice().Namespace.ShouldEqual("Library");
+    [Fact] void should_still_recover_what_it_declares() => _analysis.Slice().Commands.Single().Name.ShouldEqual("DoStuff");
+    [Fact] void should_report_that_there_is_nothing_to_arrange_by() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.NamespaceWithoutStructure);
+    [Fact] void should_say_what_would_fix_it() => _analysis.Diagnostics.First(_ => _.Code == ScreenplayDiagnosticCodes.NamespaceWithoutStructure).Message.Contains("namespace of its own", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_report_it_as_information_since_the_document_is_still_valid() => _analysis.Diagnostics.First(_ => _.Code == ScreenplayDiagnosticCodes.NamespaceWithoutStructure).Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Information);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/concepts_referred_to_by_an_artifact.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/concepts_referred_to_by_an_artifact.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A concept is declared once at the top of a document and referred to by name from there on, so every concept an
+/// artifact refers to has to be collected while its type is resolved. The primitive behind each one has to survive
+/// exactly - Screenplay tells a whole number from a fractional one, which the TypeScript proxy map does not.
+/// </summary>
+public class concepts_referred_to_by_an_artifact : Specification
+{
+    const string Source = """
+        using System;
+        using Cratis.Chronicle.Compliance.GDPR;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration;
+
+        public record AuthorId(Guid Value) : ConceptAs<Guid>(Value);
+
+        [PII("The name of a person")]
+        public record AuthorName(string Value) : ConceptAs<string>(Value);
+
+        public record RoyaltyRate(decimal Value) : ConceptAs<decimal>(Value);
+
+        public enum MembershipTier { Standard, Premium }
+
+        [EventType]
+        public record AuthorRegistered(AuthorId Id, AuthorName Name, RoyaltyRate Rate, MembershipTier Tier, int Books);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    ConceptModel Concept(string name) => _analysis.Model.Concepts.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_declare_every_concept_referred_to() => _analysis.Model.Concepts.Select(_ => _.Name).ShouldContainOnly(["AuthorId", "AuthorName", "MembershipTier", "RoyaltyRate"]);
+    [Fact] void should_order_them_by_name() => _analysis.Model.Concepts.First().Name.ShouldEqual("AuthorId");
+    [Fact] void should_back_an_identity_with_a_uuid() => Concept("AuthorId").Primitive.ShouldEqual(ScreenplayPrimitive.Uuid);
+    [Fact] void should_back_a_name_with_a_string() => Concept("AuthorName").Primitive.ShouldEqual(ScreenplayPrimitive.String);
+    [Fact] void should_tell_a_fractional_number_from_a_whole_one() => Concept("RoyaltyRate").Primitive.ShouldEqual(ScreenplayPrimitive.Decimal);
+    [Fact] void should_recover_that_a_concept_carries_personal_data() => Concept("AuthorName").IsPii.ShouldBeTrue();
+    [Fact] void should_not_claim_the_others_do() => Concept("AuthorId").IsPii.ShouldBeFalse();
+    [Fact] void should_declare_an_enumeration_referred_to() => Concept("MembershipTier").Primitive.ShouldEqual(ScreenplayPrimitive.Enum);
+    [Fact] void should_recover_its_values() => Concept("MembershipTier").EnumValues.ShouldContainOnly(["Standard", "Premium"]);
+    [Fact] void should_leave_a_primitive_undeclared() => _analysis.Model.Concepts.Any(_ => _.Name == "Int").ShouldBeFalse();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/queries_declared_under_the_same_name.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/queries_declared_under_the_same_name.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Two read models in one namespace can each declare a query called the same thing. Emitting both under that one
+/// name compiles, which is worse than failing - the document reads as if one were a duplicate of the other. Both are
+/// therefore qualified by the read model that declares them, so both survive and both are traceable back to source.
+/// </summary>
+public class queries_declared_under_the_same_name : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Showcase.Listing;
+
+        [ReadModel]
+        public record ShowcaseItem(string Id)
+        {
+            public static IEnumerable<ShowcaseItem> ObserveAll() => [];
+
+            public static IEnumerable<ShowcaseItem> OnlyHere() => [];
+        }
+
+        [ReadModel]
+        public record AuditItem(string Id)
+        {
+            public static IEnumerable<AuditItem> ObserveAll() => [];
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_keep_both_queries() => _analysis.Slice().Queries.Count().ShouldEqual(3);
+    [Fact] void should_qualify_every_colliding_name_by_its_read_model() => _analysis.Slice().Queries.Select(_ => _.Name).ShouldContainOnly(["AuditItemObserveAll", "ShowcaseItemObserveAll", "OnlyHere"]);
+    [Fact] void should_leave_a_name_that_collides_with_nothing_alone() => _analysis.Slice().Queries.Any(_ => _.Name == "OnlyHere").ShouldBeTrue();
+    [Fact] void should_report_each_query_it_renamed() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.AmbiguousQueryName).ShouldEqual(2);
+    [Fact] void should_report_it_as_information_since_nothing_was_lost() => _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.AmbiguousQueryName).All(_ => _.Severity == ScreenplayDiagnosticSeverity.Information).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/source_a_referenced_package_contributed.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/source_a_referenced_package_contributed.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A compilation carries more than the project's own files - a referenced package can ship source of its own, and it
+/// is compiled from wherever the package cache lives. Letting that decide where the project is puts the file system
+/// root in front of every path in the document, so what a reader gets is the absolute layout of the machine that
+/// generated it. A document that cannot be committed and diffed is a document nobody regenerates.
+/// </summary>
+public class source_a_referenced_package_contributed : Specification
+{
+    const string Slice = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+
+        namespace Library.Lending.Notifications;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        public class ReservationNotifier : IReactor
+        {
+            public Task BookReserved(BookReserved @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    const string FromAPackage = "global using System;";
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("/Volumes/work/Library/Lending/Notifications/Notifications.cs", Slice),
+        ("/Volumes/work/Library/Program.cs", "namespace Library;"),
+        ("/Users/someone/.nuget/packages/cratis/20.8.3/contentFiles/cs/any/GlobalUsings.cs", FromAPackage)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_write_the_path_relative_to_the_project() => _analysis.Slice().Reactors.Single().SourceFilePath.ShouldEqual("Lending/Notifications/Notifications.cs");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/source_that_compiles_but_declares_nothing.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/source_that_compiles_but_declares_nothing.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Source that builds and declares no artifact is a different thing from source that does not build, and conflating
+/// the two would tell a reader their application is empty when really it is broken. Only the first is worth stating
+/// as "declares nothing", and neither is an error - an application with no Arc artifacts yet is a perfectly ordinary
+/// thing to point the generator at.
+/// </summary>
+public class source_that_compiles_but_declares_nothing : Specification
+{
+    const string Source = """
+        namespace Library.Plumbing;
+
+        public class NotAnArtifact
+        {
+            public string Name { get; set; } = string.Empty;
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_be_analyzing_source_that_really_does_compile() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_report_that_it_declares_nothing() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AnalysisUnavailable]);
+    [Fact] void should_not_claim_the_source_failed_to_compile() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.SourceDidNotCompile).ShouldBeFalse();
+    [Fact] void should_report_it_as_information_only() => _analysis.Diagnostics.Single().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Information);
+    [Fact] void should_recover_no_slice() => _analysis.Model.Slices.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/source_that_did_not_compile.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/source_that_did_not_compile.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Source that does not build still yields symbols, and analyzing them produces a document that looks like an
+/// answer while describing an application that does not exist. A nearly empty document handed back with nothing
+/// wrong reported is the one outcome nobody can act on, so this is an error - which is what makes a host exit non
+/// zero - while whatever was recovered is still returned for whoever wants to look at it.
+/// </summary>
+public class source_that_did_not_compile : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(ThisDoesNotExist);
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    ScreenplayDiagnostic Reported => _analysis.Diagnostics.First(_ => _.Code == ScreenplayDiagnosticCodes.SourceDidNotCompile);
+
+    [Fact] void should_be_analyzing_source_that_really_does_not_compile() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldNotBeEmpty();
+    [Fact] void should_report_that_the_source_did_not_compile() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.SourceDidNotCompile);
+    [Fact] void should_report_it_as_an_error() => Reported.Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Error);
+    [Fact] void should_say_the_document_cannot_be_relied_on() => Reported.Message.Contains("describes the application reliably", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_quote_the_first_thing_the_compiler_said() => Reported.Message.Contains("ThisDoesNotExist", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_still_return_whatever_it_recovered() => _analysis.Slice().Commands.Single().Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_not_throw_instead() => _analysis.Model.ShouldNotBeNull();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/the_same_source_twice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/the_same_source_twice.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A generated document is meant to be committed, diffed and reviewed, which only works if the same source always
+/// yields the same model. Symbol enumeration order is not something to rely on, so everything is ordered explicitly -
+/// and this is what proves it, by analyzing two separate compilations of the same source.
+/// </summary>
+public class the_same_source_twice : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Authorization;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration;
+
+        public record AuthorId(Guid Value) : ConceptAs<Guid>(Value);
+
+        public record AuthorName(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        [Tag("audit")]
+        public record AuthorRegistered(AuthorName Name);
+
+        [EventType]
+        public record AuthorRetired(AuthorName Name);
+
+        [Command]
+        [Roles("Librarian")]
+        public record RegisterAuthor(AuthorId Id, AuthorName Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+
+        [Command]
+        public record RetireAuthor(AuthorId Id, AuthorName Name)
+        {
+            public AuthorRetired Handle() => new(Name);
+        }
+
+        [ReadModel]
+        [FromEvent<AuthorRegistered>]
+        public record Author
+        {
+            [SetFrom<AuthorRegistered>("name")]
+            public AuthorName Name { get; init; } = new(string.Empty);
+
+            public static IEnumerable<Author> AllAuthors() => [];
+        }
+        """;
+
+    string _first;
+    string _second;
+
+    void Because()
+    {
+        _first = Describe(Analyzed.Source(Source));
+        _second = Describe(Analyzed.Source(Source));
+    }
+
+    static string Describe(ApplicationModelAnalysis analysis) =>
+        string.Join('\n', [.. Lines(analysis)]);
+
+    static IEnumerable<string> Lines(ApplicationModelAnalysis analysis)
+    {
+        yield return string.Join(',', analysis.Model.Concepts.Select(_ => $"{_.Name}:{_.Primitive}"));
+        yield return string.Join(',', analysis.Model.Policies.Select(_ => _.Name));
+
+        foreach (var slice in analysis.Model.Slices)
+        {
+            yield return $"{slice.Namespace}/{slice.Name}/{slice.Kind}";
+            yield return string.Join(',', slice.Commands.Select(_ => $"{_.Name}({string.Join('|', _.Properties.Select(p => p.Name))})"));
+            yield return string.Join(',', slice.Commands.SelectMany(_ => _.Produces).Select(_ => _.EventName));
+            yield return string.Join(',', slice.Events.Select(_ => $"{_.Name}[{string.Join('|', _.Tags)}]"));
+            yield return string.Join(',', slice.Queries.Select(_ => _.Name));
+            yield return string.Join(',', slice.Projection?.Scope.From.SelectMany(_ => _.EventTypes) ?? []);
+        }
+
+        yield return string.Join(',', analysis.Diagnostics.Select(_ => _.Code));
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_the_same_model_both_times() => _second.ShouldEqual(_first);
+    [Fact] void should_have_recovered_something_to_compare() => _first.ShouldNotBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/two_concepts_sharing_a_simple_name.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/two_concepts_sharing_a_simple_name.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A concept is declared once at the top of the document and referred to by its simple name, so two types in two
+/// namespaces sharing that name cannot both be described. Keeping the first is the only choice left - but the second
+/// one is then quietly described as something it is not, which is the one outcome a reader cannot detect.
+/// </summary>
+public class two_concepts_sharing_a_simple_name : Specification
+{
+    const string InOneSlice = """
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration;
+
+        public record Identifier(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        public record AuthorRegistered(Identifier Id);
+        """;
+
+    const string InAnother = """
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Lending.Reserving;
+
+        public record Identifier(int Value) : ConceptAs<int>(Value);
+
+        [EventType]
+        public record BookReserved(Identifier Id);
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", InOneSlice),
+        ("Library/Lending/Reserving/Reserving.cs", InAnother)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_declare_the_name_once() => _analysis.Model.Concepts.Count(_ => _.Name == "Identifier").ShouldEqual(1);
+    [Fact] void should_report_the_one_it_could_not_describe() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.AmbiguousConceptName);
+    [Fact] void should_name_the_type_it_could_not_describe() => _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.AmbiguousConceptName).Message.ShouldContain("Library.Lending.Reserving.Identifier");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/user_interface_files_claiming_one_screen_name.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/user_interface_files_claiming_one_screen_name.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A name is what one screen is told apart from another by, and what <c>navigate to</c> refers to, so a slice
+/// declaring the same one twice means it differently in two places. The first is kept and the rest are reported,
+/// because a document that says one thing is better than one that says two and settles neither.
+/// </summary>
+public class user_interface_files_claiming_one_screen_name : Specification
+{
+    const string Events = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+        """;
+
+    const string Commands = """
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Authors.Registration;
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Api/Authors/Registration/Commands.cs", Commands),
+        ("Library/Domain/Authors/Registration/Events.cs", Events)
+    ];
+
+    static readonly DeclaredUserInterfaceFiles _files = new(
+        "Library/Domain/Authors/Registration/AddAuthor.tsx",
+        "Library/Api/Authors/Registration/AddAuthor.tsx");
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ScreenModel> _screens;
+    ScreenplayDiagnostic _repeated;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_files, _sources);
+        _screens = _analysis.Slice().Screens;
+        _repeated = _analysis.Diagnostics.Single(_ => _.Severity == ScreenplayDiagnosticSeverity.Warning);
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_declare_the_screen_once() => _screens.Count().ShouldEqual(1);
+    [Fact] void should_keep_the_first_file_it_read() => _screens.Single().FilePath.ShouldEqual("Api/Authors/Registration/AddAuthor.tsx");
+    [Fact] void should_report_the_file_it_left_out() => _repeated.Code.ShouldEqual(ScreenplayDiagnosticCodes.AmbiguousScreenFile);
+    [Fact] void should_name_the_file_it_left_out() => _repeated.Message.Contains("Domain/Authors/Registration/AddAuthor.tsx", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_locate_the_report_at_the_slice() => _repeated.Location.ShouldEqual("Library.Authors.Registration");
+}

--- a/Source/DotNET/Screenplay.Specs/for_AuthorizeSyntaxBuilder/when_building/what_a_command_requires_of_the_caller.cs
+++ b/Source/DotNET/Screenplay.Specs/for_AuthorizeSyntaxBuilder/when_building/what_a_command_requires_of_the_caller.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Policies;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_AuthorizeSyntaxBuilder.when_building;
+
+/// <summary>
+/// Roles are alternatives to each other while a named policy is an additional demand, and the well known
+/// authenticated policy stands in only when nothing else was asked for. Adding it alongside a role would quietly
+/// turn "any librarian" into "any librarian who is also authenticated by name", which is a different rule.
+/// </summary>
+public class what_a_command_requires_of_the_caller : Specification
+{
+    AuthorizeSyntaxBuilder _builder;
+    AuthorizeSyntax? _withRoles;
+    AuthorizeSyntax? _withNothingNamed;
+    AuthorizeSyntax? _withNothingRequired;
+
+    void Establish() => _builder = new();
+
+    void Because()
+    {
+        _withRoles = _builder.Build(new AuthorizationModel(true, ["Librarian", "Archivist"]));
+        _withNothingNamed = _builder.Build(new AuthorizationModel(true, []));
+        _withNothingRequired = _builder.Build(null);
+    }
+
+    [Fact] void should_reference_every_role_it_was_given() => _withRoles!.Policies.Select(_ => _.Name).ShouldEqual(["Archivist", "Librarian"]);
+    [Fact] void should_offer_the_roles_as_alternatives() => _withRoles!.Policies.Select(_ => _.IsAlternative).ShouldEqual([false, true]);
+    [Fact] void should_not_add_authentication_alongside_a_role() => _withRoles!.Policies.Select(_ => _.Name).ShouldNotContain(AuthorizeSyntaxBuilder.AuthenticatedPolicy);
+    [Fact] void should_stand_in_with_authentication_when_nothing_was_named() => _withNothingNamed!.Policies.Select(_ => _.Name).ShouldEqual([AuthorizeSyntaxBuilder.AuthenticatedPolicy]);
+    [Fact] void should_build_nothing_when_nothing_is_required() => _withNothingRequired.ShouldBeNull();
+    [Fact] void should_record_every_policy_the_document_has_to_declare() => _builder.Referenced.ShouldContainOnly(["Archivist", "Librarian", AuthorizeSyntaxBuilder.AuthenticatedPolicy]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/given/a_command_syntax_builder.cs
+++ b/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/given/a_command_syntax_builder.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Commands;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Policies;
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Emission.Validation;
+
+namespace Cratis.Arc.Screenplay.for_CommandSyntaxBuilder.given;
+
+public class a_command_syntax_builder : Specification
+{
+    protected CommandSyntaxBuilder _builder;
+    protected ScreenplayDiagnostics _diagnostics;
+
+    void Establish()
+    {
+        var naming = new ScreenplayNaming();
+        _diagnostics = new();
+        var names = new NameAvailability(naming, _diagnostics);
+        _builder = new(
+            naming,
+            new TypeReferenceConverter(naming),
+            new AuthorizeSyntaxBuilder(),
+            new ValidationSyntaxBuilder(naming, _diagnostics),
+            new ProducesSyntaxBuilder(naming, names),
+            new ConcurrencySyntaxBuilder(naming, _diagnostics),
+            names);
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/when_building/a_command_with_a_property_called_description.cs
+++ b/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/when_building/a_command_with_a_property_called_description.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_CommandSyntaxBuilder.when_building;
+
+/// <summary>
+/// A command body reads the first word of every line to decide what the line is, so a property called
+/// <c>Description</c> is written as <c>description RequestDescription</c> and read as the description of the command
+/// - which is a document that does not compile. The language offers nothing to escape the name with, so the property
+/// is left out and the loss is reported.
+/// </summary>
+public class a_command_with_a_property_called_description : given.a_command_syntax_builder
+{
+    CommandSyntax _result;
+
+    void Because() => _result = _builder.Build(
+        new CommandModel(
+            "RequestBook",
+            null,
+            [
+                Declare.Property("Title", "BookTitle"),
+                Declare.Property("Description", "RequestDescription")
+            ],
+            null,
+            [],
+            [],
+            null,
+            "Lending/Requesting/Requesting.cs"),
+        "Library.Lending.Requesting");
+
+    [Fact] void should_leave_the_property_out() => _result.Properties.Select(_ => _.Name).ShouldNotContain("description");
+    [Fact] void should_keep_the_properties_it_can_write() => _result.Properties.Select(_ => _.Name).ShouldContainOnly(["title"]);
+    [Fact] void should_report_the_property() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.NameReservedByGrammar]);
+    [Fact] void should_report_it_as_a_warning() => _diagnostics.All.Single().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Warning);
+    [Fact] void should_locate_the_report_where_the_command_lives() => _diagnostics.All.Single().Location.ShouldEqual("Library.Lending.Requesting");
+    [Fact] void should_name_the_property_in_the_report() => _diagnostics.All.Single().Message.Contains("'Description'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_name_the_declaring_type_in_the_report() => _diagnostics.All.Single().Message.Contains("'RequestBook'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_name_the_block_reserving_it_in_the_report() => _diagnostics.All.Single().Message.Contains("command block", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/when_building/a_command_with_a_property_for_every_word_the_body_reserves.cs
+++ b/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/when_building/a_command_with_a_property_for_every_word_the_body_reserves.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_CommandSyntaxBuilder.when_building;
+
+/// <summary>
+/// Every word a command body dispatches on takes a property with it. Two of them are worse than a compile error:
+/// <c>authorize</c> is read as a reference to a policy and <c>produces</c> as a reference to an event, so a document
+/// keeping them says something the application never said and warns about the invention rather than the loss.
+/// </summary>
+public class a_command_with_a_property_for_every_word_the_body_reserves : given.a_command_syntax_builder
+{
+    CommandSyntax _result;
+
+    void Because() => _result = _builder.Build(
+        new CommandModel(
+            "RequestBook",
+            null,
+            [
+                Declare.Property("Authorize", "AuthorizationToken"),
+                Declare.Property("Concurrency", "ConcurrencyToken"),
+                Declare.Property("Description", "RequestDescription"),
+                Declare.Property("Handler", "HandlerName"),
+                Declare.Property("Produces", "ProductionKind"),
+                Declare.Property("Validate", "ValidationMode"),
+                Declare.Property("Title", "BookTitle")
+            ],
+            null,
+            [],
+            [],
+            null,
+            "Lending/Requesting/Requesting.cs"),
+        "Library.Lending.Requesting");
+
+    [Fact] void should_keep_only_the_property_no_directive_answers_to() => _result.Properties.Select(_ => _.Name).ShouldContainOnly(["title"]);
+    [Fact] void should_report_every_property_it_left_out() => _diagnostics.All.Count.ShouldEqual(6);
+    [Fact] void should_report_them_all_under_the_same_code() => _diagnostics.All.Select(_ => _.Code).Distinct().ShouldContainOnly([ScreenplayDiagnosticCodes.NameReservedByGrammar]);
+    [Fact] void should_name_every_property_it_left_out() => _diagnostics.All.Count(_ => _.Message.Contains("'Validate'", StringComparison.Ordinal)).ShouldEqual(1);
+}

--- a/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/when_building/a_command_with_properties_no_directive_answers_to.cs
+++ b/Source/DotNET/Screenplay.Specs/for_CommandSyntaxBuilder/when_building/a_command_with_properties_no_directive_answers_to.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_CommandSyntaxBuilder.when_building;
+
+/// <summary>
+/// Only the words a command body actually dispatches on cost a property, so a name that merely reads like a keyword
+/// elsewhere in the language - <c>tag</c> belongs to an event body, <c>key</c> to a projection - stays exactly where
+/// it is. Leaving those out would drop members the document can perfectly well describe.
+/// </summary>
+public class a_command_with_properties_no_directive_answers_to : given.a_command_syntax_builder
+{
+    CommandSyntax _result;
+
+    void Because() => _result = _builder.Build(
+        new CommandModel(
+            "RequestBook",
+            null,
+            [
+                Declare.Property("Title", "BookTitle"),
+                Declare.Property("Tag", "RequestTag"),
+                Declare.Property("Key", "RequestKey"),
+                Declare.Property("Parent", "RequestId"),
+                Declare.Property("Events", "EventKind")
+            ],
+            null,
+            [],
+            [],
+            null,
+            "Lending/Requesting/Requesting.cs"),
+        "Library.Lending.Requesting");
+
+    [Fact] void should_keep_every_property() => _result.Properties.Select(_ => _.Name).ShouldContainOnly(["title", "tag", "key", "parent", "events"]);
+    [Fact] void should_report_nothing() => _diagnostics.All.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/given/a_concept_syntax_builder.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/given/a_concept_syntax_builder.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Concepts;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Validation;
+
+namespace Cratis.Arc.Screenplay.for_ConceptSyntaxBuilder.given;
+
+public class a_concept_syntax_builder : Specification
+{
+    protected ConceptSyntaxBuilder _builder;
+    protected ScreenplayDiagnostics _diagnostics;
+
+    void Establish()
+    {
+        var naming = new ScreenplayNaming();
+        _diagnostics = new();
+        _builder = new(naming, new ValidationSyntaxBuilder(naming, _diagnostics), _diagnostics);
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/given/a_concept_syntax_builder.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/given/a_concept_syntax_builder.cs
@@ -16,6 +16,6 @@ public class a_concept_syntax_builder : Specification
     {
         var naming = new ScreenplayNaming();
         _diagnostics = new();
-        _builder = new(naming, new ValidationSyntaxBuilder(naming, _diagnostics), _diagnostics);
+        _builder = new(naming, new ValidationSyntaxBuilder(naming, _diagnostics), _diagnostics, new NameAvailability(naming, _diagnostics));
     }
 }

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/a_concept_carrying_personal_data.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/a_concept_carrying_personal_data.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Concepts;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ConceptSyntaxBuilder.when_building;
+
+/// <summary>
+/// The attribute is inherited by every property typed with the concept, so declaring it once at the top of the
+/// document is what makes erasure rules readable at a glance.
+/// </summary>
+public class a_concept_carrying_personal_data : given.a_concept_syntax_builder
+{
+    ConceptSyntax _marked;
+    ConceptSyntax _unmarked;
+
+    void Because()
+    {
+        var concepts = _builder.Build(
+        [
+            new ConceptModel("AuthorName", ScreenplayPrimitive.String, true, [], []),
+            new ConceptModel("BookTitle", ScreenplayPrimitive.String, false, [], [])
+        ]).ToList();
+
+        _marked = concepts.First(_ => _.Name == "AuthorName");
+        _unmarked = concepts.First(_ => _.Name == "BookTitle");
+    }
+
+    [Fact] void should_mark_the_concept_carrying_personal_data() => _marked.Attributes.ShouldContainOnly([ConceptSyntaxBuilder.PersonallyIdentifiableInformation]);
+    [Fact] void should_not_mark_a_concept_that_carries_none() => _unmarked.Attributes.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/an_enumeration.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/an_enumeration.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ConceptSyntaxBuilder.when_building;
+
+/// <summary>
+/// Enumeration values have to match <c>^[a-z_]\w*$</c>, so declared PascalCase members have to be lower camelled.
+/// </summary>
+public class an_enumeration : given.a_concept_syntax_builder
+{
+    ConceptSyntax _result;
+
+    void Because() => _result = _builder
+        .Build([new ConceptModel("MembershipTier", ScreenplayPrimitive.Enum, false, ["Standard", "Premium"], [])])
+        .Single();
+
+    [Fact] void should_declare_it_as_an_enum() => _result.IsEnum.ShouldBeTrue();
+    [Fact] void should_lower_camel_every_value() => _result.Values.ShouldEqual(["standard", "premium"]);
+    [Fact] void should_report_nothing() => _diagnostics.All.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/an_enumeration_with_a_value_called_validate.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/an_enumeration_with_a_value_called_validate.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ConceptSyntaxBuilder.when_building;
+
+/// <summary>
+/// A concept body dispatches on <c>validate</c>, so an enumeration value called <c>Validate</c> is written on a line
+/// of its own and read as the opening of an empty validate block. Nothing about that fails to compile, which is what
+/// makes it worth reporting - the value disappears from the document without a word otherwise.
+/// </summary>
+public class an_enumeration_with_a_value_called_validate : given.a_concept_syntax_builder
+{
+    IEnumerable<ConceptSyntax> _result;
+
+    void Because() => _result = _builder.Build(
+        [new ConceptModel("RequestState", ScreenplayPrimitive.Enum, false, ["Pending", "Validate", "Approved"], [])]);
+
+    [Fact] void should_leave_the_value_out() => _result.Single().Values.ShouldContainOnly(["pending", "approved"]);
+    [Fact] void should_report_the_value() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.NameReservedByGrammar]);
+    [Fact] void should_locate_the_report_at_the_concept() => _diagnostics.All.Single().Location.ShouldEqual("RequestState");
+    [Fact] void should_name_the_value_in_the_report() => _diagnostics.All.Single().Message.Contains("'Validate'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_name_the_block_reserving_it_in_the_report() => _diagnostics.All.Single().Message.Contains("concept block", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/an_enumeration_without_values.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/an_enumeration_without_values.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ConceptSyntaxBuilder.when_building;
+
+/// <summary>
+/// An enumeration declaration whose body is empty says nothing and does not compile, so it is left out - visibly.
+/// </summary>
+public class an_enumeration_without_values : given.a_concept_syntax_builder
+{
+    IEnumerable<ConceptSyntax> _result;
+
+    void Because() => _result = _builder.Build([new ConceptModel("MembershipTier", ScreenplayPrimitive.Enum, false, [], [])]);
+
+    [Fact] void should_declare_nothing() => _result.ShouldBeEmpty();
+    [Fact] void should_report_the_concept() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.EnumWithoutValues]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ConcurrencySyntaxBuilder/when_building/a_scope_narrowing_nothing.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConcurrencySyntaxBuilder/when_building/a_scope_narrowing_nothing.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Commands;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ConcurrencySyntaxBuilder.when_building;
+
+/// <summary>
+/// A concurrency block that narrows nothing at all is a compile error, so it has to be left out rather than emitted
+/// empty - and left out visibly, since a command that silently loses its concurrency scope reads as if it never had
+/// one.
+/// </summary>
+public class a_scope_narrowing_nothing : Specification
+{
+    ScreenplayDiagnostics _diagnostics;
+    ConcurrencySyntaxBuilder _builder;
+    ConcurrencySyntax? _result;
+
+    void Establish()
+    {
+        _diagnostics = new();
+        _builder = new(new ScreenplayNaming(), _diagnostics);
+    }
+
+    void Because() => _result = _builder.Build(new ConcurrencyModel(false, null, null, null, []), "Library.Inventory.Adding");
+
+    [Fact] void should_emit_no_block() => _result.ShouldBeNull();
+    [Fact] void should_report_the_scope() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.EmptyConcurrencyScope]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ConcurrencySyntaxBuilder/when_building/a_scope_narrowing_the_stream.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConcurrencySyntaxBuilder/when_building/a_scope_narrowing_the_stream.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Commands;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ConcurrencySyntaxBuilder.when_building;
+
+public class a_scope_narrowing_the_stream : Specification
+{
+    ScreenplayDiagnostics _diagnostics;
+    ConcurrencySyntaxBuilder _builder;
+    ConcurrencySyntax? _result;
+
+    void Establish()
+    {
+        _diagnostics = new();
+        _builder = new(new ScreenplayNaming(), _diagnostics);
+    }
+
+    void Because() => _result = _builder.Build(
+        new ConcurrencyModel(true, "Author", "Inventory", "Primary", ["BookAddedToInventory"]),
+        "Library.Inventory.Adding");
+
+    [Fact] void should_include_the_event_source() => _result!.EventSource.ShouldBeTrue();
+    [Fact] void should_carry_the_source_type() => _result!.EventSourceType.ShouldEqual("Author");
+    [Fact] void should_carry_the_stream_type() => _result!.EventStreamType.ShouldEqual("Inventory");
+    [Fact] void should_carry_the_stream_id() => _result!.EventStreamId.ShouldEqual("Primary");
+    [Fact] void should_carry_the_event_types() => _result!.EventTypes.ShouldContainOnly(["BookAddedToInventory"]);
+    [Fact] void should_report_nothing() => _diagnostics.All.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_EventSyntaxBuilder/given/an_event_syntax_builder.cs
+++ b/Source/DotNET/Screenplay.Specs/for_EventSyntaxBuilder/given/an_event_syntax_builder.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Events;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Types;
+
+namespace Cratis.Arc.Screenplay.for_EventSyntaxBuilder.given;
+
+public class an_event_syntax_builder : Specification
+{
+    protected EventSyntaxBuilder _builder;
+    protected ScreenplayDiagnostics _diagnostics;
+
+    void Establish()
+    {
+        var naming = new ScreenplayNaming();
+        _diagnostics = new();
+        _builder = new(naming, new TypeReferenceConverter(naming), new NameAvailability(naming, _diagnostics));
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_EventSyntaxBuilder/when_building/an_event_with_a_property_called_tag.cs
+++ b/Source/DotNET/Screenplay.Specs/for_EventSyntaxBuilder/when_building/an_event_with_a_property_called_tag.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_EventSyntaxBuilder.when_building;
+
+/// <summary>
+/// An event body dispatches on <c>tag</c>, so a property called <c>Tag</c> is written as <c>tag BookTag</c> and read
+/// as a tag on the event. That is worse than a compile error - a tag naming a type is accepted, so the property
+/// disappears and a tag the application never declared appears in its place, silently.
+/// </summary>
+public class an_event_with_a_property_called_tag : given.an_event_syntax_builder
+{
+    EventSyntax _result;
+
+    void Because() => _result = _builder.Build(
+        new EventModel(
+            "BookRequested",
+            [
+                Declare.Property("Title", "BookTitle"),
+                Declare.Property("Tag", "BookTag")
+            ],
+            ["audit"]),
+        "Library.Lending.Requesting");
+
+    [Fact] void should_leave_the_property_out() => _result.Properties.Select(_ => _.Name).ShouldContainOnly(["title"]);
+    [Fact] void should_not_turn_the_property_into_a_tag() => _result.Tags!.Count().ShouldEqual(1);
+    [Fact] void should_report_the_property() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.NameReservedByGrammar]);
+    [Fact] void should_locate_the_report_where_the_event_lives() => _diagnostics.All.Single().Location.ShouldEqual("Library.Lending.Requesting");
+    [Fact] void should_name_the_property_in_the_report() => _diagnostics.All.Single().Message.Contains("'Tag'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_name_the_declaring_type_in_the_report() => _diagnostics.All.Single().Message.Contains("'BookRequested'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_name_the_block_reserving_it_in_the_report() => _diagnostics.All.Single().Message.Contains("event block", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_member_of_an_enumeration.cs
+++ b/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_member_of_an_enumeration.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Expressions;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_LiteralConverter;
+
+/// <summary>
+/// A concept declares the members of an enumeration in lower camel case and every reference to one is a string
+/// matching a declared member exactly. The member therefore goes through the same name conversion the declaration
+/// was written with, rather than the number behind it being written as a number nothing declares.
+/// </summary>
+public class when_converting_a_member_of_an_enumeration : Specification
+{
+    readonly ScreenplayNaming _naming = new();
+    LiteralExpressionSyntax _member;
+    LiteralExpressionSyntax _acronym;
+    LiteralExpressionSyntax _number;
+
+    void Because()
+    {
+        _member = LiteralConverter.Convert(new EnumValue("ClientContact"), _naming);
+        _acronym = LiteralConverter.Convert(new EnumValue("ISBNOnly"), _naming);
+        _number = LiteralConverter.Convert(6, _naming);
+    }
+
+    [Fact] void should_write_the_member_in_the_casing_the_concept_declares_it() => _member.Value.ShouldEqual("clientContact");
+    [Fact] void should_write_the_member_as_a_string() => _member.Value.ShouldBeOfExactType<string>();
+    [Fact] void should_convert_an_acronym_the_way_the_declaration_does() => _acronym.Value.ShouldEqual("isbnOnly");
+    [Fact] void should_leave_a_number_that_belongs_to_no_enumeration_as_a_number() => _number.Value.ShouldBeOfExactType<double>();
+    [Fact] void should_not_treat_a_member_as_a_number() => LiteralConverter.IsNumeric(new EnumValue("ClientContact")).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_number.cs
+++ b/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_number.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Arc.Screenplay.Emission.Expressions;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Printing;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_LiteralConverter;
+
+/// <summary>
+/// The printer formats anything that is not a double with the current culture, which emits a comma as the decimal
+/// separator on most of the world's machines and produces a document that no longer parses. Everything numeric has
+/// to reach the printer as a double.
+/// </summary>
+public class when_converting_a_number : Specification
+{
+    readonly ScreenplayNaming _naming = new();
+    CultureInfo _original;
+    LiteralExpressionSyntax _fromDecimal;
+    LiteralExpressionSyntax _fromInt;
+    LiteralExpressionSyntax _fromFloat;
+    string _printed;
+
+    void Establish()
+    {
+        _original = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("nb-NO");
+    }
+
+    void Because()
+    {
+        _fromDecimal = LiteralConverter.Convert(5.5m, _naming);
+        _fromInt = LiteralConverter.Convert(42, _naming);
+        _fromFloat = LiteralConverter.Convert(1.25f, _naming);
+        _printed = Print(_fromDecimal);
+    }
+
+    void Destroy() => CultureInfo.CurrentCulture = _original;
+
+    [Fact] void should_convert_a_decimal_to_a_double() => _fromDecimal.Value.ShouldBeOfExactType<double>();
+    [Fact] void should_convert_an_int_to_a_double() => _fromInt.Value.ShouldBeOfExactType<double>();
+    [Fact] void should_convert_a_float_to_a_double() => _fromFloat.Value.ShouldBeOfExactType<double>();
+    [Fact] void should_print_a_fraction_with_an_invariant_separator() => _printed.Contains("5.5", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_not_print_a_fraction_with_the_current_culture_separator() => _printed.Contains("5,5", StringComparison.Ordinal).ShouldBeFalse();
+
+    static string Print(ExpressionSyntax value)
+    {
+        var slice = new SliceSyntax(
+            SliceType.StateChange,
+            "Reserving",
+            [],
+            [
+                new CommandSyntax(
+                    "ReserveBook",
+                    [],
+                    null,
+                    [],
+                    [new ProducesSyntax("BookReserved", null, [new PropertyMappingSyntax("total", value, SourceLocation.Start)], SourceLocation.Start)],
+                    null,
+                    SourceLocation.Start)
+            ],
+            [],
+            null,
+            [],
+            [],
+            [],
+            [],
+            [],
+            SourceLocation.Start);
+
+        var module = new ModuleSyntax("Library", [], [new FeatureSyntax("Lending", [], [slice], SourceLocation.Start)], SourceLocation.Start);
+
+        return new ScreenplayPrinter().Print(new ApplicationSyntax([], [], [], [module], SourceLocation.Start));
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_string.cs
+++ b/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_string.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Expressions;
+using Cratis.Arc.Screenplay.Emission.Naming;
+
+namespace Cratis.Arc.Screenplay.for_LiteralConverter;
+
+/// <summary>
+/// The printer never escapes a string literal, so a quote reaching it produces output that cannot be parsed back.
+/// </summary>
+public class when_converting_a_string : Specification
+{
+    readonly ScreenplayNaming _naming = new();
+
+    [Fact] void should_neutralize_a_quote() => LiteralConverter.Convert(@"He said ""hi""", _naming).Value.ShouldEqual("He said 'hi'");
+    [Fact] void should_keep_a_bool_as_a_bool() => LiteralConverter.Convert(true, _naming).Value.ShouldEqual(true);
+    [Fact] void should_keep_nothing_as_nothing() => LiteralConverter.Convert(null, _naming).Value.ShouldBeNull();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ProducesSyntaxBuilder/when_building/a_block_mapping_onto_a_property_called_tag.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ProducesSyntaxBuilder/when_building/a_block_mapping_onto_a_property_called_tag.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Commands;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ProducesSyntaxBuilder.when_building;
+
+/// <summary>
+/// A produces block fills in the properties of the event it produces, and dispatches on <c>tag</c> exactly as the
+/// event body does. A mapping onto a property called <c>Tag</c> is therefore written as <c>tag = tag</c> and read as
+/// a tag whose value is an assignment, which the compiler rejects outright.
+/// </summary>
+public class a_block_mapping_onto_a_property_called_tag : Specification
+{
+    ScreenplayDiagnostics _diagnostics;
+    ProducesSyntaxBuilder _builder;
+    IEnumerable<ProducesSyntax> _result;
+
+    void Establish()
+    {
+        var naming = new ScreenplayNaming();
+        _diagnostics = new();
+        _builder = new(naming, new NameAvailability(naming, _diagnostics));
+    }
+
+    void Because() => _result = _builder.Build(
+        [
+            new ProducesModel(
+                "BookRequested",
+                null,
+                [
+                    Declare.From("Title", "Title"),
+                    Declare.From("Tag", "Tag")
+                ])
+        ],
+        "Library.Lending.Requesting");
+
+    [Fact] void should_leave_the_mapping_out() => _result.Single().Mappings.Select(_ => _.Property).ShouldContainOnly(["title"]);
+    [Fact] void should_report_the_mapping() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.NameReservedByGrammar]);
+    [Fact] void should_locate_the_report_where_the_command_lives() => _diagnostics.All.Single().Location.ShouldEqual("Library.Lending.Requesting");
+    [Fact] void should_name_the_event_the_property_belongs_to() => _diagnostics.All.Single().Message.Contains("'BookRequested'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_name_the_block_reserving_it_in_the_report() => _diagnostics.All.Single().Message.Contains("produces block", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ProjectionKeyConverter/when_converting_a_composite_key.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ProjectionKeyConverter/when_converting_a_composite_key.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Projections;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.for_ProjectionKeyConverter;
+
+/// <summary>
+/// The key decides which read model instance an event maps onto, so losing it silently would misstate the model.
+/// Composite keys are written in two shapes and both have to be understood.
+/// </summary>
+public class when_converting_a_composite_key : Specification
+{
+    CompositeKeySyntax _withoutATypeName;
+    CompositeKeySyntax _withATypeName;
+    KeySyntax? _unconvertible;
+
+    void Because()
+    {
+        _withoutATypeName = (CompositeKeySyntax)ProjectionKeyConverter.Convert("$composite(CustomerId=customerId,OrderNumber=orderNumber)", "Order")!;
+        _withATypeName = (CompositeKeySyntax)ProjectionKeyConverter.Convert("$composite(OrderKey, CustomerId=customerId, OrderNumber=orderNumber)", "Order")!;
+        _unconvertible = ProjectionKeyConverter.Convert("$composite(CustomerId=$unknownExpression)", "Order");
+    }
+
+    [Fact] void should_read_every_part_of_the_shape_without_a_type_name() => _withoutATypeName.Parts.Select(_ => _.Property).ShouldContainOnly(["CustomerId", "OrderNumber"]);
+    [Fact] void should_fall_back_to_the_read_model_name_when_no_type_is_carried() => _withoutATypeName.Type.ShouldEqual("Order");
+    [Fact] void should_read_every_part_of_the_shape_with_a_type_name() => _withATypeName.Parts.Select(_ => _.Property).ShouldContainOnly(["CustomerId", "OrderNumber"]);
+    [Fact] void should_use_the_type_the_shape_carries() => _withATypeName.Type.ShouldEqual("OrderKey");
+    [Fact] void should_drop_a_composite_whose_part_cannot_be_expressed() => _unconvertible.ShouldBeNull();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ProjectionKeyConverter/when_converting_the_default_key.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ProjectionKeyConverter/when_converting_the_default_key.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Projections;
+
+namespace Cratis.Arc.Screenplay.for_ProjectionKeyConverter;
+
+/// <summary>
+/// The event source id is the implicit key of every block, so writing it out would add noise without adding meaning.
+/// A key that is merely the default has to be told apart from one that was lost, because only the latter is worth
+/// reporting.
+/// </summary>
+public class when_converting_the_default_key : Specification
+{
+    [Fact] void should_treat_the_event_source_id_as_the_default() => ProjectionKeyConverter.IsDefault("$eventSourceId").ShouldBeTrue();
+    [Fact] void should_treat_no_key_as_the_default() => ProjectionKeyConverter.IsDefault(null).ShouldBeTrue();
+    [Fact] void should_not_treat_an_unmappable_key_as_the_default() => ProjectionKeyConverter.IsDefault("$unknownExpression").ShouldBeFalse();
+    [Fact] void should_emit_no_key_for_the_event_source_id() => ProjectionKeyConverter.Convert("$eventSourceId", "Order").ShouldBeNull();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ProjectionSyntaxBuilder/when_building/a_from_block_mapping_onto_properties_it_reserves.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ProjectionSyntaxBuilder/when_building/a_from_block_mapping_onto_properties_it_reserves.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Projections;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.for_ProjectionSyntaxBuilder.when_building;
+
+/// <summary>
+/// A projection <c>from</c> block dispatches on <c>key</c> and <c>parent</c>, so an assignment onto a read model
+/// property of either name is read as that directive and rejected. Only a plain assignment leads with the property
+/// though - <c>increment</c>, <c>count</c> and their kind lead with the operation - so those stay whatever they fill
+/// in, and a block that leads with the operation costs the read model nothing.
+/// </summary>
+public class a_from_block_mapping_onto_properties_it_reserves : Specification
+{
+    ScreenplayDiagnostics _diagnostics;
+    ProjectionSyntaxBuilder _builder;
+    ProjectionSyntax? _result;
+
+    void Establish()
+    {
+        var naming = new ScreenplayNaming();
+        _diagnostics = new();
+        _builder = new(naming, _diagnostics, new NameAvailability(naming, _diagnostics));
+    }
+
+    void Because() => _result = _builder.Build(
+        new ProjectionModel(
+            "Library.Lending.Listing.RequestProjection",
+            "Request",
+            "event-log",
+            ProjectionAutoMapMode.Enabled,
+            false,
+            ProjectionScopeModel.Empty with
+            {
+                From =
+                [
+                    new(
+                        ["BookRequested"],
+                        "$eventSourceId",
+                        null,
+                        Declare.Map(
+                            ("title", "title"),
+                            ("key", "requestKey"),
+                            ("parent", "parentId"),
+                            ("count", ProjectionMappingConverter.Increment)))
+                ]
+            }),
+        "Library.Lending.Listing");
+
+    IEnumerable<string> Filled => _result!.Blocks.OfType<FromSyntax>().Single().Mappings.Select(_ => _.Property);
+
+    [Fact] void should_leave_out_the_assignments_the_block_reserves() => Filled.ShouldContainOnly(["count", "title"]);
+    [Fact] void should_keep_a_mapping_leading_with_its_operation() => _result!.Blocks.OfType<FromSyntax>().Single().Mappings.OfType<IncrementMappingSyntax>().Single().Property.ShouldEqual("count");
+    [Fact] void should_report_both_properties() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.NameReservedByGrammar, ScreenplayDiagnosticCodes.NameReservedByGrammar]);
+    [Fact] void should_locate_the_reports_where_the_projection_lives() => _diagnostics.All.Select(_ => _.Location).Distinct().ShouldContainOnly(["Library.Lending.Listing"]);
+    [Fact] void should_name_the_read_model_in_the_reports() => _diagnostics.All.Count(_ => _.Message.Contains("'Request'", StringComparison.Ordinal)).ShouldEqual(2);
+    [Fact] void should_name_the_block_reserving_them_in_the_reports() => _diagnostics.All.Count(_ => _.Message.Contains("from block", StringComparison.Ordinal)).ShouldEqual(2);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_observing_nothing.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_observing_nothing.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Reactors;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ReactorSyntaxBuilder.when_building;
+
+/// <summary>
+/// A reactor declaration with no triggers has an empty body and does not compile.
+/// </summary>
+public class a_reactor_observing_nothing : Specification
+{
+    ScreenplayDiagnostics _diagnostics;
+    ReactorSyntaxBuilder _builder;
+    ReactorSyntax? _result;
+
+    void Establish()
+    {
+        _diagnostics = new();
+        _builder = new(new ScreenplayNaming(), _diagnostics);
+    }
+
+    void Because() => _result = _builder.Build(
+        new ReactorModel("ReservationNotifier", [], false, null),
+        "Library.Lending.Notifications");
+
+    [Fact] void should_emit_no_declaration() => _result.ShouldBeNull();
+    [Fact] void should_report_the_reactor() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.ReactorWithoutEvents]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_without_a_source_file.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_without_a_source_file.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Reactors;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ReactorSyntaxBuilder.when_building;
+
+/// <summary>
+/// An artifact living in a referenced package has metadata but no source, so no path can be read off a syntax tree.
+/// A trigger with neither a file nor an inline body has an empty body and does not compile, so the vertical slice
+/// convention is used to point somewhere rather than nowhere.
+/// </summary>
+public class a_reactor_without_a_source_file : Specification
+{
+    ScreenplayDiagnostics _diagnostics;
+    ReactorSyntaxBuilder _builder;
+    ReactorSyntax? _result;
+
+    void Establish()
+    {
+        _diagnostics = new();
+        _builder = new(new ScreenplayNaming(), _diagnostics);
+    }
+
+    void Because() => _result = _builder.Build(
+        new ReactorModel("RestockRequester", ["BookReserved"], true, null),
+        "Library.Lending.Restocking");
+
+    [Fact] void should_point_at_the_conventional_path() => _result!.Triggers.Single().File!.Path.ShouldEqual("Lending/Restocking/RestockRequester.cs");
+    [Fact] void should_observe_the_event() => _result!.Triggers.Single().Event.ShouldEqual("BookReserved");
+    [Fact] void should_report_nothing() => _diagnostics.All.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/given/a_screen_syntax_builder.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/given/a_screen_syntax_builder.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Arc.Screenplay.Emission.Naming;
 using Cratis.Arc.Screenplay.Emission.Screens;
+using Cratis.Arc.Screenplay.Emission.Types;
 
 namespace Cratis.Arc.Screenplay.for_ScreenSyntaxBuilder.given;
 
@@ -10,5 +11,10 @@ public class a_screen_syntax_builder : Specification
 {
     protected ScreenSyntaxBuilder _builder;
 
-    void Establish() => _builder = new(new ScreenplayNaming());
+    void Establish()
+    {
+        var naming = new ScreenplayNaming();
+
+        _builder = new(naming, new TypeReferenceConverter(naming));
+    }
 }

--- a/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/given/a_screen_syntax_builder.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/given/a_screen_syntax_builder.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Screens;
+
+namespace Cratis.Arc.Screenplay.for_ScreenSyntaxBuilder.given;
+
+public class a_screen_syntax_builder : Specification
+{
+    protected ScreenSyntaxBuilder _builder;
+
+    void Establish() => _builder = new(new ScreenplayNaming());
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/when_building/a_screen_bound_to_queries.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/when_building/a_screen_bound_to_queries.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ScreenSyntaxBuilder.when_building;
+
+/// <summary>
+/// A screen carries its bindings and its file together - the grammar allows both, the bindings state what the screen
+/// reads, and the file stays the pointer to the implementation no directive replaces. The optional marker is the one
+/// thing that has to go: a data directive has no room for it, and a document carrying one does not compile.
+/// </summary>
+public class a_screen_bound_to_queries : given.a_screen_syntax_builder
+{
+    ScreenSyntax _screen;
+
+    void Because() => _screen = _builder.Build(
+        new ScreenModel("AuthorList", "Authors/Listing/AuthorList.tsx")
+        {
+            Data =
+            [
+                new("AuthorById", new TypeReferenceModel("Author", false, true), "Id"),
+                new("AllAuthors", new TypeReferenceModel("Author", true, false), null)
+            ]
+        },
+        "Library.Authors.Listing");
+
+    ScreenDataSyntax Binding(int index) => _screen.Directives.OfType<ScreenDataSyntax>().ElementAt(index);
+
+    [Fact] void should_refer_to_the_file_realizing_it() => _screen.File!.Path.ShouldEqual("Authors/Listing/AuthorList.tsx");
+    [Fact] void should_write_a_directive_per_binding() => _screen.Directives.Count().ShouldEqual(2);
+    [Fact] void should_order_the_bindings_by_query() => _screen.Directives.OfType<ScreenDataSyntax>().Select(_ => _.Query).ShouldEqual(["AllAuthors", "AuthorById"]);
+    [Fact] void should_keep_a_collection_a_collection() => Binding(0).Type.IsCollection.ShouldBeTrue();
+    [Fact] void should_state_no_key_for_a_query_requiring_none() => Binding(0).By.ShouldBeNull();
+    [Fact] void should_camel_case_the_key_a_binding_is_read_by() => Binding(1).By.ShouldEqual("id");
+    [Fact] void should_drop_the_optional_marker_a_data_directive_cannot_carry() => Binding(1).Type.IsOptional.ShouldBeFalse();
+    [Fact] void should_keep_naming_the_type_the_query_returns() => Binding(1).Type.Name.ShouldEqual("Author");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/when_building/a_screen_realized_by_a_file.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/when_building/a_screen_realized_by_a_file.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ScreenSyntaxBuilder.when_building;
+
+/// <summary>
+/// A screen is written in its <c>file</c> form and never in its declarative one, because what a screen shows and
+/// does is written in TypeScript and nothing in a compilation says it.
+/// </summary>
+public class a_screen_realized_by_a_file : given.a_screen_syntax_builder
+{
+    ScreenSyntax _screen;
+
+    void Because() => _screen = _builder.Build(
+        new ScreenModel("Add-Author", "Authors/Registration/Add-Author.tsx"),
+        "Library.Authors.Registration");
+
+    [Fact] void should_name_the_screen_after_the_file() => _screen.Name.ShouldEqual("AddAuthor");
+    [Fact] void should_refer_to_the_file() => _screen.File!.Path.ShouldEqual("Authors/Registration/Add-Author.tsx");
+    [Fact] void should_state_nothing_about_what_the_screen_shows() => _screen.Directives.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/when_building/a_screen_without_a_file.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenSyntaxBuilder/when_building/a_screen_without_a_file.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ScreenSyntaxBuilder.when_building;
+
+/// <summary>
+/// A screen with neither a file nor a directive has an empty body and does not compile, so a path is always
+/// resolved - falling back to where the vertical slice convention would put the file.
+/// </summary>
+public class a_screen_without_a_file : given.a_screen_syntax_builder
+{
+    ScreenSyntax _screen;
+
+    void Because() => _screen = _builder.Build(new ScreenModel("AddAuthor", string.Empty), "Library.Authors.Registration");
+
+    [Fact] void should_still_name_the_screen() => _screen.Name.ShouldEqual("AddAuthor");
+    [Fact] void should_fall_back_to_where_the_convention_puts_it() => _screen.File!.Path.ShouldEqual("Authors/Registration/AddAuthor.tsx");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/given/a_library_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/given/a_library_model.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.given;
+
+public class a_library_model : an_emitter
+{
+    protected ApplicationModel _model;
+
+    void Establish() => _model = LibraryApplication.Build();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/given/an_emitter.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/given/an_emitter.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.given;
+
+public class an_emitter : Specification
+{
+    protected ScreenplayEmitter _emitter;
+    protected ScreenplayOptions _options;
+
+    void Establish()
+    {
+        _emitter = new();
+        _options = new();
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_library_application.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_library_application.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// The round trip is the correctness gate for everything the generator produces. Output that does not compile means
+/// the generator is wrong, and output that does not print identically the second time means information was lost.
+/// </summary>
+public class a_library_application : given.a_library_model
+{
+    ScreenplayEmission _emission;
+    ModuleSyntax _module;
+    RoundTripResult _roundTrip;
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _module = _emission.Application.Modules.Single();
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    [Fact] void should_compile_without_errors() => _roundTrip.Errors.ShouldBeEmpty();
+    [Fact] void should_compile_without_any_diagnostics() => _roundTrip.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _roundTrip.Reprinted.ShouldEqual(_roundTrip.Printed);
+    [Fact] void should_report_nothing_as_unmappable() => _emission.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_what_it_returns() => _emission.Source.ShouldEqual(_roundTrip.Printed);
+    [Fact] void should_name_the_domain_after_the_application() => _emission.Application.Domain!.Name.ShouldEqual("Library");
+    [Fact] void should_name_the_module_after_the_application() => _module.Name.ShouldEqual("Library");
+    [Fact] void should_have_a_feature_per_top_level_namespace() => _module.Features.Select(_ => _.Name).ShouldContainOnly(["Authors", "Inventory", "Lending"]);
+    [Fact] void should_have_a_slice_per_slice_namespace() => Slices().Select(_ => _.Name).ShouldContainOnly(["Registration", "Listing", "Adding", "Listing", "Reserving", "Notifications", "Restocking"]);
+    [Fact] void should_carry_the_kind_of_a_translating_slice() => Slice("Restocking").Type.ShouldEqual(SliceType.Translate);
+    [Fact] void should_carry_the_kind_of_an_automating_slice() => Slice("Notifications").Type.ShouldEqual(SliceType.Automation);
+    [Fact] void should_carry_the_kind_of_a_state_changing_slice() => Slice("Registration").Type.ShouldEqual(SliceType.StateChange);
+    [Fact] void should_carry_the_kind_of_a_state_viewing_slice() => Slice("Adding").Type.ShouldEqual(SliceType.StateChange);
+    [Fact] void should_declare_every_concept_of_the_application() => _emission.Application.Concepts.Select(_ => _.Name).ShouldContainOnly(["AuthorId", "AuthorName", "BookTitle", "CopyCount", "ISBN", "MemberId", "MembershipTier"]);
+    [Fact] void should_order_the_concepts_by_name() => _emission.Application.Concepts.Select(_ => _.Name).ShouldEqual(_emission.Application.Concepts.Select(_ => _.Name).Order(StringComparer.Ordinal));
+
+    SliceSyntax Slice(string name) => Slices().First(_ => _.Name == name);
+
+    IEnumerable<SliceSyntax> Slices() => _module.Features.SelectMany(_ => _.Slices);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_projection_using_every_block_kind.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_projection_using_every_block_kind.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// The projection definition language is the hardest corner of the document to get right - two expression grammars
+/// that must not be crossed, several blocks that do not compile when empty, and keys in more than one shape. If
+/// every block survives a round trip, the converters are honest.
+/// <para>
+/// A join names the read model property holding the joined data separately from the property it keys on, and both
+/// are read from the model - the event joined from is listed underneath rather than standing in for either.
+/// </para>
+/// </summary>
+public class a_projection_using_every_block_kind : given.an_emitter
+{
+    ApplicationModel _model;
+    ScreenplayEmission _emission;
+    RoundTripResult _roundTrip;
+
+    void Establish() => _model = LibraryApplication.Build() with { Slices = [OrderingSlice.Build()] };
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    [Fact] void should_compile_without_errors() => _roundTrip.Errors.ShouldBeEmpty();
+    [Fact] void should_compile_without_any_diagnostics() => _roundTrip.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _roundTrip.Reprinted.ShouldEqual(_roundTrip.Printed);
+    [Fact] void should_report_nothing_as_unmappable() => _emission.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_name_the_sequence() => Contains("sequence orders").ShouldBeTrue();
+    [Fact] void should_turn_automatic_mapping_off_at_the_root() => Contains("no automap").ShouldBeTrue();
+    [Fact] void should_emit_the_every_block() => Contains("every").ShouldBeTrue();
+    [Fact] void should_exclude_children_from_the_every_block() => Contains("exclude children").ShouldBeTrue();
+    [Fact] void should_emit_the_composite_key() => Contains("key OrderKey").ShouldBeTrue();
+    [Fact] void should_emit_the_parent_key() => Contains("parent customerId").ShouldBeTrue();
+    [Fact] void should_emit_the_event_context_expression() => Contains("lastUpdated = $eventContext.occurred").ShouldBeTrue();
+    [Fact] void should_emit_the_caused_by_expression() => Contains("placedBy = $causedBy.name").ShouldBeTrue();
+    [Fact] void should_emit_the_event_source_id_expression() => Contains("id = $eventSourceId").ShouldBeTrue();
+    [Fact] void should_emit_a_constant_as_a_literal() => Contains(@"status = ""placed""").ShouldBeTrue();
+    [Fact] void should_emit_the_increment_mapping() => Contains("increment versions").ShouldBeTrue();
+    [Fact] void should_emit_the_decrement_mapping() => Contains("decrement pending").ShouldBeTrue();
+    [Fact] void should_emit_the_add_mapping() => Contains("add total by amount").ShouldBeTrue();
+    [Fact] void should_emit_the_subtract_mapping() => Contains("subtract refunded by amount").ShouldBeTrue();
+    [Fact] void should_emit_the_count_mapping() => Contains("count occurrences").ShouldBeTrue();
+    [Fact] void should_emit_the_join_block() => Contains("join customer on customerId").ShouldBeTrue();
+    [Fact] void should_list_the_event_joined_from() => Contains("with CustomerRegistered").ShouldBeTrue();
+    [Fact] void should_emit_the_mapping_of_the_joined_event() => Contains("customerName = name").ShouldBeTrue();
+    [Fact] void should_emit_the_children_block() => Contains("children items identified by lineNumber").ShouldBeTrue();
+    [Fact] void should_emit_the_nested_block() => Contains("nested shipping").ShouldBeTrue();
+    [Fact] void should_emit_the_remove_with_block() => Contains("remove with OrderCancelled").ShouldBeTrue();
+    [Fact] void should_emit_the_remove_via_join_block() => Contains("remove via join on CustomerAccountClosed").ShouldBeTrue();
+
+    bool Contains(string text) => _emission.Source.Contains(text, StringComparison.Ordinal);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_projection_with_an_unmappable_expression.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_projection_with_an_unmappable_expression.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// The projection definition language rejects host expressions, so a mapping the language cannot express has to be
+/// left out. It is reported rather than dropped, which is what turns silent loss into something a reader can act on.
+/// </summary>
+public class a_projection_with_an_unmappable_expression : given.an_emitter
+{
+    ApplicationModel _model;
+    ScreenplayEmission _emission;
+    RoundTripResult _roundTrip;
+
+    void Establish() =>
+        _model = LibraryApplication.Build() with
+        {
+            Slices =
+            [
+                LibraryAuthors.Registration(),
+                LibraryAuthors.Listing() with { Projection = ProjectionWithAnUnmappableMapping() }
+            ]
+        };
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    [Fact] void should_keep_the_mapping_it_can_express() => _emission.Source.Contains("name = name", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_leave_the_mapping_it_cannot_express_out() => _emission.Source.Contains("summary", StringComparison.Ordinal).ShouldBeFalse();
+    [Fact] void should_report_the_mapping_as_unmappable() => _emission.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.UnmappableProjectionExpression]);
+    [Fact] void should_name_the_expression_in_the_report() => _emission.Diagnostics.Single().Message.Contains("$env.SERVICE", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_still_compile() => _roundTrip.Errors.ShouldBeEmpty();
+    [Fact] void should_still_compile_without_any_diagnostics() => _roundTrip.Diagnostics.ShouldBeEmpty();
+
+    static ProjectionModel ProjectionWithAnUnmappableMapping() =>
+        new(
+            "Library.Authors.Listing.AuthorProjection",
+            "Author",
+            "event-log",
+            ProjectionAutoMapMode.Enabled,
+            false,
+            ProjectionScopeModel.Empty with
+            {
+                From =
+                [
+                    new(
+                        ["AuthorRegistered"],
+                        "$eventSourceId",
+                        null,
+                        Declare.Map(("name", "name"), ("summary", "$env.SERVICE")))
+                ]
+            });
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_naming_its_members_after_directives.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_naming_its_members_after_directives.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// The whole point of the rule is what it does to a real document, so this is the case end to end: a command with a
+/// property called <c>Description</c>, an event with one called <c>Tag</c>, and a produces block filling that same
+/// property in. Written out as they are, three lines are read as directives instead of names and the document stops
+/// compiling. Left out and reported, everything around them survives intact.
+/// </summary>
+public class a_slice_naming_its_members_after_directives : given.an_emitter
+{
+    ApplicationModel _model;
+    ScreenplayEmission _emission;
+    RoundTripResult _roundTrip;
+
+    void Establish() =>
+        _model = LibraryApplication.Build() with { Slices = [Requesting()] };
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    bool Says(string text) => _emission.Source.Contains(text, StringComparison.Ordinal);
+
+    [Fact] void should_compile_without_errors() => _roundTrip.Errors.ShouldBeEmpty();
+    [Fact] void should_compile_without_any_diagnostics() => _roundTrip.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _roundTrip.Reprinted.ShouldEqual(_roundTrip.Printed);
+    [Fact] void should_not_write_the_command_property_the_body_reserves() => Says("description RequestDescription").ShouldBeFalse();
+    [Fact] void should_not_write_the_event_property_the_body_reserves() => Says("tag BookTag").ShouldBeFalse();
+    [Fact] void should_not_write_the_mapping_the_produces_block_reserves() => Says("tag = tag").ShouldBeFalse();
+    [Fact] void should_keep_the_command_property_it_can_write() => Says("title BookTitle").ShouldBeTrue();
+    [Fact] void should_keep_the_mapping_it_can_write() => Says("title = title").ShouldBeTrue();
+    [Fact] void should_report_every_line_it_left_out() => _emission.Diagnostics.Select(_ => _.Code).ShouldContainOnly(
+    [
+        ScreenplayDiagnosticCodes.NameReservedByGrammar,
+        ScreenplayDiagnosticCodes.NameReservedByGrammar,
+        ScreenplayDiagnosticCodes.NameReservedByGrammar
+    ]);
+
+    static SliceModel Requesting() =>
+        new(
+            "Library.Lending.Requesting",
+            "Requesting",
+            SliceKind.StateChange,
+            null,
+            [
+                new CommandModel(
+                    "RequestBook",
+                    null,
+                    [
+                        Declare.Property("Title", "BookTitle"),
+                        Declare.Property("Description", "RequestDescription")
+                    ],
+                    null,
+                    [],
+                    [
+                        new ProducesModel(
+                            "BookRequested",
+                            null,
+                            [
+                                Declare.From("Title", "Title"),
+                                Declare.From("Tag", "Tag")
+                            ])
+                    ],
+                    null,
+                    "Lending/Requesting/Requesting.cs")
+            ],
+            [
+                new EventModel(
+                    "BookRequested",
+                    [
+                        Declare.Property("Title", "BookTitle"),
+                        Declare.Property("Tag", "BookTag")
+                    ],
+                    [])
+            ],
+            [],
+            null,
+            [],
+            []);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_that_declares_nothing.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_that_declares_nothing.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// A slice header with no body does not compile, so a slice that declares nothing has to be left out. Leaving it out
+/// silently is what makes generated output impossible to trust, so the drop is reported.
+/// </summary>
+public class a_slice_that_declares_nothing : given.an_emitter
+{
+    ApplicationModel _model;
+    ScreenplayEmission _emission;
+    RoundTripResult _roundTrip;
+
+    void Establish() =>
+        _model = LibraryApplication.Build() with
+        {
+            Slices = [.. LibraryApplication.Slices(), SliceModel.Empty("Library.Lending.Archiving", "Archiving", SliceKind.StateView)]
+        };
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    [Fact] void should_leave_the_slice_out() => _emission.Source.Contains("Archiving", StringComparison.Ordinal).ShouldBeFalse();
+    [Fact] void should_report_the_slice_as_dropped() => _emission.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.EmptySlice]);
+    [Fact] void should_locate_the_report_at_the_slice() => _emission.Diagnostics.Single().Location.ShouldEqual("Library.Lending.Archiving");
+    [Fact] void should_report_it_as_a_warning() => _emission.Diagnostics.Single().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Warning);
+    [Fact] void should_still_compile() => _roundTrip.Errors.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_whose_screens_are_all_it_declares.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_whose_screens_are_all_it_declares.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// A screen is a body of its own, so a slice whose screens are the only thing it declares is a slice worth keeping -
+/// and it is the smallest document a screen can appear in, which makes it the sharpest round trip for one.
+/// </summary>
+public class a_slice_whose_screens_are_all_it_declares : given.an_emitter
+{
+    ApplicationModel _model;
+    ScreenplayEmission _emission;
+    RoundTripResult _roundTrip;
+
+    void Establish() =>
+        _model = LibraryApplication.Build() with
+        {
+            Slices =
+            [
+                .. LibraryApplication.Slices(),
+                SliceModel.Empty("Library.Lending.Overview", "Overview", SliceKind.StateView) with
+                {
+                    Screens =
+                    [
+                        new("LendingOverview", "Lending/Overview/LendingOverview.tsx"),
+                        new("DueSoon", "Lending/Overview/DueSoon.tsx")
+                    ]
+                }
+            ]
+        };
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    bool Says(string text) => _emission.Source.Contains(text, StringComparison.Ordinal);
+
+    [Fact] void should_keep_the_slice() => Says("slice StateView Overview").ShouldBeTrue();
+    [Fact] void should_declare_every_screen() => Says("screen DueSoon").ShouldBeTrue();
+    [Fact] void should_refer_to_the_file_realizing_each_screen() => Says("file Lending/Overview/LendingOverview.tsx").ShouldBeTrue();
+    [Fact] void should_order_the_screens_by_name() => _emission.Source.IndexOf("screen DueSoon", StringComparison.Ordinal).ShouldBeLessThan(_emission.Source.IndexOf("screen LendingOverview", StringComparison.Ordinal));
+    [Fact] void should_compile_without_errors() => _roundTrip.Errors.ShouldBeEmpty();
+    [Fact] void should_compile_without_any_diagnostics() => _roundTrip.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _roundTrip.Reprinted.ShouldEqual(_roundTrip.Printed);
+    [Fact] void should_report_nothing_as_unmappable() => _emission.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/the_same_model_twice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/the_same_model_twice.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Library;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// A generated document is only worth committing if regenerating it produces the same bytes. The two models are
+/// built separately on purpose - equal content arriving as different instances, in whatever order the collections
+/// happen to enumerate in, has to reach the printer arranged identically.
+/// </summary>
+public class the_same_model_twice : given.an_emitter
+{
+    string _first;
+    string _second;
+
+    void Because()
+    {
+        _first = _emitter.Emit(LibraryApplication.Build(), _options).Source;
+        _second = _emitter.Emit(LibraryApplication.Build(), _options).Source;
+    }
+
+    [Fact] void should_produce_identical_output() => _second.ShouldEqual(_first);
+    [Fact] void should_produce_output_at_all() => _first.ShouldNotBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_compilation.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_compilation.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.given;
+
+/// <summary>
+/// A compilation built from source strings, which is all the generator ever needs - no workspace, no project file
+/// and no build output.
+/// </summary>
+public class a_compilation : Specification
+{
+    protected Compilation _compilation;
+
+    void Establish() => _compilation = CSharpCompilation.Create(
+        "Library",
+        [CSharpSyntaxTree.ParseText("namespace Library.Authors.Registration;")]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_compilation.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_compilation.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.given;
 
@@ -10,11 +9,13 @@ namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.given;
 /// A compilation built from source strings, which is all the generator ever needs - no workspace, no project file
 /// and no build output.
 /// </summary>
+/// <remarks>
+/// The source compiles and declares nothing, which are two different things. Analysis tells them apart, so a
+/// specification about declaring nothing has to start from source that really does build.
+/// </remarks>
 public class a_compilation : Specification
 {
     protected Compilation _compilation;
 
-    void Establish() => _compilation = CSharpCompilation.Create(
-        "Library",
-        [CSharpSyntaxTree.ParseText("namespace Library.Authors.Registration;")]);
+    void Establish() => _compilation = Analyzed.Compile(("Library/Authors/Registration/Registration.cs", "namespace Library.Authors.Registration;"));
 }

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_recovered_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_recovered_model.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.given;
+
+/// <summary>
+/// Stands in for the analysis half, returning a model that was prepared rather than recovered.
+/// </summary>
+/// <param name="model">The model to return.</param>
+/// <param name="diagnostics">What analysis reports alongside the model.</param>
+public class a_recovered_model(ApplicationModel model, params ScreenplayDiagnostic[] diagnostics) : IApplicationModelAnalyzer
+{
+    /// <summary>
+    /// Gets the options the generator handed to analysis.
+    /// </summary>
+    public ScreenplayOptions? Options { get; private set; }
+
+    /// <inheritdoc/>
+    public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options)
+    {
+        Options = options;
+
+        return new(model, diagnostics);
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/LibrarySource.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/LibrarySource.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The source of a small library application, written the way an Arc application really is written.
+/// </summary>
+/// <remarks>
+/// Every discovery path the end to end specification exercises is here rather than in a fixture built by hand, so
+/// that what is asserted is what the generator does to source rather than what it does to a model someone wrote.
+/// </remarks>
+public static class LibrarySource
+{
+    /// <summary>
+    /// The slice registering an author.
+    /// </summary>
+    public const string AuthorRegistration = """
+        using Cratis.Arc.Authorization;
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle;
+        using Cratis.Chronicle.Compliance.GDPR;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Events.Constraints;
+        using Cratis.Concepts;
+        using FluentValidation;
+
+        namespace Library.Authors.Registration;
+
+        [PII("The name of a person")]
+        public record AuthorName(string Value) : ConceptAs<string>(Value);
+
+        /// <summary>
+        /// An author was registered in the library.
+        /// </summary>
+        [EventType]
+        [Tag("audit")]
+        public record AuthorRegistered([property: Unique("UniqueAuthorName")] AuthorName Name);
+
+        /// <summary>
+        /// Registers a new author.
+        /// </summary>
+        [Command]
+        [Roles("Librarian")]
+        public record RegisterAuthor(AuthorName Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+
+        public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+        {
+            public RegisterAuthorValidator()
+            {
+                RuleFor(_ => _.Name).NotEmpty().WithMessage("An author must have a name");
+                RuleFor(_ => _.Name).MaximumLength(200);
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The slice listing the registered authors.
+    /// </summary>
+    public const string AuthorListing = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Projections;
+        using Library.Authors.Registration;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public AuthorName Name { get; init; } = new(string.Empty);
+
+            public static IEnumerable<Author> AllAuthors() => [];
+
+            public static Author AuthorById(string id) => new();
+        }
+
+        public class AuthorProjection : IProjectionFor<Author>
+        {
+            public void Define(IProjectionBuilderFor<Author> builder) => builder
+                .AutoMap()
+                .From<AuthorRegistered>(_ => _
+                    .Set(m => m.Id).ToEventSourceId()
+                    .Set(m => m.Name).To(e => e.Name));
+        }
+        """;
+
+    /// <summary>
+    /// The slice reserving a copy of a book.
+    /// </summary>
+    public const string Reserving = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Lending.Reserving;
+
+        public record Isbn(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        public record BookReserved(Isbn Isbn);
+
+        [EventType]
+        public record ReservationRefused(Isbn Isbn);
+
+        /// <summary>
+        /// Reserves a copy of a book for a member.
+        /// </summary>
+        [Command]
+        public record ReserveBook(Isbn Isbn, bool InStock)
+        {
+            public object Handle()
+            {
+                if (InStock)
+                {
+                    return new BookReserved(Isbn);
+                }
+
+                return new ReservationRefused(Isbn);
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The slice notifying a member that their reservation is ready.
+    /// </summary>
+    public const string Notifications = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+        using Library.Lending.Reserving;
+
+        namespace Library.Lending.Notifications;
+
+        public class ReservationNotifier : IReactor
+        {
+            public Task BookReserved(BookReserved @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/PolicyAndAggregateSource.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/PolicyAndAggregateSource.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The source of a library application whose commands name authorization policies and govern their changes through
+/// an aggregate root, written the way an Arc application really is written.
+/// </summary>
+public static class PolicyAndAggregateSource
+{
+    /// <summary>
+    /// The part of the authorization framework a registration is written against.
+    /// </summary>
+    public const string Framework = """
+        using System;
+
+        namespace Microsoft.AspNetCore.Authorization;
+
+        public class AuthorizationPolicyBuilder
+        {
+            public AuthorizationPolicyBuilder RequireRole(params string[] roles) => this;
+
+            public AuthorizationPolicyBuilder RequireClaim(string claimType, params string[] allowedValues) => this;
+        }
+
+        public class AuthorizationOptions
+        {
+            public void AddPolicy(string name, Action<AuthorizationPolicyBuilder> configurePolicy)
+            {
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Where the application says what each of its policies means.
+    /// </summary>
+    public const string Composition = """
+        using Microsoft.AspNetCore.Authorization;
+
+        namespace Library;
+
+        public static class Composition
+        {
+            public static void Authorization(AuthorizationOptions options)
+            {
+                options.AddPolicy("CanReserve", policy => policy.RequireRole("Librarian").RequireClaim("branch", "central"));
+                options.AddPolicy("SeniorStaff", policy => policy.RequireRole("Librarian", "Archivist"));
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The slice reserving a copy of a book through the aggregate root governing the reservation.
+    /// </summary>
+    public const string Reserving = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Authorization;
+        using Cratis.Arc.Chronicle.Aggregates;
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+        using FluentValidation;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(string Isbn, string Member);
+
+        public class Reservation : AggregateRoot
+        {
+            public Task Reserve(string isbn, string member) => Apply(new BookReserved(isbn, member));
+
+            public void OnBookReserved(BookReserved @event)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Reserves a copy of a book for a member.
+        /// </summary>
+        [Command]
+        [Authorize(Policy = "CanReserve")]
+        public record ReserveBook(string Isbn, string MemberId)
+        {
+            public async Task Handle(Reservation reservation)
+            {
+                await reservation.Reserve(Isbn, MemberId);
+                await reservation.Commit();
+            }
+        }
+
+        public class ReserveBookValidator : CommandValidator<ReserveBook>
+        {
+            public ReserveBookValidator()
+            {
+                RuleFor(_ => _.Isbn).Length(10, 13).WithMessage("An ISBN is between 10 and 13 characters");
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The slice writing off a lost copy, which only senior staff may do.
+    /// </summary>
+    public const string WritingOff = """
+        using Cratis.Arc.Authorization;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.WritingOff;
+
+        [EventType]
+        public record CopyWrittenOff(string Isbn);
+
+        [Command]
+        [Authorize(Policy = "SeniorStaff", Roles = "Librarian")]
+        public record WriteOffCopy(string Isbn)
+        {
+            public CopyWrittenOff Handle() => new(Isbn);
+        }
+        """;
+
+    /// <summary>
+    /// Gets every source file of the application, keyed by the path each one is compiled as.
+    /// </summary>
+    /// <returns>The source files.</returns>
+    public static (string Path, string Text)[] All() =>
+    [
+        ("Library/Composition.cs", Composition),
+        ("Library/Authorization.cs", Framework),
+        ("Library/Lending/Reserving/Reserving.cs", Reserving),
+        ("Library/Lending/WritingOff/WritingOff.cs", WritingOff)
+    ];
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_command_naming_a_policy_an_identifier_cannot_hold.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_command_naming_a_policy_an_identifier_cannot_hold.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// An application names its policies and roles whatever it likes - <c>can-reserve</c>, <c>reader</c> - while the
+/// grammar accepts a policy reference only as a Pascal cased identifier. Both the reference and the declaration are
+/// converted the same way, so a name the grammar cannot hold yields a document that still compiles and still declares
+/// everything it refers to.
+/// </summary>
+public class from_a_command_naming_a_policy_an_identifier_cannot_hold : Specification
+{
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Lending/Reserving/Reserving.cs", """
+            using Cratis.Arc.Authorization;
+            using Cratis.Arc.Commands.ModelBound;
+            using Cratis.Chronicle.Events;
+
+            namespace Library.Lending.Reserving;
+
+            [EventType]
+            public record BookReserved(string Isbn);
+
+            [Command]
+            [Authorize(Policy = "can-reserve", Roles = "reader")]
+            public record ReserveBook(string Isbn)
+            {
+                public BookReserved Handle() => new(Isbn);
+            }
+            """)
+    ];
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    bool HasLine(string text) => _result.Source.Split('\n').Any(_ => string.Equals(_.Trim(), text, StringComparison.Ordinal));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_refer_to_the_policy_by_a_name_the_grammar_accepts() => HasLine("CanReserve").ShouldBeTrue();
+    [Fact] void should_declare_the_policy_it_refers_to() => HasLine("policy CanReserve").ShouldBeTrue();
+    [Fact] void should_refer_to_the_role_by_a_name_the_grammar_accepts() => HasLine("authorize Reader").ShouldBeTrue();
+    [Fact] void should_keep_the_role_the_application_really_names() => HasLine("require role \"reader\"").ShouldBeTrue();
+    [Fact] void should_report_that_nothing_registers_the_policy() => _result.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_generator_nobody_wired.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_generator_nobody_wired.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The package ships no dependency injection, so a host that just wants a document has to be able to say
+/// <c>new ScreenplayGenerator()</c> and get one. Nothing outside the package should have to know that an analysis
+/// half and an emission half exist.
+/// </summary>
+public class from_a_generator_nobody_wired : given.a_compilation
+{
+    IScreenplayGenerator _generator;
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+
+    void Establish() => _generator = new ScreenplayGenerator();
+
+    void Because()
+    {
+        _result = _generator.Generate(_compilation, new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+    }
+
+    [Fact] void should_produce_a_document() => _result.Source.ShouldNotBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_without_diagnostics() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_name_the_domain_after_the_compilation() => _result.Model.Domain.ShouldEqual("Library");
+    [Fact] void should_not_report_it_as_a_failure() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_recovered_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_recovered_model.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The generator is the two halves joined together. It resolves the options once, hands them to analysis, emits what
+/// analysis recovered, and reports everything either half could not express.
+/// </summary>
+public class from_a_recovered_model : given.a_compilation
+{
+    given.a_recovered_model _analyzer;
+    ScreenplayGenerator _generator;
+    ScreenplayGenerationResult _result;
+
+    void Establish()
+    {
+        _analyzer = new(
+            LibraryApplication.Build(),
+            new ScreenplayDiagnostic(ScreenplayDiagnosticSeverity.Warning, "SP9999", "Something was not recovered", "Library"));
+        _generator = new(_analyzer, new ScreenplayEmitter());
+    }
+
+    void Because() => _result = _generator.Generate(_compilation, new ScreenplayOptions());
+
+    [Fact] void should_return_the_model_it_generated_from() => _result.Model.Domain.ShouldEqual("Library");
+    [Fact] void should_print_the_document() => _result.Source.StartsWith("domain Library", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_carry_forward_what_analysis_reported() => _result.Diagnostics.Select(_ => _.Code).ShouldContainOnly(["SP9999"]);
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_resolve_the_domain_from_the_compilation() => _analyzer.Options!.Domain.ShouldEqual("Library");
+    [Fact] void should_default_the_module_to_the_domain() => _analyzer.Options!.Module.ShouldEqual("Library");
+    [Fact] void should_default_the_segments_to_skip() => _analyzer.Options!.SegmentsToSkip.ShouldEqual(0);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_carrying_text_the_grammar_cannot_hold.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_carrying_text_the_grammar_cannot_hold.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The one failure mode worse than a document that says too little is a document that does not compile. A tag and a
+/// validation message are both free text the developer wrote, and both are printed unescaped onto a line of their
+/// own, so a line break in either of them splits the construct in two and the rest of the file is read as garbage.
+/// </summary>
+public class from_source_carrying_text_the_grammar_cannot_hold : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle;
+        using Cratis.Chronicle.Events;
+        using FluentValidation;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        [Tag("carries\na line break")]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+
+        public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+        {
+            public RegisterAuthorValidator()
+            {
+                RuleFor(_ => _.Name).NotEmpty().WithMessage("An author must have a name.\nGive it one.");
+            }
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources = [("Library/Authors/Registration/Registration.cs", Source)];
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator(
+                new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None),
+                new ScreenplayEmitter())
+            .Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_keep_the_tag_on_one_line() => _result.Source.ShouldContain("tag \"carries a line break\"");
+    [Fact] void should_keep_the_message_on_one_line() => _result.Source.ShouldContain("message \"An author must have a name. Give it one.\"");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_declaring_children_and_nested_objects.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_declaring_children_and_nested_objects.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// A child collection and a nested object are the two blocks a projection body nests, and both of them are declared
+/// across two types rather than one. Compiling the document they produce and printing it again is what proves the
+/// two halves were put back together into something the projection definition language really accepts.
+/// </summary>
+public class from_source_declaring_children_and_nested_objects : Specification
+{
+    const string Shelving = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Inventory.Shelving;
+
+        [EventType]
+        public record ShelfInstalled(string Name);
+
+        [EventType]
+        public record ShelfLocated(string Aisle);
+
+        [EventType]
+        public record BookPlacedOnShelf(Guid ShelfId, Guid BookId, string Title);
+
+        [FromEvent<ShelfLocated>]
+        public record ShelfLocation(
+            [SetFrom<ShelfLocated>(nameof(ShelfLocated.Aisle))] string Aisle);
+
+        public record ShelvedBook(
+            Guid Id,
+            [SetFrom<BookPlacedOnShelf>(nameof(BookPlacedOnShelf.Title))] string Title);
+
+        [ReadModel]
+        [FromEvent<ShelfInstalled>]
+        public record Shelf(
+            Guid Id,
+            string Name,
+            [ChildrenFrom<BookPlacedOnShelf>(
+                key: nameof(BookPlacedOnShelf.BookId),
+                parentKey: nameof(BookPlacedOnShelf.ShelfId))]
+            IEnumerable<ShelvedBook> Books,
+            [Nested] ShelfLocation? Location);
+        """;
+
+    static readonly (string Path, string Text)[] _sources = [("Library/Inventory/Shelving/Shelving.cs", Shelving)];
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    bool Says(string text) => _result.Source.Contains(text, StringComparison.Ordinal);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_write_out_the_children_block() => Says("children books identified by id").ShouldBeTrue();
+    [Fact] void should_key_the_children_on_the_event_property() => Says("key bookId").ShouldBeTrue();
+    [Fact] void should_find_the_parent_of_a_child() => Says("parent shelfId").ShouldBeTrue();
+    [Fact] void should_map_what_the_type_of_the_child_declares() => Says("title = title").ShouldBeTrue();
+    [Fact] void should_write_out_the_nested_block() => Says("nested location").ShouldBeTrue();
+    [Fact] void should_map_what_the_type_of_the_nested_object_declares() => Says("aisle = aisle").ShouldBeTrue();
+    [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_declaring_nothing.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_declaring_nothing.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// Source that declares no artifact leaves nothing to describe. The generator still has to produce a document that
+/// compiles, and it has to say that it recovered nothing rather than imply the application is empty.
+/// </summary>
+public class from_source_declaring_nothing : given.a_compilation
+{
+    ScreenplayGenerator _generator;
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+
+    void Establish() => _generator = new(new ApplicationModelAnalyzer(), new ScreenplayEmitter());
+
+    void Because()
+    {
+        _result = _generator.Generate(_compilation, new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+    }
+
+    [Fact] void should_still_name_the_domain() => _result.Source.ShouldEqual("domain Library\n");
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_without_diagnostics() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_report_that_nothing_was_recovered() => _result.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.AnalysisUnavailable]);
+    [Fact] void should_not_report_it_as_a_failure() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_referring_to_members_of_an_enumeration.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_referring_to_members_of_an_enumeration.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// This is the whole point of naming a member end to end: a document declaring <c>concept UserRole : Enum</c> with
+/// <c>clientContact</c> underneath it, and then referring to that member by the number behind it, describes an
+/// application nobody can read back. Every place a member can appear - a mapping, a guard, a validation rule and a
+/// projection - has to write the name the concept declares, while a number that belongs to no enumeration stays a
+/// number.
+/// </summary>
+public class from_source_referring_to_members_of_an_enumeration : Specification
+{
+    const string Inviting = """
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+        using FluentValidation;
+
+        namespace Library.Access.Inviting;
+
+        public enum UserRole
+        {
+            None,
+            CustomerAdvisor,
+            ClientContact
+        }
+
+        [EventType]
+        public record ClientContactInvited(UserRole Role, int Attempt);
+
+        [EventType]
+        public record AccessGranted(UserRole Role);
+
+        [Command]
+        public record InviteUser(UserRole Role)
+        {
+            public object Handle()
+            {
+                if (Role == UserRole.ClientContact)
+                {
+                    return new ClientContactInvited(UserRole.ClientContact, 6);
+                }
+
+                return new AccessGranted(Role);
+            }
+        }
+
+        public class InviteUserValidator : CommandValidator<InviteUser>
+        {
+            public InviteUserValidator()
+            {
+                RuleFor(_ => _.Role).Equal(UserRole.ClientContact);
+            }
+        }
+        """;
+
+    const string Listing = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Projections.ModelBound;
+        using Library.Access.Inviting;
+
+        namespace Library.Access.Listing;
+
+        [ReadModel]
+        [FromEvent<ClientContactInvited>]
+        public record Invitation
+        {
+            [SetValue<ClientContactInvited>(UserRole.ClientContact)]
+            public UserRole Role { get; init; }
+
+            [SetValue<ClientContactInvited>(6)]
+            public int Attempt { get; init; }
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Access/Inviting/Inviting.cs", Inviting),
+        ("Library/Access/Listing/Listing.cs", Listing)
+    ];
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    IEnumerable<string> Lines() =>
+        _result.Source.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(_ => _.Trim());
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_declare_the_enumeration_as_a_concept() => Lines().ShouldContain("concept UserRole : Enum");
+    [Fact] void should_declare_the_member_the_document_refers_to() => Lines().ShouldContain("clientContact");
+    [Fact] void should_write_a_mapping_as_the_member_it_names() => Lines().ShouldContain(@"role = ""clientContact""");
+    [Fact] void should_write_the_mapping_of_the_command_and_of_the_projection_alike() => Lines().Count(_ => _ == @"role = ""clientContact""").ShouldEqual(2);
+    [Fact] void should_write_a_guard_as_the_member_it_compares_against() => Lines().ShouldContain(@"produces when role == ""clientContact""");
+    [Fact] void should_write_the_opposite_guard_as_the_member_too() => Lines().ShouldContain(@"produces when role != ""clientContact""");
+    [Fact] void should_write_a_validation_rule_as_the_member_it_compares_against() => Lines().ShouldContain(@"role == ""clientContact""");
+    [Fact] void should_never_refer_to_a_member_by_the_number_behind_it() => Lines().ShouldNotContain("role = 2");
+    [Fact] void should_never_compare_against_the_number_behind_a_member() => Lines().ShouldNotContain("produces when role == 2");
+    [Fact] void should_leave_a_number_belonging_to_no_enumeration_as_a_number() => Lines().ShouldContain("attempt = 6");
+    [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_same_source_handed_over_in_another_order.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_same_source_handed_over_in_another_order.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// A generated document is meant to be committed, diffed and reviewed, which it cannot be if it reorders itself
+/// between builds. Nothing decides the order a build hands its source files over in, so the same files in another
+/// order have to produce the same bytes - that is the whole of the determinism promise, stated as something that
+/// can fail.
+/// </summary>
+public class from_the_same_source_handed_over_in_another_order : Specification
+{
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", LibrarySource.AuthorRegistration),
+        ("Library/Authors/Listing/Listing.cs", LibrarySource.AuthorListing),
+        ("Library/Lending/Reserving/Reserving.cs", LibrarySource.Reserving),
+        ("Library/Lending/Notifications/Notifications.cs", LibrarySource.Notifications)
+    ];
+
+    string _asGiven;
+    string _reversed;
+
+    void Because()
+    {
+        _asGiven = Generate(_sources);
+        _reversed = Generate([.. _sources.AsEnumerable().Reverse()]);
+    }
+
+    static string Generate((string Path, string Text)[] sources) =>
+        new ScreenplayGenerator(
+                new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None),
+                new ScreenplayEmitter())
+            .Generate(Analyzed.Compile(sources), new ScreenplayOptions())
+            .Source;
+
+    [Fact] void should_have_produced_a_document_at_all() => _asGiven.ShouldNotBeEmpty();
+    [Fact] void should_produce_the_same_document_either_way() => _reversed.ShouldEqual(_asGiven);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_controller_based_application.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_controller_based_application.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The other half of the promise: an application written against controllers rather than model-bound artifacts has
+/// to come out of the same generator as a document the real Screenplay compiler accepts without a single
+/// diagnostic. This is the shape that produced the defects worth fixing - transport types standing in for read
+/// models, and two queries in one slice under one name - so it is the shape worth gating on.
+/// </summary>
+public class from_the_source_of_a_controller_based_application : Specification
+{
+    const string WebFramework = """
+        using System;
+
+        namespace Microsoft.AspNetCore.Mvc;
+
+        public abstract class ControllerBase;
+
+        public interface IActionResult;
+
+        public abstract class ActionResult : IActionResult;
+
+        public sealed class OkObjectResult : ActionResult;
+
+        public sealed class ActionResult<TValue>
+        {
+            public static implicit operator ActionResult<TValue>(TValue value) => new();
+        }
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class HttpGetAttribute : Attribute;
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class HttpPostAttribute : Attribute;
+
+        [AttributeUsage(AttributeTargets.Parameter)]
+        public sealed class FromBodyAttribute : Attribute;
+        """;
+
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Authorization;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+        using Microsoft.AspNetCore.Mvc;
+
+        namespace Library.Messaging.Feed;
+
+        public record MessageText(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        public record MessagePosted(MessageText Text);
+
+        public record PostToFeed(MessageText Text);
+
+        public record FeedMessage(string Id, MessageText Text);
+
+        public record ArchivedMessage(string Id, MessageText Text);
+
+        public class FeedController : ControllerBase
+        {
+            /// <summary>
+            /// Posts a message to the feed.
+            /// </summary>
+            [HttpPost]
+            [Roles("Author")]
+            public MessagePosted Post([FromBody] PostToFeed command) => new(command.Text);
+
+            [HttpGet]
+            public ActionResult<IEnumerable<FeedMessage>> ObserveAll() => new();
+
+            [HttpGet]
+            public IActionResult Raw() => new OkObjectResult();
+        }
+
+        public class ArchiveController : ControllerBase
+        {
+            [HttpGet]
+            public IEnumerable<ArchivedMessage> ObserveAll() => [];
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Web/Mvc.cs", WebFramework),
+        ("Library/Messaging/Feed/FeedController.cs", Source)
+    ];
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    bool Says(string text) => _result.Source.Contains(text, StringComparison.Ordinal);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_the_real_compiler_accepts() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_real_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_declare_the_command_named_after_its_request_body() => Says("command PostToFeed").ShouldBeTrue();
+    [Fact] void should_state_what_the_command_produces() => Says("produces MessagePosted").ShouldBeTrue();
+    [Fact] void should_declare_what_the_command_requires_of_the_caller() => Says("authorize Author").ShouldBeTrue();
+    [Fact] void should_tell_the_two_observing_queries_apart() => Says("query ArchiveControllerObserveAll").ShouldBeTrue();
+    [Fact] void should_tell_the_other_one_apart_too() => Says("query FeedControllerObserveAll").ShouldBeTrue();
+    [Fact] void should_never_put_a_transport_type_in_the_document() => Says("ActionResult").ShouldBeFalse();
+    [Fact] void should_leave_out_the_query_whose_read_model_is_unknowable() => Says("query Raw").ShouldBeFalse();
+    [Fact] void should_report_the_query_it_left_out() => _result.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableQuery);
+    [Fact] void should_report_nothing_as_an_error() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_whole_application.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_whole_application.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// This is the whole promise, end to end: C# an Arc application could really be written in goes in, and a document
+/// that the Screenplay compiler accepts without a single diagnostic comes out - and printing that document again
+/// yields byte identical text, which is what proves nothing was lost between the two halves.
+/// </summary>
+public class from_the_source_of_a_whole_application : Specification
+{
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", LibrarySource.AuthorRegistration),
+        ("Library/Authors/Listing/Listing.cs", LibrarySource.AuthorListing),
+        ("Library/Lending/Reserving/Reserving.cs", LibrarySource.Reserving),
+        ("Library/Lending/Notifications/Notifications.cs", LibrarySource.Notifications)
+    ];
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    bool Says(string text) => _result.Source.Contains(text, StringComparison.Ordinal);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_name_the_domain_after_the_compilation() => Says("domain Library").ShouldBeTrue();
+    [Fact] void should_declare_the_concepts_the_application_refers_to() => Says("concept AuthorName : String @pii").ShouldBeTrue();
+    [Fact] void should_arrange_the_slices_into_features() => Says("feature Authors").ShouldBeTrue();
+    [Fact] void should_declare_the_command() => Says("command RegisterAuthor").ShouldBeTrue();
+    [Fact] void should_state_what_the_command_produces() => Says("produces AuthorRegistered").ShouldBeTrue();
+    [Fact] void should_state_the_condition_a_decision_produces_under() => Says("produces when inStock == true").ShouldBeTrue();
+    [Fact] void should_map_the_produced_event_from_the_command_input() => Says("name = name").ShouldBeTrue();
+    [Fact] void should_declare_the_validation_rules_with_their_messages() => Says("name not empty message \"An author must have a name\"").ShouldBeTrue();
+    [Fact] void should_declare_what_the_command_requires_of_the_caller() => Says("authorize").ShouldBeTrue();
+    [Fact] void should_declare_the_constraint() => Says("constraint UniqueAuthorName").ShouldBeTrue();
+    [Fact] void should_declare_the_query() => Says("query AllAuthors").ShouldBeTrue();
+    [Fact] void should_declare_the_projection() => Says("projection Author").ShouldBeTrue();
+    [Fact] void should_declare_the_reactor() => Says("reactor ReservationNotifier").ShouldBeTrue();
+    [Fact] void should_read_the_reactor_from_the_file_it_lives_in() => Says("Lending/Notifications/Notifications.cs").ShouldBeTrue();
+    [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_whole_application.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_whole_application.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
 using Cratis.Screenplay;
 
 namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
@@ -26,7 +28,10 @@ public class from_the_source_of_a_whole_application : Specification
 
     void Because()
     {
-        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _result = new ScreenplayGenerator(
+                new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None),
+                new ScreenplayEmitter())
+            .Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
         _compiled = new ScreenplayCompiler().Compile(_result.Source);
         _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
     }

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_using_policies_and_aggregates.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_using_policies_and_aggregates.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// Everything a named policy, a length range and an aggregate root recover has to survive all the way into text the
+/// Screenplay compiler accepts without a diagnostic - and printing that text again has to yield the same bytes. A
+/// policy the document refers to but never declares would compile with a warning, and a warning in generated output
+/// is a generated output nobody trusts.
+/// </summary>
+public class from_the_source_of_an_application_using_policies_and_aggregates : Specification
+{
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(PolicyAndAggregateSource.All()), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    bool Says(string text) => _result.Source.Contains(text, StringComparison.Ordinal);
+
+    bool HasLine(string text) => _result.Source.Split('\n').Any(_ => string.Equals(_.Trim(), text, StringComparison.Ordinal));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(PolicyAndAggregateSource.All()).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_refer_to_the_policy_the_command_names() => Says("authorize CanReserve").ShouldBeTrue();
+    [Fact] void should_declare_the_policy_it_refers_to() => Says("policy CanReserve").ShouldBeTrue();
+    [Fact] void should_declare_what_the_policy_requires() => HasLine("require role \"Librarian\" and claim \"branch\" matches central").ShouldBeTrue();
+    [Fact] void should_declare_the_several_values_of_one_requirement_as_alternatives() => HasLine("require role \"Librarian\" or role \"Archivist\"").ShouldBeTrue();
+    [Fact] void should_ask_for_a_role_before_the_policy_it_is_asked_with() => HasLine("authorize Librarian").ShouldBeTrue();
+    [Fact] void should_ask_for_the_policy_alongside_the_role() => HasLine("SeniorStaff").ShouldBeTrue();
+    [Fact] void should_state_what_a_command_governed_by_an_aggregate_root_produces() => Says("produces BookReserved").ShouldBeTrue();
+    [Fact] void should_map_the_produced_event_from_the_command_input() => Says("member = memberId").ShouldBeTrue();
+    [Fact] void should_carry_the_message_of_a_length_range_on_its_lower_bound() => Says("isbn min 10 message \"An ISBN is between 10 and 13 characters\"").ShouldBeTrue();
+    [Fact] void should_carry_the_message_of_a_length_range_on_its_upper_bound() => Says("isbn max 13 message \"An ISBN is between 10 and 13 characters\"").ShouldBeTrue();
+    [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_with_screens.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_with_screens.cs
@@ -10,21 +10,36 @@ namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
 /// <summary>
 /// The whole promise with the screens in it: source an Arc application could really be written in, with the
 /// components a vertical slice puts next to it, produces a document the Screenplay compiler accepts without a single
-/// diagnostic - and printing that document again yields byte identical text, which is what proves the screens
-/// survived the trip.
+/// diagnostic - and printing that document again yields byte identical text, which is what proves the screens and
+/// the queries they bind survived the trip.
 /// </summary>
 public class from_the_source_of_an_application_with_screens : Specification
 {
+    const string AddAuthorComponent = """
+        import { CommandDialog } from '@cratis/components/CommandDialog';
+        import { RegisterAuthor } from './RegisterAuthor';
+
+        export const AddAuthor = () => <CommandDialog command={RegisterAuthor} />;
+        """;
+
+    const string AuthorListComponent = """
+        import { DataTable } from 'primereact/datatable';
+        import { AllAuthors } from './AllAuthors';
+        import { AuthorById } from './AuthorById';
+
+        export const AuthorList = () => <DataTable value={AllAuthors.use()} />;
+        """;
+
     static readonly (string Path, string Text)[] _sources =
     [
         ("Library/Authors/Registration/Registration.cs", LibrarySource.AuthorRegistration),
         ("Library/Authors/Listing/Listing.cs", LibrarySource.AuthorListing)
     ];
 
-    static readonly DeclaredUserInterfaceFiles _files = new(
-        "Library/Authors/Registration/AddAuthor.tsx",
-        "Library/Authors/Listing/AuthorList.tsx",
-        "Library/Authors/Listing/AuthorList.stories.tsx");
+    static readonly DeclaredUserInterfaceFiles _files = DeclaredUserInterfaceFiles.Holding(
+        ("Library/Authors/Registration/AddAuthor.tsx", AddAuthorComponent),
+        ("Library/Authors/Listing/AuthorList.tsx", AuthorListComponent),
+        ("Library/Authors/Listing/AuthorList.stories.tsx", AuthorListComponent));
 
     ScreenplayGenerationResult _result;
     CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
@@ -47,7 +62,10 @@ public class from_the_source_of_an_application_with_screens : Specification
     [Fact] void should_declare_the_screen_of_the_state_changing_slice() => Says("screen AddAuthor").ShouldBeTrue();
     [Fact] void should_declare_the_screen_of_the_state_viewing_slice() => Says("screen AuthorList").ShouldBeTrue();
     [Fact] void should_refer_to_the_file_realizing_the_screen() => Says("file Authors/Registration/AddAuthor.tsx").ShouldBeTrue();
+    [Fact] void should_bind_the_query_returning_many() => Says("data Author[] via query AllAuthors").ShouldBeTrue();
+    [Fact] void should_bind_the_query_keyed_by_a_parameter() => Says("data Author via query AuthorById by id").ShouldBeTrue();
     [Fact] void should_leave_out_the_companion_of_a_component() => Says("AuthorList.stories").ShouldBeFalse();
-    [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_bind_nothing_on_a_screen_that_imports_only_a_command() => Says("via query RegisterAuthor").ShouldBeFalse();
+    [Fact] void should_report_only_what_no_screen_states() => _result.Diagnostics.Select(_ => _.Code).Distinct().ShouldContainOnly([ScreenplayDiagnosticCodes.ScreenStructureNotInferred]);
     [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_with_screens.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_with_screens.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The whole promise with the screens in it: source an Arc application could really be written in, with the
+/// components a vertical slice puts next to it, produces a document the Screenplay compiler accepts without a single
+/// diagnostic - and printing that document again yields byte identical text, which is what proves the screens
+/// survived the trip.
+/// </summary>
+public class from_the_source_of_an_application_with_screens : Specification
+{
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", LibrarySource.AuthorRegistration),
+        ("Library/Authors/Listing/Listing.cs", LibrarySource.AuthorListing)
+    ];
+
+    static readonly DeclaredUserInterfaceFiles _files = new(
+        "Library/Authors/Registration/AddAuthor.tsx",
+        "Library/Authors/Listing/AuthorList.tsx",
+        "Library/Authors/Listing/AuthorList.stories.tsx");
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator(new ApplicationModelAnalyzer(_files), new ScreenplayEmitter())
+            .Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    bool Says(string text) => _result.Source.Contains(text, StringComparison.Ordinal);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_declare_the_screen_of_the_state_changing_slice() => Says("screen AddAuthor").ShouldBeTrue();
+    [Fact] void should_declare_the_screen_of_the_state_viewing_slice() => Says("screen AuthorList").ShouldBeTrue();
+    [Fact] void should_refer_to_the_file_realizing_the_screen() => Says("file Authors/Registration/AddAuthor.tsx").ShouldBeTrue();
+    [Fact] void should_leave_out_the_companion_of_a_component() => Says("AuthorList.stories").ShouldBeFalse();
+    [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/given/a_naming.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/given/a_naming.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayNaming.given;
+
+public class a_naming : Specification
+{
+    protected ScreenplayNaming _naming;
+
+    void Establish() => _naming = new();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_file_path/from_a_declared_path.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_file_path/from_a_declared_path.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayNaming.when_making_a_file_path;
+
+/// <summary>
+/// A file reference is written verbatim, so a Windows separator would travel into a document read on any platform.
+/// </summary>
+public class from_a_declared_path : given.a_naming
+{
+    string? _withBackslashes;
+    string? _withNothing;
+
+    void Because()
+    {
+        _withBackslashes = _naming.ToFilePath(@"Authors\Registration\Registration.cs");
+        _withNothing = _naming.ToFilePath("   ");
+    }
+
+    [Fact] void should_normalize_the_separator() => _withBackslashes.ShouldEqual("Authors/Registration/Registration.cs");
+    [Fact] void should_treat_whitespace_only_as_absent() => _withNothing.ShouldBeNull();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_property_name/from_declared_names.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_property_name/from_declared_names.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayNaming.when_making_a_property_name;
+
+/// <summary>
+/// The Screenplay property line regex is <c>^[a-z_]\w*$</c>, so every declared PascalCase name has to be lower
+/// camelled before it is emitted.
+/// </summary>
+public class from_declared_names : given.a_naming
+{
+    string _pascalCased;
+    string _acronym;
+    string _allUpperCase;
+    string _startingWithADigit;
+    string _alreadyCamelCased;
+    string _empty;
+
+    void Because()
+    {
+        _pascalCased = _naming.ToPropertyName("AuthorName");
+        _acronym = _naming.ToPropertyName("ISBNValue");
+        _allUpperCase = _naming.ToPropertyName("ISBN");
+        _startingWithADigit = _naming.ToPropertyName("1Value");
+        _alreadyCamelCased = _naming.ToPropertyName("name");
+        _empty = _naming.ToPropertyName(string.Empty);
+    }
+
+    [Fact] void should_lower_camel_a_pascal_cased_name() => _pascalCased.ShouldEqual("authorName");
+    [Fact] void should_keep_the_word_boundary_of_an_acronym() => _acronym.ShouldEqual("isbnValue");
+    [Fact] void should_lower_an_entirely_upper_case_name() => _allUpperCase.ShouldEqual("isbn");
+    [Fact] void should_prefix_a_name_starting_with_a_digit() => _startingWithADigit.ShouldEqual("_1Value");
+    [Fact] void should_leave_an_already_camel_cased_name_alone() => _alreadyCamelCased.ShouldEqual("name");
+    [Fact] void should_fall_back_for_a_name_with_nothing_in_it() => _empty.ShouldEqual("value");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_property_path/from_a_dotted_path.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_property_path/from_a_dotted_path.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayNaming.when_making_a_property_path;
+
+/// <summary>
+/// Every segment of a path is a property name in its own right, so camel casing only the first one leaves the rest
+/// failing the property regex.
+/// </summary>
+public class from_a_dotted_path : given.a_naming
+{
+    string _nested;
+    string _single;
+    string _empty;
+
+    void Because()
+    {
+        _nested = _naming.ToPropertyPath("Lines.Quantity");
+        _single = _naming.ToPropertyPath("Name");
+        _empty = _naming.ToPropertyPath(string.Empty);
+    }
+
+    [Fact] void should_camel_case_every_segment() => _nested.ShouldEqual("lines.quantity");
+    [Fact] void should_camel_case_a_single_segment() => _single.ShouldEqual("name");
+    [Fact] void should_fall_back_for_a_path_with_nothing_in_it() => _empty.ShouldEqual("value");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_string_literal/with_content_that_would_end_the_line.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_string_literal/with_content_that_would_end_the_line.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayNaming.when_making_a_string_literal;
+
+/// <summary>
+/// Screenplay is line based and the printer never escapes, so a line break inside a string literal ends the
+/// construct halfway through and everything after it is read as a new declaration. A validation message, a tag or a
+/// description carrying one therefore has to be brought back onto a single line before it is handed over.
+/// </summary>
+public class with_content_that_would_end_the_line : given.a_naming
+{
+    string? _withALineBreak;
+    string? _withACarriageReturn;
+    string? _withATab;
+    string? _withOnlyControlCharacters;
+    string? _withAPathOnTwoLines;
+
+    void Because()
+    {
+        _withALineBreak = _naming.ToStringLiteral("First line\nSecond line");
+        _withACarriageReturn = _naming.ToStringLiteral("First line\r\nSecond line");
+        _withATab = _naming.ToStringLiteral("Name\tis required");
+        _withOnlyControlCharacters = _naming.ToStringLiteral("\n\t\r");
+        _withAPathOnTwoLines = _naming.ToFilePath("Lending/Reserving\n/Reserving.cs");
+    }
+
+    [Fact] void should_bring_a_line_break_onto_one_line() => _withALineBreak.ShouldEqual("First line Second line");
+    [Fact] void should_bring_a_carriage_return_onto_one_line() => _withACarriageReturn.ShouldEqual("First line Second line");
+    [Fact] void should_bring_a_tab_onto_one_line() => _withATab.ShouldEqual("Name is required");
+    [Fact] void should_treat_control_characters_only_as_absent() => _withOnlyControlCharacters.ShouldBeNull();
+    [Fact] void should_bring_a_path_onto_one_line() => _withAPathOnTwoLines.ShouldEqual("Lending/Reserving /Reserving.cs");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_string_literal/with_content_the_printer_cannot_escape.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_string_literal/with_content_the_printer_cannot_escape.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayNaming.when_making_a_string_literal;
+
+/// <summary>
+/// The Screenplay printer never escapes string literals, so a quote reaching it produces output that cannot be
+/// parsed back. Anything the printer cannot represent has to be neutralized before it is handed over.
+/// </summary>
+public class with_content_the_printer_cannot_escape : given.a_naming
+{
+    string? _withAQuote;
+    string? _withWhitespaceOnly;
+    string? _withNull;
+    string? _withSurroundingWhitespace;
+
+    void Because()
+    {
+        _withAQuote = _naming.ToStringLiteral(@"He said ""hello""");
+        _withWhitespaceOnly = _naming.ToStringLiteral("   ");
+        _withNull = _naming.ToStringLiteral(null);
+        _withSurroundingWhitespace = _naming.ToStringLiteral("  Registers an author.  ");
+    }
+
+    [Fact] void should_replace_every_quote() => _withAQuote.ShouldEqual("He said 'hello'");
+    [Fact] void should_treat_whitespace_only_as_absent() => _withWhitespaceOnly.ShouldBeNull();
+    [Fact] void should_treat_null_as_absent() => _withNull.ShouldBeNull();
+    [Fact] void should_trim_surrounding_whitespace() => _withSurroundingWhitespace.ShouldEqual("Registers an author.");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayOptions/when_resolving_defaults/with_a_module_configured.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayOptions/when_resolving_defaults/with_a_module_configured.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayOptions.when_resolving_defaults;
+
+public class with_a_module_configured : Specification
+{
+    ScreenplayOptions _result;
+
+    void Because() => _result = new ScreenplayOptions { Module = "Lending", SegmentsToSkip = 2 }.WithDefaults("Library");
+
+    [Fact] void should_keep_the_configured_module() => _result.Module.ShouldEqual("Lending");
+    [Fact] void should_keep_the_configured_segments_to_skip() => _result.SegmentsToSkip.ShouldEqual(2);
+    [Fact] void should_still_name_the_domain_after_the_assembly() => _result.Domain.ShouldEqual("Library");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayOptions/when_resolving_defaults/with_nothing_configured.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayOptions/when_resolving_defaults/with_nothing_configured.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayOptions.when_resolving_defaults;
+
+public class with_nothing_configured : Specification
+{
+    ScreenplayOptions _fromAName;
+    ScreenplayOptions _fromNothing;
+
+    void Because()
+    {
+        _fromAName = new ScreenplayOptions().WithDefaults("Library");
+        _fromNothing = new ScreenplayOptions().WithDefaults(null);
+    }
+
+    [Fact] void should_name_the_domain_after_the_assembly() => _fromAName.Domain.ShouldEqual("Library");
+    [Fact] void should_name_the_module_after_the_domain() => _fromAName.Module.ShouldEqual("Library");
+    [Fact] void should_skip_no_segments() => _fromAName.SegmentsToSkip.ShouldEqual(0);
+    [Fact] void should_fall_back_when_there_is_no_assembly_name() => _fromNothing.Domain.ShouldEqual(ScreenplayOptions.DefaultName);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayPrimitiveTypes/when_naming_a_primitive.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayPrimitiveTypes/when_naming_a_primitive.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayPrimitiveTypes;
+
+/// <summary>
+/// Screenplay keeps distinctions the TypeScript proxy type system collapses - <c>Int</c> is not <c>Decimal</c> and
+/// <c>Date</c> is not <c>DateTime</c> - so the leaf map cannot be shared with the proxy generator.
+/// </summary>
+public class when_naming_a_primitive : Specification
+{
+    [Fact] void should_name_a_uuid() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.Uuid).ShouldEqual("Uuid");
+    [Fact] void should_name_a_string() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.String).ShouldEqual("String");
+    [Fact] void should_name_an_int() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.Int).ShouldEqual("Int");
+    [Fact] void should_name_a_decimal() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.Decimal).ShouldEqual("Decimal");
+    [Fact] void should_name_a_bool() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.Bool).ShouldEqual("Bool");
+    [Fact] void should_name_a_date() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.Date).ShouldEqual("Date");
+    [Fact] void should_name_a_date_time() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.DateTime).ShouldEqual("DateTime");
+    [Fact] void should_name_an_enum() => ScreenplayPrimitiveTypes.GetName(ScreenplayPrimitive.Enum).ShouldEqual("Enum");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayPrimitiveTypes/when_resolving_a_framework_type.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayPrimitiveTypes/when_resolving_a_framework_type.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayPrimitiveTypes;
+
+/// <summary>
+/// The map from framework type to primitive is what analysis resolves a concept's backing type with, and it keeps
+/// distinctions that matter to a reader - a whole number is not a fractional one, a date is not a point in time.
+/// </summary>
+public class when_resolving_a_framework_type : Specification
+{
+    [Fact] void should_resolve_a_guid_to_uuid() => Resolve("System.Guid").ShouldEqual(ScreenplayPrimitive.Uuid);
+    [Fact] void should_resolve_a_string_to_string() => Resolve("System.String").ShouldEqual(ScreenplayPrimitive.String);
+    [Fact] void should_resolve_an_int_to_int() => Resolve("System.Int32").ShouldEqual(ScreenplayPrimitive.Int);
+    [Fact] void should_resolve_a_long_to_int() => Resolve("System.Int64").ShouldEqual(ScreenplayPrimitive.Int);
+    [Fact] void should_resolve_a_decimal_to_decimal() => Resolve("System.Decimal").ShouldEqual(ScreenplayPrimitive.Decimal);
+    [Fact] void should_resolve_a_double_to_decimal() => Resolve("System.Double").ShouldEqual(ScreenplayPrimitive.Decimal);
+    [Fact] void should_resolve_a_bool_to_bool() => Resolve("System.Boolean").ShouldEqual(ScreenplayPrimitive.Bool);
+    [Fact] void should_resolve_a_date_only_to_date() => Resolve("System.DateOnly").ShouldEqual(ScreenplayPrimitive.Date);
+    [Fact] void should_resolve_a_date_time_to_date_time() => Resolve("System.DateTime").ShouldEqual(ScreenplayPrimitive.DateTime);
+    [Fact] void should_resolve_a_date_time_offset_to_date_time() => Resolve("System.DateTimeOffset").ShouldEqual(ScreenplayPrimitive.DateTime);
+    [Fact] void should_not_resolve_a_type_of_the_application() => ScreenplayPrimitiveTypes.TryResolve("Library.AuthorId", out _).ShouldBeFalse();
+
+    static ScreenplayPrimitive Resolve(string name)
+    {
+        ScreenplayPrimitiveTypes.TryResolve(name, out var primitive).ShouldBeTrue();
+
+        return primitive;
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceContent/when_checking_a_slice_with_nothing_declared.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceContent/when_checking_a_slice_with_nothing_declared.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Slices;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_SliceContent;
+
+/// <summary>
+/// A read model whose projection could not be expressed, with no query onto it, leaves a slice with nothing to
+/// declare. The header alone is not a valid slice body, so the generator has to drop it.
+/// </summary>
+public class when_checking_a_slice_with_nothing_declared : Specification
+{
+    SliceSyntax _empty;
+    SliceSyntax _withOnlyAnEvent;
+    SliceSyntax _withOnlyADescription;
+
+    void Establish()
+    {
+        _empty = Slice(null);
+        _withOnlyADescription = Slice("Reserves a copy of a book.");
+        _withOnlyAnEvent = _empty with
+        {
+            Events = [new EventSyntax("BookReserved", [], SourceLocation.Start)]
+        };
+    }
+
+    [Fact] void should_report_a_slice_with_nothing_as_empty() => SliceContent.IsEmpty(_empty).ShouldBeTrue();
+    [Fact] void should_not_report_a_slice_with_an_event_as_empty() => SliceContent.IsEmpty(_withOnlyAnEvent).ShouldBeFalse();
+    [Fact] void should_not_report_a_slice_carrying_only_a_description_as_empty() => SliceContent.IsEmpty(_withOnlyADescription).ShouldBeFalse();
+
+    static SliceSyntax Slice(string? description) =>
+        new(SliceType.StateView, "Listing", [], [], [], null, [], [], [], [], [], SourceLocation.Start, description);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/with_a_command.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/with_a_command.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_inferring;
+
+public class with_a_command : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Infer(LibraryAuthors.Registration().Commands, []);
+
+    [Fact] void should_infer_state_change() => _result.ShouldEqual(SliceKind.StateChange);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/with_a_reactor_causing_an_effect.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/with_a_reactor_causing_an_effect.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_inferring;
+
+/// <summary>
+/// A reactor decides the kind of the slice even when the slice also holds a command - what the slice is about is
+/// the reaction, not the intent that happens to live alongside it.
+/// </summary>
+public class with_a_reactor_causing_an_effect : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Infer(
+        LibraryAuthors.Registration().Commands,
+        LibraryLending.Notifications().Reactors);
+
+    [Fact] void should_infer_automation_even_though_there_is_a_command() => _result.ShouldEqual(SliceKind.Automation);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/with_a_reactor_producing_further_events.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/with_a_reactor_producing_further_events.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_inferring;
+
+/// <summary>
+/// A reactor that turns an event into further events or commands is adapting one part of the model into another,
+/// which is what a translation describes rather than an automation.
+/// </summary>
+public class with_a_reactor_producing_further_events : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Infer([], LibraryLending.Restocking().Reactors);
+
+    [Fact] void should_infer_translate() => _result.ShouldEqual(SliceKind.Translate);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/without_commands_or_reactors.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_inferring/without_commands_or_reactors.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_inferring;
+
+public class without_commands_or_reactors : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Infer([], []);
+
+    [Fact] void should_infer_state_view() => _result.ShouldEqual(SliceKind.StateView);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceTreeBuilder/when_building/with_a_deeply_nested_namespace.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceTreeBuilder/when_building/with_a_deeply_nested_namespace.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_SliceTreeBuilder.when_building;
+
+/// <summary>
+/// Features nest to whatever depth the namespaces do, and the last segment is always the slice rather than a feature
+/// wrapping a single slice.
+/// </summary>
+public class with_a_deeply_nested_namespace : Specification
+{
+    ScreenplayEmitter _emitter;
+    ApplicationModel _model;
+    ModuleSyntax _module;
+
+    void Establish()
+    {
+        _emitter = new();
+        _model = LibraryApplication.Build() with
+        {
+            Slices = [LibraryAuthors.Registration() with { Namespace = "Library.Authors.Onboarding.Registration" }]
+        };
+    }
+
+    void Because() => _module = _emitter.Emit(_model, new ScreenplayOptions()).Application.Modules.Single();
+
+    [Fact] void should_nest_the_outer_feature() => _module.Features.Select(_ => _.Name).ShouldContainOnly(["Authors"]);
+    [Fact] void should_nest_the_inner_feature() => _module.Features.Single().Features.Select(_ => _.Name).ShouldContainOnly(["Onboarding"]);
+    [Fact] void should_place_the_slice_in_the_inner_feature() => _module.Features.Single().Features.Single().Slices.Select(_ => _.Name).ShouldContainOnly(["Registration"]);
+    [Fact] void should_not_place_the_slice_in_the_outer_feature() => _module.Features.Single().Slices.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceTreeBuilder/when_building/with_segments_to_skip.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceTreeBuilder/when_building/with_segments_to_skip.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_SliceTreeBuilder.when_building;
+
+/// <summary>
+/// The namespace of a slice usually leads with segments that say nothing about the model - the company, the product,
+/// the assembly. Skipping them is what keeps the feature tree about the domain.
+/// </summary>
+public class with_segments_to_skip : Specification
+{
+    ScreenplayEmitter _emitter;
+    ApplicationModel _model;
+    ModuleSyntax _module;
+
+    void Establish()
+    {
+        _emitter = new();
+        _model = LibraryApplication.Build() with
+        {
+            Slices = [LibraryAuthors.Registration() with { Namespace = "Contoso.Library.Authors.Registration" }]
+        };
+    }
+
+    void Because() => _module = _emitter
+        .Emit(_model, new ScreenplayOptions { SegmentsToSkip = 1 })
+        .Application.Modules.Single();
+
+    [Fact] void should_drop_the_skipped_segment() => _module.Features.Select(_ => _.Name).ShouldContainOnly(["Authors"]);
+    [Fact] void should_keep_the_slice_under_the_feature() => _module.Features.Single().Slices.Select(_ => _.Name).ShouldContainOnly(["Registration"]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_TypeReferenceConverter/given/a_type_reference_converter.cs
+++ b/Source/DotNET/Screenplay.Specs/for_TypeReferenceConverter/given/a_type_reference_converter.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Types;
+
+namespace Cratis.Arc.Screenplay.for_TypeReferenceConverter.given;
+
+public class a_type_reference_converter : Specification
+{
+    protected TypeReferenceConverter _converter;
+
+    void Establish() => _converter = new(new ScreenplayNaming());
+}

--- a/Source/DotNET/Screenplay.Specs/for_TypeReferenceConverter/when_converting/a_reference_with_modifiers.cs
+++ b/Source/DotNET/Screenplay.Specs/for_TypeReferenceConverter/when_converting/a_reference_with_modifiers.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.for_TypeReferenceConverter.when_converting;
+
+/// <summary>
+/// A concept keeps its own name rather than being reduced to the primitive behind it, because the concept is
+/// declared once at the top of the document and referenced by name from there on.
+/// </summary>
+public class a_reference_with_modifiers : given.a_type_reference_converter
+{
+    TypeRefSyntax _concept;
+    TypeRefSyntax _optional;
+    TypeRefSyntax _collection;
+    TypeRefSyntax _unnamed;
+
+    void Because()
+    {
+        _concept = _converter.Convert(new TypeReferenceModel("AuthorId", false, false));
+        _optional = _converter.Convert(new TypeReferenceModel("Int", false, true));
+        _collection = _converter.Convert(new TypeReferenceModel("AuthorName", true, false));
+        _unnamed = _converter.Convert(new TypeReferenceModel(string.Empty, false, false));
+    }
+
+    [Fact] void should_name_a_concept_after_the_concept() => _concept.Name.ShouldEqual("AuthorId");
+    [Fact] void should_not_mark_a_plain_reference_as_optional() => _concept.IsOptional.ShouldBeFalse();
+    [Fact] void should_not_mark_a_plain_reference_as_a_collection() => _concept.IsCollection.ShouldBeFalse();
+    [Fact] void should_keep_a_primitive_name() => _optional.Name.ShouldEqual("Int");
+    [Fact] void should_mark_an_optional_reference_as_optional() => _optional.IsOptional.ShouldBeTrue();
+    [Fact] void should_keep_the_element_name_of_a_collection() => _collection.Name.ShouldEqual("AuthorName");
+    [Fact] void should_mark_a_collection_as_a_collection() => _collection.IsCollection.ShouldBeTrue();
+    [Fact] void should_fall_back_for_a_reference_with_no_name() => _unnamed.Name.ShouldEqual("String");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/given/a_validation_syntax_builder.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/given/a_validation_syntax_builder.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Validation;
+
+namespace Cratis.Arc.Screenplay.for_ValidationSyntaxBuilder.given;
+
+public class a_validation_syntax_builder : Specification
+{
+    protected ValidationSyntaxBuilder _builder;
+    protected ScreenplayDiagnostics _diagnostics;
+
+    void Establish()
+    {
+        _diagnostics = new();
+        _builder = new(new ScreenplayNaming(), _diagnostics);
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/when_building/a_rule_missing_the_operand_it_needs.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/when_building/a_rule_missing_the_operand_it_needs.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Syntax;
+using ModelRuleKind = Cratis.Arc.Screenplay.Model.ValidationRuleKind;
+
+namespace Cratis.Arc.Screenplay.for_ValidationSyntaxBuilder.when_building;
+
+/// <summary>
+/// A comparison with nothing to compare against prints an operator with no operand, which does not parse. It is left
+/// out and reported rather than emitted as something that breaks the document.
+/// </summary>
+public class a_rule_missing_the_operand_it_needs : given.a_validation_syntax_builder
+{
+    IEnumerable<ValidateSyntax> _blocks;
+
+    void Because() => _blocks = _builder.Build(
+        [new("Count", ModelRuleKind.GreaterThan, null, null)],
+        "Library.Inventory.Adding");
+
+    [Fact] void should_leave_the_rule_out() => _blocks.ShouldBeEmpty();
+    [Fact] void should_report_the_rule() => _diagnostics.All.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.ValidationRuleWithoutOperand]);
+    [Fact] void should_locate_the_report_where_the_rule_was_declared() => _diagnostics.All.Single().Location.ShouldEqual("Library.Inventory.Adding");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/when_building/rules_carrying_operands_and_messages.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/when_building/rules_carrying_operands_and_messages.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Syntax;
+using ModelRuleKind = Cratis.Arc.Screenplay.Model.ValidationRuleKind;
+using SyntaxRuleKind = Cratis.Screenplay.Syntax.ValidationRuleKind;
+
+namespace Cratis.Arc.Screenplay.for_ValidationSyntaxBuilder.when_building;
+
+/// <summary>
+/// A message starting with the localization prefix is a key into the companion strings file and is written
+/// unquoted, while a named pattern such as <c>email</c> is written as a bare word rather than as a string.
+/// </summary>
+public class rules_carrying_operands_and_messages : given.a_validation_syntax_builder
+{
+    IEnumerable<ValidationRuleSyntax> _rules;
+
+    void Because() => _rules = _builder
+        .Build(
+            [
+                new("Name", ModelRuleKind.NotEmpty, null, "A name is required"),
+                new("Name", ModelRuleKind.Max, 100, "$strings.authors.nameTooLong"),
+                new("Contact.Email", ModelRuleKind.Matches, "email", null),
+                new("Reference", ModelRuleKind.Matches, @"^INV-\d+$", null)
+            ],
+            "Library.Authors.Registration")
+        .OfType<DeclarativeValidateSyntax>()
+        .SelectMany(_ => _.Rules);
+
+    [Fact] void should_build_every_rule() => _rules.Count().ShouldEqual(4);
+    [Fact] void should_camel_case_a_nested_property_path() => _rules.ElementAt(2).Property.ShouldEqual("contact.email");
+    [Fact] void should_leave_a_rule_without_an_operand_without_one() => _rules.ElementAt(0).Value.ShouldBeNull();
+    [Fact] void should_convert_a_numeric_operand_to_a_double() => ((LiteralExpressionSyntax)_rules.ElementAt(1).Value!).Value.ShouldBeOfExactType<double>();
+    [Fact] void should_keep_a_localization_key_unquoted() => _rules.ElementAt(1).Message.ShouldEqual("$strings.authors.nameTooLong");
+    [Fact] void should_write_a_named_pattern_as_a_bare_word() => _rules.ElementAt(2).Value.ShouldBeOfExactType<PathExpressionSyntax>();
+    [Fact] void should_write_a_regular_expression_as_a_literal() => _rules.ElementAt(3).Value.ShouldBeOfExactType<LiteralExpressionSyntax>();
+    [Fact] void should_map_the_kind_of_every_rule() => _rules.Select(_ => _.Rule).ShouldEqual([SyntaxRuleKind.NotEmpty, SyntaxRuleKind.Max, SyntaxRuleKind.Matches, SyntaxRuleKind.Matches]);
+    [Fact] void should_report_nothing() => _diagnostics.All.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/when_building/rules_for_a_concept.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ValidationSyntaxBuilder/when_building/rules_for_a_concept.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Syntax;
+using ModelRuleKind = Cratis.Arc.Screenplay.Model.ValidationRuleKind;
+
+namespace Cratis.Arc.Screenplay.for_ValidationSyntaxBuilder.when_building;
+
+/// <summary>
+/// Rules inside a concept declaration carry no property name - the concept's own value is the implied subject - so
+/// whatever member the rule was declared on is irrelevant to the document.
+/// </summary>
+public class rules_for_a_concept : given.a_validation_syntax_builder
+{
+    IEnumerable<ValidationRuleSyntax> _rules;
+
+    void Because() => _rules = _builder
+        .Build(
+            [
+                new("Value", ModelRuleKind.NotEmpty, null, null),
+                new("SomethingElse", ModelRuleKind.Max, 200, null)
+            ],
+            "AuthorName",
+            impliedSubject: true)
+        .OfType<DeclarativeValidateSyntax>()
+        .SelectMany(_ => _.Rules);
+
+    [Fact] void should_leave_the_subject_of_every_rule_implied() => _rules.Select(_ => _.Property).Distinct().ShouldContainOnly([ValidationRuleSyntax.ConceptValue]);
+    [Fact] void should_keep_every_rule() => _rules.Count().ShouldEqual(2);
+}

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootBehaviors.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootBehaviors.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Aggregates;
+
+/// <summary>
+/// Finds the behaviors of an aggregate root that a command handler hands its work to.
+/// </summary>
+/// <remarks>
+/// A command that governs its change through an aggregate root constructs no event itself - the aggregate root does,
+/// from inside the behavior the handler called. Reading that behavior's body is what turns the command from one that
+/// appears to produce nothing into one that states exactly what it produces, so the two ways of writing an Arc
+/// command describe the same thing in the document.
+/// <para>
+/// Only the behaviors the handler calls directly are followed. A behavior calling another is code deciding for
+/// itself, and following it would state a production the handler never asked for.
+/// </para>
+/// </remarks>
+public static class AggregateRootBehaviors
+{
+    /// <summary>
+    /// Finds the behaviors a handler body reaches.
+    /// </summary>
+    /// <param name="body">The body of the handler.</param>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <returns>The behaviors, in the order the handler calls them.</returns>
+    public static IEnumerable<AggregateRootInvocation> ReachedFrom(SyntaxNode body, Compilation compilation)
+    {
+        var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
+        var reached = new List<AggregateRootInvocation>();
+
+        foreach (var call in body.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (semanticModel.GetSymbolInfo(call).Symbol is not IMethodSymbol { MethodKind: MethodKind.Ordinary } method ||
+                !AggregateRoots.IsDeclaredByApplication(method.ContainingType))
+            {
+                continue;
+            }
+
+            reached.AddRange(HandlerBodies.Of(method).Select(declaration =>
+                new AggregateRootInvocation(
+                    method.ContainingType,
+                    declaration,
+                    ParameterBindings.For(method, call, semanticModel))));
+        }
+
+        return reached;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootCatalog.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Aggregates;
+
+/// <summary>
+/// Keeps track of every aggregate root the application declares and of which of them a command reaches.
+/// </summary>
+/// <remarks>
+/// What an aggregate root applies is stated through the command that calls it, so an aggregate root nothing calls is
+/// the only one whose events go unstated. Reporting is therefore left until every command has been read, rather than
+/// reporting each aggregate root the moment it is found.
+/// </remarks>
+public class AggregateRootCatalog
+{
+    readonly List<(INamedTypeSymbol Type, string Namespace)> _declared = [];
+    readonly HashSet<INamedTypeSymbol> _reached = new(SymbolEqualityComparer.Default);
+
+    /// <summary>
+    /// Records an aggregate root the application declares.
+    /// </summary>
+    /// <param name="type">The type declaring it.</param>
+    /// <param name="namespace">The namespace it lives in.</param>
+    public void Declare(INamedTypeSymbol type, string @namespace)
+    {
+        if (!_declared.Exists(declared => SymbolEqualityComparer.Default.Equals(declared.Type, type)))
+        {
+            _declared.Add((type, @namespace));
+        }
+    }
+
+    /// <summary>
+    /// Records that a command handler reached an aggregate root.
+    /// </summary>
+    /// <param name="type">The aggregate root that was reached.</param>
+    public void Reached(INamedTypeSymbol type) => _reached.Add(type);
+
+    /// <summary>
+    /// Reports every aggregate root whose events no command states.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    public void Report(ScreenplayDiagnostics diagnostics)
+    {
+        foreach (var (type, @namespace) in _declared.Where(declared => !_reached.Contains(declared.Type)))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.AggregateRootWithoutCounterpart,
+                $"'{type.Name}' is an aggregate root that no command in the compilation hands its work to, so the events it applies are not stated as produced by anything",
+                @namespace);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootInvocation.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootInvocation.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Aggregates;
+
+/// <summary>
+/// Represents one behavior of an aggregate root, reached from the handler of a command.
+/// </summary>
+/// <param name="AggregateRoot">The aggregate root declaring the behavior.</param>
+/// <param name="Body">The body of the behavior.</param>
+/// <param name="Bindings">What the handler gave the behavior's parameters.</param>
+public record AggregateRootInvocation(
+    INamedTypeSymbol AggregateRoot,
+    SyntaxNode Body,
+    ParameterBindings Bindings);

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRoots.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRoots.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Aggregates;
+
+/// <summary>
+/// Recognizes the types that govern a state change from inside a class.
+/// </summary>
+public static class AggregateRoots
+{
+    /// <summary>
+    /// Determines whether a type is an aggregate root.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is an aggregate root.</returns>
+    public static bool Is(ITypeSymbol? type) =>
+        type.FindBase(WellKnownTypeNames.AggregateRoot) is not null ||
+        type.FindInterface(WellKnownTypeNames.AggregateRootInterface) is not null;
+
+    /// <summary>
+    /// Determines whether a type declares behavior of its own rather than being the framework's own base type.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is an aggregate root an application wrote.</returns>
+    /// <remarks>
+    /// The base type declares <c>Apply</c> and <c>Commit</c>, which are how a state change is carried out rather than
+    /// what it is. Only what the application declares on top of them says anything about the application.
+    /// </remarks>
+    public static bool IsDeclaredByApplication(ITypeSymbol? type) =>
+        type is { TypeKind: TypeKind.Class } && Is(type) && !type.Is(WellKnownTypeNames.AggregateRoot);
+}

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateState.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateState.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Aggregates;
+
+/// <summary>
+/// Recognizes an expression that reads the state an aggregate root holds.
+/// </summary>
+/// <remarks>
+/// A condition in a document compares the input of a command, and nothing else exists to compare. An aggregate root
+/// deciding on what it has already seen is therefore a decision no <c>produces when</c> can carry - not because it
+/// was read badly, but because the language has nowhere to put it. Telling that case apart from an expression that
+/// simply could not be read is what makes the difference reportable.
+/// </remarks>
+public static class AggregateState
+{
+    /// <summary>
+    /// Determines whether an expression reads the state of an aggregate root.
+    /// </summary>
+    /// <param name="expression">The expression to check.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="aggregateRoot">The aggregate root declaring the body, if there is one.</param>
+    /// <returns>True when the expression reads state the aggregate root holds.</returns>
+    public static bool IsReadBy(ExpressionSyntax expression, SemanticModel semanticModel, INamedTypeSymbol? aggregateRoot) =>
+        aggregateRoot is not null &&
+        expression
+            .DescendantNodesAndSelf()
+            .OfType<SimpleNameSyntax>()
+            .Any(_ => IsState(semanticModel.GetSymbolInfo(_).Symbol, aggregateRoot));
+
+    /// <summary>
+    /// Determines whether a symbol is state an aggregate root holds.
+    /// </summary>
+    /// <param name="symbol">The symbol to check.</param>
+    /// <param name="aggregateRoot">The aggregate root to check against.</param>
+    /// <returns>True when the symbol is state of the aggregate root.</returns>
+    static bool IsState(ISymbol? symbol, INamedTypeSymbol aggregateRoot) =>
+        symbol is IFieldSymbol or IPropertySymbol &&
+        !symbol.IsStatic &&
+        IsHeldBy(aggregateRoot, symbol.ContainingType);
+
+    /// <summary>
+    /// Determines whether an aggregate root holds the members a type declares, including the ones it inherits.
+    /// </summary>
+    /// <param name="aggregateRoot">The aggregate root to walk.</param>
+    /// <param name="declaring">The type declaring the member.</param>
+    /// <returns>True when the aggregate root holds them.</returns>
+    static bool IsHeldBy(INamedTypeSymbol aggregateRoot, INamedTypeSymbol? declaring)
+    {
+        for (var current = aggregateRoot; current is not null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, declaring))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/BoundArgument.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/BoundArgument.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Aggregates;
+
+/// <summary>
+/// Represents the expression a parameter was given at the call site it was reached through.
+/// </summary>
+/// <param name="Expression">The expression the caller handed over.</param>
+/// <param name="SemanticModel">The semantic model of the tree the expression lives in.</param>
+/// <remarks>
+/// The expression belongs to the caller's tree, which is not necessarily the tree the parameter is used in, so the
+/// model that can make sense of it travels with it.
+/// </remarks>
+public record BoundArgument(ExpressionSyntax Expression, SemanticModel SemanticModel);

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/ParameterBindings.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/ParameterBindings.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Aggregates;
+
+/// <summary>
+/// Holds what each parameter of a method was given at the call site it was reached through.
+/// </summary>
+/// <remarks>
+/// A command that hands its work to an aggregate root passes its own input along, and the aggregate root names that
+/// input whatever it likes. Without the substitution the call site declares, every value inside the aggregate root
+/// would look like code rather than like the command input it really is.
+/// </remarks>
+public sealed class ParameterBindings
+{
+    readonly Dictionary<ISymbol, BoundArgument> _bound;
+
+    ParameterBindings(Dictionary<ISymbol, BoundArgument> bound) => _bound = bound;
+
+    /// <summary>
+    /// Binds the parameters of a method to what one call site gave them.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <param name="call">The call site.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call site lives in.</param>
+    /// <returns>The <see cref="ParameterBindings"/>.</returns>
+    public static ParameterBindings For(IMethodSymbol method, InvocationExpressionSyntax call, SemanticModel semanticModel)
+    {
+        var bound = new Dictionary<ISymbol, BoundArgument>(SymbolEqualityComparer.Default);
+        var arguments = call.ArgumentList.Arguments;
+
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            if (ParameterOf(method, arguments[index], index) is { } parameter)
+            {
+                bound[parameter] = new(arguments[index].Expression, semanticModel);
+            }
+        }
+
+        return new(bound);
+    }
+
+    /// <summary>
+    /// Resolves what an expression was given, when it names a bound parameter and nothing else.
+    /// </summary>
+    /// <param name="expression">The expression to resolve.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <returns>The binding, or <see langword="null"/> when the expression names no bound parameter.</returns>
+    public BoundArgument? Resolve(ExpressionSyntax expression, SemanticModel semanticModel) =>
+        expression is IdentifierNameSyntax identifier &&
+        semanticModel.GetSymbolInfo(identifier).Symbol is IParameterSymbol parameter &&
+        _bound.TryGetValue(parameter, out var argument)
+            ? argument
+            : null;
+
+    /// <summary>
+    /// Gets the parameter an argument fills in.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <param name="argument">The argument.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The parameter, or <see langword="null"/> when it cannot be resolved.</returns>
+    static IParameterSymbol? ParameterOf(IMethodSymbol method, ArgumentSyntax argument, int index)
+    {
+        if (argument.NameColon is { } named)
+        {
+            return method.Parameters.FirstOrDefault(_ => string.Equals(_.Name, named.Name.Identifier.ValueText, StringComparison.Ordinal));
+        }
+
+        return index < method.Parameters.Length ? method.Parameters[index] : null;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalysis.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalysis.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Represents the outcome of analyzing a compilation.
+/// </summary>
+/// <param name="Model">The model recovered from the source.</param>
+/// <param name="Diagnostics">Everything the source declared that could not be recovered.</param>
+public record ApplicationModelAnalysis(ApplicationModel Model, IReadOnlyList<ScreenplayDiagnostic> Diagnostics)
+{
+    /// <summary>
+    /// Creates an analysis carrying a model and nothing to report.
+    /// </summary>
+    /// <param name="model">The model recovered from the source.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    public static ApplicationModelAnalysis For(ApplicationModel model) => new(model, []);
+}

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Policies;
+using Cratis.Arc.Screenplay.Analysis.Screens;
 using Cratis.Arc.Screenplay.Analysis.Slices;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
@@ -10,12 +12,27 @@ namespace Cratis.Arc.Screenplay.Analysis;
 /// <summary>
 /// Represents an <see cref="IApplicationModelAnalyzer"/> that recovers the model from the source of an application.
 /// </summary>
+/// <param name="userInterfaceFiles">The <see cref="IUserInterfaceFiles"/> the screens of a slice are found through.</param>
 /// <remarks>
 /// Namespaces are read in order and everything within a slice is ordered explicitly, so the same compilation always
 /// yields the same model - which is what makes the document it produces something worth committing.
 /// </remarks>
-public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
+public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : IApplicationModelAnalyzer
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationModelAnalyzer"/> class reading the file system the
+    /// source was built from.
+    /// </summary>
+    /// <remarks>
+    /// A compilation answers for everything but the file realizing a screen, which is why that one question is
+    /// asked of a collaborator. This is the single place the answer comes from a real disk, so a host that wants a
+    /// compilation analyzed without one substitutes it and everything else stays as it is.
+    /// </remarks>
+    public ApplicationModelAnalyzer()
+        : this(new UserInterfaceFiles())
+    {
+    }
+
     /// <inheritdoc/>
     public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options)
     {
@@ -23,7 +40,8 @@ public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
         var failedToCompile = ReportCompilationErrors(compilation, diagnostics);
         var catalog = ArtifactCatalog.From(compilation);
         var readers = ArtifactReaders.For(compilation, catalog, diagnostics);
-        var reader = new SliceReader(readers, diagnostics);
+        var screens = new ScreenReader(userInterfaceFiles, SourcePaths.For(compilation), new(diagnostics));
+        var reader = new SliceReader(readers, diagnostics, screens);
 
         var slices = catalog.Namespaces
             .Select(@namespace => reader.Read(@namespace, catalog.In(@namespace)))
@@ -31,6 +49,7 @@ public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
             .ToList();
 
         ConceptValidations.Link(catalog, readers);
+        readers.AggregateRoots.Report(diagnostics);
         ReportEventsFromOutside(slices, diagnostics);
         ReportNamespacesWithoutStructure(slices, diagnostics, options.SegmentsToSkip ?? 0);
 
@@ -47,7 +66,7 @@ public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
                 options.Domain ?? compilation.AssemblyName ?? ScreenplayOptions.DefaultName,
                 options.Module ?? options.Domain ?? ScreenplayOptions.DefaultName,
                 readers.Types.Concepts,
-                Policies(slices),
+                new PolicyCatalog(compilation, diagnostics).Declare(slices.SelectMany(AuthorizationsIn)),
                 slices),
             diagnostics.All);
     }
@@ -80,21 +99,6 @@ public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
 
         return true;
     }
-
-    /// <summary>
-    /// Declares a policy for every role the application names.
-    /// </summary>
-    /// <param name="slices">The slices to read.</param>
-    /// <returns>The policies, ordered by name.</returns>
-    static IEnumerable<PolicyModel> Policies(IEnumerable<SliceModel> slices) =>
-    [
-        .. slices
-            .SelectMany(AuthorizationsIn)
-            .SelectMany(_ => _.Roles)
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-            .Select(_ => new PolicyModel(_, true, _))
-    ];
 
     /// <summary>
     /// Gets everything within a slice that requires something of the caller.

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -40,7 +40,12 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
         var failedToCompile = ReportCompilationErrors(compilation, diagnostics);
         var catalog = ArtifactCatalog.From(compilation);
         var readers = ArtifactReaders.For(compilation, catalog, diagnostics);
-        var screens = new ScreenReader(userInterfaceFiles, SourcePaths.For(compilation), new(diagnostics));
+        var screens = new ScreenReader(
+            userInterfaceFiles,
+            SourcePaths.For(compilation, catalog),
+            new(diagnostics),
+            new(userInterfaceFiles, diagnostics));
+
         var reader = new SliceReader(readers, diagnostics, screens);
 
         var slices = catalog.Namespaces
@@ -50,6 +55,7 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
 
         ConceptValidations.Link(catalog, readers);
         readers.AggregateRoots.Report(diagnostics);
+        ReportTypesTheDocumentCannotName(readers, diagnostics, compilation.AssemblyName);
         ReportEventsFromOutside(slices, diagnostics);
         ReportNamespacesWithoutStructure(slices, diagnostics, options.SegmentsToSkip ?? 0);
 
@@ -107,6 +113,36 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
     /// <returns>The authorizations.</returns>
     static IEnumerable<AuthorizationModel> AuthorizationsIn(SliceModel slice) =>
         slice.Commands.Select(_ => _.Authorization).Concat(slice.Queries.Select(_ => _.Authorization)).OfType<AuthorizationModel>();
+
+    /// <summary>
+    /// Reports every type the document had to refer to by a name that does not say what it is.
+    /// </summary>
+    /// <param name="readers">The readers holding the types encountered.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <param name="location">Where to report against.</param>
+    /// <remarks>
+    /// A Screenplay type reference is a single identifier, so a type the grammar cannot hold is written as whatever
+    /// of its name survives - and the property then claims a type nothing declares. Saying which types those were is
+    /// the difference between a document with a known gap and a document that is quietly wrong.
+    /// </remarks>
+    static void ReportTypesTheDocumentCannotName(ArtifactReaders readers, ScreenplayDiagnostics diagnostics, string? location)
+    {
+        foreach (var type in readers.Types.Unmappable)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableTypeReference,
+                $"'{type}' has no Screenplay counterpart, so it is referred to by a name the document never declares",
+                location);
+        }
+
+        foreach (var type in readers.Types.Ambiguous)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.AmbiguousConceptName,
+                $"'{type}' shares its simple name with a concept the document already declares, so what it is is described by the first one instead",
+                location);
+        }
+    }
 
     /// <summary>
     /// Reports every event the application refers to but does not declare.

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Slices;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Represents an <see cref="IApplicationModelAnalyzer"/> that recovers the model from the source of an application.
+/// </summary>
+/// <remarks>
+/// Namespaces are read in order and everything within a slice is ordered explicitly, so the same compilation always
+/// yields the same model - which is what makes the document it produces something worth committing.
+/// </remarks>
+public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
+{
+    /// <inheritdoc/>
+    public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options)
+    {
+        var diagnostics = new ScreenplayDiagnostics();
+        var catalog = ArtifactCatalog.From(compilation);
+        var readers = ArtifactReaders.For(compilation, catalog, diagnostics);
+        var reader = new SliceReader(readers, diagnostics);
+
+        var slices = catalog.Namespaces
+            .Select(@namespace => reader.Read(@namespace, catalog.In(@namespace)))
+            .OfType<SliceModel>()
+            .ToList();
+
+        ConceptValidations.Link(catalog, readers);
+        ReportEventsFromOutside(slices, diagnostics);
+        ReportNamespacesWithoutStructure(slices, diagnostics, options.SegmentsToSkip ?? 0);
+
+        if (slices.Count == 0)
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.AnalysisUnavailable,
+                "The source declares nothing that can be expressed, so the generated document describes nothing",
+                compilation.AssemblyName);
+        }
+
+        return new(
+            new ApplicationModel(
+                options.Domain ?? compilation.AssemblyName ?? ScreenplayOptions.DefaultName,
+                options.Module ?? options.Domain ?? ScreenplayOptions.DefaultName,
+                readers.Types.Concepts,
+                Policies(slices),
+                slices),
+            diagnostics.All);
+    }
+
+    /// <summary>
+    /// Declares a policy for every role the application names.
+    /// </summary>
+    /// <param name="slices">The slices to read.</param>
+    /// <returns>The policies, ordered by name.</returns>
+    static IEnumerable<PolicyModel> Policies(IEnumerable<SliceModel> slices) =>
+    [
+        .. slices
+            .SelectMany(AuthorizationsIn)
+            .SelectMany(_ => _.Roles)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .Select(_ => new PolicyModel(_, true, _))
+    ];
+
+    /// <summary>
+    /// Gets everything within a slice that requires something of the caller.
+    /// </summary>
+    /// <param name="slice">The slice to read.</param>
+    /// <returns>The authorizations.</returns>
+    static IEnumerable<AuthorizationModel> AuthorizationsIn(SliceModel slice) =>
+        slice.Commands.Select(_ => _.Authorization).Concat(slice.Queries.Select(_ => _.Authorization)).OfType<AuthorizationModel>();
+
+    /// <summary>
+    /// Reports every event the application refers to but does not declare.
+    /// </summary>
+    /// <param name="slices">The slices to check.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <remarks>
+    /// An event living in a referenced package is real, but nothing in the compilation declares it, so the document
+    /// would refer to something it never introduces. Saying so is better than inventing a declaration for it.
+    /// </remarks>
+    static void ReportEventsFromOutside(IReadOnlyList<SliceModel> slices, ScreenplayDiagnostics diagnostics)
+    {
+        var declared = slices.SelectMany(_ => _.Events).Select(_ => _.Name).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var slice in slices)
+        {
+            foreach (var name in ReferencedEvents(slice).Where(_ => !declared.Contains(_)).Order(StringComparer.Ordinal))
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.EventDeclaredOutsideCompilation,
+                    $"'{name}' is referred to but declared outside the compilation, so the document refers to an event it never introduces",
+                    slice.Namespace);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reports a namespace that carries nothing to arrange the document by.
+    /// </summary>
+    /// <param name="slices">The slices to check.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments being skipped.</param>
+    /// <remarks>
+    /// Artifacts sitting in the root namespace leave the module, the feature and the slice with nothing to be named
+    /// after but the assembly, so all of them end up saying the same word. Naming them anything else would be
+    /// fiction - the source really does say nothing about where they belong - so this says what would fix it
+    /// instead, which is either a namespace per slice or a leading segment skipped.
+    /// </remarks>
+    static void ReportNamespacesWithoutStructure(
+        IEnumerable<SliceModel> slices,
+        ScreenplayDiagnostics diagnostics,
+        int segmentsToSkip)
+    {
+        foreach (var slice in slices.Where(_ => Segments(_.Namespace, segmentsToSkip) <= 1))
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.NamespaceWithoutStructure,
+                "The namespace carries no feature or slice to arrange by, so the module, the feature and the slice all take the same name - give the slice a namespace of its own, or skip a leading segment",
+                slice.Namespace);
+        }
+    }
+
+    /// <summary>
+    /// Counts the namespace segments left to arrange a slice by.
+    /// </summary>
+    /// <param name="namespace">The namespace to count.</param>
+    /// <param name="segmentsToSkip">The number of leading segments being skipped.</param>
+    /// <returns>The number of segments.</returns>
+    static int Segments(string @namespace, int segmentsToSkip) =>
+        @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries).Length - segmentsToSkip;
+
+    /// <summary>
+    /// Gets the names of every event a slice refers to.
+    /// </summary>
+    /// <param name="slice">The slice to read.</param>
+    /// <returns>The names, distinct.</returns>
+    static IEnumerable<string> ReferencedEvents(SliceModel slice) =>
+        slice.Commands.SelectMany(_ => _.Produces).Select(_ => _.EventName)
+            .Concat(slice.Reactors.SelectMany(_ => _.ObservedEvents))
+            .Concat(slice.Constraints.SelectMany(EventsOf))
+            .Concat(ProjectionEvents.In(slice.Projection))
+            .Distinct(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the names of the events a constraint refers to.
+    /// </summary>
+    /// <param name="constraint">The constraint to read.</param>
+    /// <returns>The names.</returns>
+    static IEnumerable<string> EventsOf(ConstraintModel constraint) => constraint switch
+    {
+        UniquePropertyConstraintModel unique => [unique.EventName],
+        UniqueEventConstraintModel unique => [unique.EventName],
+        _ => []
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -20,6 +20,7 @@ public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
     public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options)
     {
         var diagnostics = new ScreenplayDiagnostics();
+        var failedToCompile = ReportCompilationErrors(compilation, diagnostics);
         var catalog = ArtifactCatalog.From(compilation);
         var readers = ArtifactReaders.For(compilation, catalog, diagnostics);
         var reader = new SliceReader(readers, diagnostics);
@@ -33,7 +34,7 @@ public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
         ReportEventsFromOutside(slices, diagnostics);
         ReportNamespacesWithoutStructure(slices, diagnostics, options.SegmentsToSkip ?? 0);
 
-        if (slices.Count == 0)
+        if (slices.Count == 0 && !failedToCompile)
         {
             diagnostics.Information(
                 ScreenplayDiagnosticCodes.AnalysisUnavailable,
@@ -49,6 +50,35 @@ public class ApplicationModelAnalyzer : IApplicationModelAnalyzer
                 Policies(slices),
                 slices),
             diagnostics.All);
+    }
+
+    /// <summary>
+    /// Reports source that did not compile, which nothing recovered from it can be relied on past.
+    /// </summary>
+    /// <param name="compilation">The compilation to check.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>True when the source did not compile.</returns>
+    /// <remarks>
+    /// A compilation that does not build still yields symbols, and analyzing them produces a document that looks
+    /// like an answer while describing an application that does not exist. Reporting it as an error rather than a
+    /// warning is what makes a host exit non zero, because a nearly empty document and a success code is the one
+    /// outcome nobody can act on. The model is still returned - what was recovered is worth seeing, as long as
+    /// nobody is told it is trustworthy.
+    /// </remarks>
+    static bool ReportCompilationErrors(Compilation compilation, ScreenplayDiagnostics diagnostics)
+    {
+        var errors = compilation.GetDiagnostics().Where(_ => _.Severity == DiagnosticSeverity.Error).ToList();
+        if (errors.Count == 0)
+        {
+            return false;
+        }
+
+        diagnostics.Error(
+            ScreenplayDiagnosticCodes.SourceDidNotCompile,
+            $"The source did not compile - {errors.Count} error(s), the first being '{errors[0].GetMessage(System.Globalization.CultureInfo.InvariantCulture)}'. Nothing recovered from it describes the application reliably",
+            compilation.AssemblyName);
+
+        return true;
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/ArtifactCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactCatalog.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Holds every type the compilation declares, in a deterministic order and grouped by namespace.
+/// </summary>
+/// <remarks>
+/// Only the types the compilation itself declares are catalogued. Artifacts living in a referenced package have
+/// metadata but no body, so they are read on demand from where they are referenced rather than discovered here.
+/// </remarks>
+public class ArtifactCatalog
+{
+    readonly List<INamedTypeSymbol> _types;
+
+    ArtifactCatalog(List<INamedTypeSymbol> types) => _types = types;
+
+    /// <summary>
+    /// Gets every declared type, ordered by fully qualified name.
+    /// </summary>
+    public IReadOnlyList<INamedTypeSymbol> Types => _types;
+
+    /// <summary>
+    /// Gets the namespaces holding at least one type, ordered.
+    /// </summary>
+    public IEnumerable<string> Namespaces => _types
+        .Select(_ => _.Namespace())
+        .Distinct(StringComparer.Ordinal)
+        .Order(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Catalogues everything a compilation declares.
+    /// </summary>
+    /// <param name="compilation">The compilation to catalogue.</param>
+    /// <returns>The <see cref="ArtifactCatalog"/>.</returns>
+    public static ArtifactCatalog From(Compilation compilation)
+    {
+        var types = new List<INamedTypeSymbol>();
+        Collect(compilation.Assembly.GlobalNamespace, types);
+
+        return new([.. types.OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal)]);
+    }
+
+    /// <summary>
+    /// Gets the types declared within a namespace.
+    /// </summary>
+    /// <param name="namespace">The namespace to read.</param>
+    /// <returns>The types, ordered by name.</returns>
+    public IEnumerable<INamedTypeSymbol> In(string @namespace) =>
+        _types.Where(_ => string.Equals(_.Namespace(), @namespace, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Collects every type declared within a namespace, including nested types.
+    /// </summary>
+    /// <param name="namespace">The namespace to walk.</param>
+    /// <param name="types">The types collected so far.</param>
+    static void Collect(INamespaceSymbol @namespace, List<INamedTypeSymbol> types)
+    {
+        foreach (var member in @namespace.GetMembers())
+        {
+            switch (member)
+            {
+                case INamespaceSymbol nested:
+                    Collect(nested, types);
+                    break;
+                case INamedTypeSymbol type:
+                    Collect(type, types);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Collects a type and everything nested within it.
+    /// </summary>
+    /// <param name="type">The type to collect.</param>
+    /// <param name="types">The types collected so far.</param>
+    static void Collect(INamedTypeSymbol type, List<INamedTypeSymbol> types)
+    {
+        types.Add(type);
+
+        foreach (var nested in type.GetTypeMembers())
+        {
+            Collect(nested, types);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Analysis.Constraints;
+using Cratis.Arc.Screenplay.Analysis.Controllers;
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Cratis.Arc.Screenplay.Analysis.Projections;
+using Cratis.Arc.Screenplay.Analysis.Queries;
+using Cratis.Arc.Screenplay.Analysis.Reactors;
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Composes every reader a slice needs, so that a slice reader takes one collaborator rather than nine.
+/// </summary>
+public class ArtifactReaders
+{
+    ArtifactReaders(
+        TypeRegistry types,
+        ValidatorCatalog validators,
+        EventReader events,
+        CommandReader commands,
+        ControllerCommandReader controllerCommands,
+        QueryReader queries,
+        ModelBoundProjectionReader modelBoundProjections,
+        FluentProjectionReader fluentProjections,
+        ReducerReader reducers,
+        ReactorReader reactors,
+        ConstraintReader constraints)
+    {
+        Types = types;
+        Validators = validators;
+        Events = events;
+        Commands = commands;
+        ControllerCommands = controllerCommands;
+        Queries = queries;
+        ModelBoundProjections = modelBoundProjections;
+        FluentProjections = fluentProjections;
+        Reducers = reducers;
+        Reactors = reactors;
+        Constraints = constraints;
+    }
+
+    /// <summary>Gets the registry collecting the concepts every artifact refers to.</summary>
+    public TypeRegistry Types { get; }
+
+    /// <summary>Gets the rules every validator in the compilation declares.</summary>
+    public ValidatorCatalog Validators { get; }
+
+    /// <summary>Gets the reader for events.</summary>
+    public EventReader Events { get; }
+
+    /// <summary>Gets the reader for model-bound commands.</summary>
+    public CommandReader Commands { get; }
+
+    /// <summary>Gets the reader for commands exposed by a controller.</summary>
+    public ControllerCommandReader ControllerCommands { get; }
+
+    /// <summary>Gets the reader for queries.</summary>
+    public QueryReader Queries { get; }
+
+    /// <summary>Gets the reader for projections declared with attributes.</summary>
+    public ModelBoundProjectionReader ModelBoundProjections { get; }
+
+    /// <summary>Gets the reader for projections defined against a builder.</summary>
+    public FluentProjectionReader FluentProjections { get; }
+
+    /// <summary>Gets the reader for reducers.</summary>
+    public ReducerReader Reducers { get; }
+
+    /// <summary>Gets the reader for reactors.</summary>
+    public ReactorReader Reactors { get; }
+
+    /// <summary>Gets the reader for constraints declared in code.</summary>
+    public ConstraintReader Constraints { get; }
+
+    /// <summary>
+    /// Composes every reader for a compilation.
+    /// </summary>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="catalog">The catalogue of everything the compilation declares.</param>
+    /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+    /// <returns>The <see cref="ArtifactReaders"/>.</returns>
+    public static ArtifactReaders For(Compilation compilation, ArtifactCatalog catalog, ScreenplayDiagnostics diagnostics)
+    {
+        var types = new TypeRegistry();
+        var properties = new PropertyReader(types);
+        var paths = SourcePaths.For(compilation);
+        var produces = new ProducesReader(compilation, diagnostics);
+        var validators = ValidatorCatalog.From(catalog, new(compilation, diagnostics));
+
+        return new(
+            types,
+            validators,
+            new EventReader(properties, diagnostics),
+            new CommandReader(properties, produces, validators, paths),
+            new ControllerCommandReader(types, properties, produces, validators, paths),
+            new QueryReader(types, diagnostics),
+            new ModelBoundProjectionReader(diagnostics),
+            new FluentProjectionReader(compilation, diagnostics),
+            new ReducerReader(diagnostics),
+            new ReactorReader(compilation, paths),
+            new ConstraintReader(compilation, paths, diagnostics));
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
@@ -95,7 +95,7 @@ public class ArtifactReaders
     {
         var types = new TypeRegistry();
         var properties = new PropertyReader(types);
-        var paths = SourcePaths.For(compilation);
+        var paths = SourcePaths.For(compilation, catalog);
         var aggregates = new AggregateRootCatalog();
         var produces = new ProducesReader(compilation, aggregates, diagnostics);
         var validators = ValidatorCatalog.From(catalog, new(compilation, diagnostics));

--- a/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
 using Cratis.Arc.Screenplay.Analysis.Commands;
 using Cratis.Arc.Screenplay.Analysis.Constraints;
 using Cratis.Arc.Screenplay.Analysis.Controllers;
@@ -21,6 +22,7 @@ public class ArtifactReaders
 {
     ArtifactReaders(
         TypeRegistry types,
+        AggregateRootCatalog aggregates,
         ValidatorCatalog validators,
         EventReader events,
         CommandReader commands,
@@ -33,6 +35,7 @@ public class ArtifactReaders
         ConstraintReader constraints)
     {
         Types = types;
+        AggregateRoots = aggregates;
         Validators = validators;
         Events = events;
         Commands = commands;
@@ -47,6 +50,9 @@ public class ArtifactReaders
 
     /// <summary>Gets the registry collecting the concepts every artifact refers to.</summary>
     public TypeRegistry Types { get; }
+
+    /// <summary>Gets the aggregate roots the compilation declares, and which of them a command reaches.</summary>
+    public AggregateRootCatalog AggregateRoots { get; }
 
     /// <summary>Gets the rules every validator in the compilation declares.</summary>
     public ValidatorCatalog Validators { get; }
@@ -90,11 +96,13 @@ public class ArtifactReaders
         var types = new TypeRegistry();
         var properties = new PropertyReader(types);
         var paths = SourcePaths.For(compilation);
-        var produces = new ProducesReader(compilation, diagnostics);
+        var aggregates = new AggregateRootCatalog();
+        var produces = new ProducesReader(compilation, aggregates, diagnostics);
         var validators = ValidatorCatalog.From(catalog, new(compilation, diagnostics));
 
         return new(
             types,
+            aggregates,
             validators,
             new EventReader(properties, diagnostics),
             new CommandReader(properties, produces, validators, paths),

--- a/Source/DotNET/Screenplay/Analysis/AuthorizationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/AuthorizationReader.cs
@@ -13,6 +13,7 @@ namespace Cratis.Arc.Screenplay.Analysis;
 /// Roles are declared in two shapes - the constructor form <c>[Roles("Librarian")]</c> and the named argument form
 /// <c>[Authorize(Roles = "Librarian")]</c> - and both are read. Reading only one of them silently drops half the
 /// authorization in an application, which is a bug the proxy generator has and this deliberately does not repeat.
+/// A named policy is carried by its name alone, because the attribute says nothing else about it.
 /// </remarks>
 public static class AuthorizationReader
 {
@@ -20,6 +21,11 @@ public static class AuthorizationReader
     /// The name of the property carrying a comma separated list of roles.
     /// </summary>
     public const string RolesProperty = "Roles";
+
+    /// <summary>
+    /// The name of the property naming the policy the caller has to satisfy.
+    /// </summary>
+    public const string PolicyProperty = "Policy";
 
     /// <summary>
     /// Reads what an artifact and the type declaring it require of the caller.
@@ -47,7 +53,16 @@ public static class AuthorizationReader
             .Order(StringComparer.Ordinal)
             .ToList();
 
-        return new(true, roles);
+        var policies = attributes
+            .Select(_ => _.GetNamedArgument(PolicyProperty) as string)
+            .OfType<string>()
+            .Where(_ => _.Trim().Length > 0)
+            .Select(_ => _.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        return new(true, roles) { Policies = policies };
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/AuthorizationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/AuthorizationReader.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Reads what an artifact requires of the caller.
+/// </summary>
+/// <remarks>
+/// Roles are declared in two shapes - the constructor form <c>[Roles("Librarian")]</c> and the named argument form
+/// <c>[Authorize(Roles = "Librarian")]</c> - and both are read. Reading only one of them silently drops half the
+/// authorization in an application, which is a bug the proxy generator has and this deliberately does not repeat.
+/// </remarks>
+public static class AuthorizationReader
+{
+    /// <summary>
+    /// The name of the property carrying a comma separated list of roles.
+    /// </summary>
+    public const string RolesProperty = "Roles";
+
+    /// <summary>
+    /// Reads what an artifact and the type declaring it require of the caller.
+    /// </summary>
+    /// <param name="symbol">The artifact to read.</param>
+    /// <param name="declaring">The type declaring it, when the artifact is a member.</param>
+    /// <returns>The <see cref="AuthorizationModel"/>, or <see langword="null"/> when nothing is required.</returns>
+    public static AuthorizationModel? Read(ISymbol symbol, ISymbol? declaring = null)
+    {
+        if (symbol.HasAttribute(WellKnownTypeNames.AllowAnonymousAttribute))
+        {
+            return null;
+        }
+
+        var attributes = Attributes(symbol).Concat(declaring is null ? [] : Attributes(declaring)).ToList();
+        if (attributes.Count == 0)
+        {
+            return null;
+        }
+
+        var roles = attributes
+            .SelectMany(Roles)
+            .Where(_ => _.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        return new(true, roles);
+    }
+
+    /// <summary>
+    /// Gets every authorize attribute applied to a symbol, including the roles form deriving from it.
+    /// </summary>
+    /// <param name="symbol">The symbol to read.</param>
+    /// <returns>The attributes.</returns>
+    static IEnumerable<AttributeData> Attributes(ISymbol symbol) =>
+        symbol.GetAttributes().Where(_ =>
+            _.AttributeClass.Is(WellKnownTypeNames.AuthorizeAttribute) ||
+            _.AttributeClass.Is(WellKnownTypeNames.RolesAttribute) ||
+            _.AttributeClass.FindBase(WellKnownTypeNames.AuthorizeAttribute) is not null);
+
+    /// <summary>
+    /// Gets the roles an authorize attribute names, in either shape it can be written.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <returns>The role names.</returns>
+    static IEnumerable<string> Roles(AttributeData attribute)
+    {
+        var named = attribute.GetNamedArgument(RolesProperty) as string;
+        var positional = attribute.ConstructorArguments
+            .SelectMany(_ => _.Kind == TypedConstantKind.Array ? _.Values.Select(value => value.Value) : [_.Value])
+            .OfType<string>();
+
+        return Split(named).Concat(positional.SelectMany(Split));
+    }
+
+    /// <summary>
+    /// Splits a comma separated list of roles.
+    /// </summary>
+    /// <param name="value">The value to split.</param>
+    /// <returns>The role names.</returns>
+    static IEnumerable<string> Split(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/Source/DotNET/Screenplay/Analysis/Collections.cs
+++ b/Source/DotNET/Screenplay/Analysis/Collections.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Extends the collection abstractions with what collecting analysis results needs.
+/// </summary>
+public static class Collections
+{
+    /// <summary>
+    /// Adds everything from a sequence to a collection.
+    /// </summary>
+    /// <typeparam name="T">The type of the items.</typeparam>
+    /// <param name="target">The collection to add to.</param>
+    /// <param name="items">The items to add.</param>
+    public static void AddRange<T>(this ICollection<T> target, IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            target.Add(item);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/CommandReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/CommandReader.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reads the model-bound commands a slice declares.
+/// </summary>
+/// <param name="properties">The <see cref="PropertyReader"/> reading the input of each command.</param>
+/// <param name="produces">The <see cref="ProducesReader"/> reading what each command produces.</param>
+/// <param name="validators">The <see cref="ValidatorCatalog"/> holding the rules declared for each command.</param>
+/// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of the file each command lives in.</param>
+/// <remarks>
+/// The input of a command is what the record itself declares. The parameters of its handler are infrastructure -
+/// injected services and current state - and are never part of what a caller sends, which is exactly the mistake a
+/// reflection-based reading of the handler signature makes.
+/// </remarks>
+public class CommandReader(
+    PropertyReader properties,
+    ProducesReader produces,
+    ValidatorCatalog validators,
+    SourcePaths paths)
+{
+    /// <summary>
+    /// The name of the method handling a command.
+    /// </summary>
+    public const string HandleMethod = "Handle";
+
+    /// <summary>
+    /// Determines whether a type is a model-bound command.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a command.</returns>
+    public static bool IsCommand(ITypeSymbol type) => type.HasAttribute(WellKnownTypeNames.CommandAttribute);
+
+    /// <summary>
+    /// Reads a command.
+    /// </summary>
+    /// <param name="type">The type declaring the command.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="CommandModel"/>.</returns>
+    public CommandModel Read(INamedTypeSymbol type, string location)
+    {
+        var handlers = Handlers(type);
+
+        return new(
+            type.Name,
+            Documentation.SummaryOf(type),
+            properties.Read(type),
+            AuthorizationReader.Read(type),
+            validators.For(type),
+            produces.Read(type, handlers, location),
+            ConcurrencyReader.Read(type),
+            paths.Relative(type.SourceFilePath()));
+    }
+
+    /// <summary>
+    /// Gets the handler methods a command declares.
+    /// </summary>
+    /// <param name="type">The type declaring the command.</param>
+    /// <returns>The handlers, ordered so that the same command always reads the same way.</returns>
+    static IReadOnlyList<IMethodSymbol> Handlers(INamedTypeSymbol type) =>
+    [
+        .. type.GetMembers(HandleMethod)
+            .OfType<IMethodSymbol>()
+            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: false })
+            .OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal)
+    ];
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ComparisonKinds.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ComparisonKinds.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Maps the comparison a C# operator makes onto the one a condition states, and relates one comparison to another.
+/// </summary>
+/// <remarks>
+/// Reading a comparison and turning it around are two different jobs, and only the second one is arithmetic on the
+/// operator itself. A branch is expressed by mirroring a comparison whose operands are the other way round, and the
+/// branch not taken is expressed by negating it - neither of which needs to know anything about syntax.
+/// </remarks>
+public static class ComparisonKinds
+{
+    /// <summary>
+    /// Converts a syntax kind into the comparison it makes.
+    /// </summary>
+    /// <param name="kind">The kind to convert.</param>
+    /// <returns>The comparison, or <see langword="null"/> when the kind is not a comparison.</returns>
+    public static ComparisonKind? Of(SyntaxKind kind) => kind switch
+    {
+        SyntaxKind.EqualsExpression => ComparisonKind.Equal,
+        SyntaxKind.NotEqualsExpression => ComparisonKind.NotEqual,
+        SyntaxKind.GreaterThanExpression => ComparisonKind.GreaterThan,
+        SyntaxKind.GreaterThanOrEqualExpression => ComparisonKind.GreaterThanOrEqual,
+        SyntaxKind.LessThanExpression => ComparisonKind.LessThan,
+        SyntaxKind.LessThanOrEqualExpression => ComparisonKind.LessThanOrEqual,
+        _ => null
+    };
+
+    /// <summary>
+    /// Gets the comparison meaning the same thing with the operands the other way round.
+    /// </summary>
+    /// <param name="kind">The comparison to mirror.</param>
+    /// <returns>The mirrored comparison.</returns>
+    public static ComparisonKind Mirrored(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.GreaterThan => ComparisonKind.LessThan,
+        ComparisonKind.GreaterThanOrEqual => ComparisonKind.LessThanOrEqual,
+        ComparisonKind.LessThan => ComparisonKind.GreaterThan,
+        ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThanOrEqual,
+        _ => kind
+    };
+
+    /// <summary>
+    /// Gets the comparison that is true exactly when another is false.
+    /// </summary>
+    /// <param name="kind">The comparison to negate.</param>
+    /// <returns>The negated comparison.</returns>
+    public static ComparisonKind Opposite(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.Equal => ComparisonKind.NotEqual,
+        ComparisonKind.NotEqual => ComparisonKind.Equal,
+        ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
+        ComparisonKind.GreaterThanOrEqual => ComparisonKind.LessThan,
+        ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
+        _ => ComparisonKind.GreaterThan
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ConcurrencyReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ConcurrencyReader.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reads the scope a command's appends are checked for concurrent writers within.
+/// </summary>
+/// <remarks>
+/// The three dimensions are declared with the same attributes that name them, and only take part in the scope when
+/// they say so. An attribute that names a dimension without opting into concurrency is metadata, not a scope, and
+/// is left out.
+/// </remarks>
+public static class ConcurrencyReader
+{
+    /// <summary>
+    /// The name of the argument opting a dimension into the concurrency scope.
+    /// </summary>
+    public const string ConcurrencyArgument = "Concurrency";
+
+    /// <summary>
+    /// Reads the concurrency scope a command declares.
+    /// </summary>
+    /// <param name="command">The type declaring the command.</param>
+    /// <returns>The <see cref="ConcurrencyModel"/>, or <see langword="null"/> when the command declares none.</returns>
+    public static ConcurrencyModel? Read(INamedTypeSymbol command)
+    {
+        var sourceType = Dimension(command, WellKnownTypeNames.EventSourceTypeAttribute);
+        var streamType = Dimension(command, WellKnownTypeNames.EventStreamTypeAttribute);
+        var streamId = Dimension(command, WellKnownTypeNames.EventStreamIdAttribute);
+
+        return sourceType is null && streamType is null && streamId is null
+            ? null
+            : new(false, sourceType, streamType, streamId, []);
+    }
+
+    /// <summary>
+    /// Reads one dimension of the scope.
+    /// </summary>
+    /// <param name="command">The type declaring the command.</param>
+    /// <param name="attributeName">The fully qualified metadata name of the attribute declaring the dimension.</param>
+    /// <returns>The value, or <see langword="null"/> when the dimension takes no part in the scope.</returns>
+    static string? Dimension(INamedTypeSymbol command, string attributeName)
+    {
+        var attribute = command.GetAttribute(attributeName);
+        if (attribute is null)
+        {
+            return null;
+        }
+
+        var concurrency = attribute.GetNamedArgument(ConcurrencyArgument) ?? attribute.GetArgument(1);
+
+        return concurrency is true ? attribute.GetArgument(0) as string : null;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ConditionReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ConditionReader.cs
@@ -12,6 +12,7 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// <summary>
 /// Reads the condition guarding a branch of a command handler.
 /// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <remarks>
 /// Screenplay has no parentheses in conditions, so a combined condition only survives a round trip when the tree is
 /// left associative and shallow. Anything deeper, and anything that is not a comparison against the command's own
@@ -21,40 +22,9 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// site stand in for them and the comparison is followed back to the input it really compares.
 /// </para>
 /// </remarks>
-public static class ConditionReader
+public class ConditionReader(ScreenplayDiagnostics diagnostics)
 {
-    /// <summary>
-    /// Reads a condition.
-    /// </summary>
-    /// <param name="expression">The expression to read.</param>
-    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
-    /// <param name="owner">The type whose properties count as the command's own input.</param>
-    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
-    /// <returns>The condition, or <see langword="null"/> when it is not expressible.</returns>
-    public static ConditionModel? Read(
-        ExpressionSyntax expression,
-        SemanticModel semanticModel,
-        ITypeSymbol owner,
-        ParameterBindings? bindings = null)
-    {
-        switch (expression)
-        {
-            case ParenthesizedExpressionSyntax parenthesized:
-                return Read(parenthesized.Expression, semanticModel, owner, bindings);
-
-            case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression } negation:
-                return Invert(Read(negation.Operand, semanticModel, owner, bindings));
-
-            case BinaryExpressionSyntax binary when IsLogical(binary):
-                return ReadLogical(binary, semanticModel, owner, bindings);
-
-            case BinaryExpressionSyntax binary when ComparisonKinds.Of(binary.Kind()) is { } comparison:
-                return ReadComparison(binary, comparison, semanticModel, owner, bindings);
-
-            default:
-                return ReadTruthy(expression, semanticModel, owner, bindings);
-        }
-    }
+    readonly MappingSourceReader _sources = new(diagnostics);
 
     /// <summary>
     /// Inverts a condition, so that the other branch of a decision can be expressed.
@@ -70,67 +40,47 @@ public static class ConditionReader
     };
 
     /// <summary>
+    /// Reads a condition.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
+    /// <returns>The condition, or <see langword="null"/> when it is not expressible.</returns>
+    public ConditionModel? Read(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        string location,
+        ParameterBindings? bindings = null)
+    {
+        switch (expression)
+        {
+            case ParenthesizedExpressionSyntax parenthesized:
+                return Read(parenthesized.Expression, semanticModel, owner, location, bindings);
+
+            case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression } negation:
+                return Invert(Read(negation.Operand, semanticModel, owner, location, bindings));
+
+            case BinaryExpressionSyntax binary when IsLogical(binary):
+                return ReadLogical(binary, semanticModel, owner, location, bindings);
+
+            case BinaryExpressionSyntax binary when ComparisonKinds.Of(binary.Kind()) is { } comparison:
+                return ReadComparison(binary, comparison, semanticModel, owner, location, bindings);
+
+            default:
+                return ReadTruthy(expression, semanticModel, owner, bindings);
+        }
+    }
+
+    /// <summary>
     /// Determines whether an operator combines two conditions.
     /// </summary>
     /// <param name="binary">The expression to check.</param>
     /// <returns>True when the expression combines conditions.</returns>
     static bool IsLogical(BinaryExpressionSyntax binary) =>
         binary.IsKind(SyntaxKind.LogicalAndExpression) || binary.IsKind(SyntaxKind.LogicalOrExpression);
-
-    /// <summary>
-    /// Reads two conditions combined with a logical operator.
-    /// </summary>
-    /// <param name="binary">The expression to read.</param>
-    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
-    /// <param name="owner">The type whose properties count as the command's own input.</param>
-    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
-    /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
-    static LogicalCondition? ReadLogical(
-        BinaryExpressionSyntax binary,
-        SemanticModel semanticModel,
-        ITypeSymbol owner,
-        ParameterBindings? bindings)
-    {
-        var left = Read(binary.Left, semanticModel, owner, bindings);
-        var right = Read(binary.Right, semanticModel, owner, bindings);
-
-        return left is null || right is null ? null : new LogicalCondition(left, binary.IsKind(SyntaxKind.LogicalOrExpression), right);
-    }
-
-    /// <summary>
-    /// Reads a comparison between the command's own input and a value.
-    /// </summary>
-    /// <param name="binary">The expression to read.</param>
-    /// <param name="comparison">The comparison being made.</param>
-    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
-    /// <param name="owner">The type whose properties count as the command's own input.</param>
-    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
-    /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
-    static ComparisonCondition? ReadComparison(
-        BinaryExpressionSyntax binary,
-        ComparisonKind comparison,
-        SemanticModel semanticModel,
-        ITypeSymbol owner,
-        ParameterBindings? bindings)
-    {
-        var left = MappingSourceReader.ReadPath(binary.Left, semanticModel, owner, bindings);
-        if (left is not null)
-        {
-            var right = MappingSourceReader.Read(binary.Right, semanticModel, owner, bindings);
-
-            return right is null ? null : new ComparisonCondition(left, comparison, right);
-        }
-
-        var mirrored = MappingSourceReader.ReadPath(binary.Right, semanticModel, owner, bindings);
-        if (mirrored is null)
-        {
-            return null;
-        }
-
-        var value = MappingSourceReader.Read(binary.Left, semanticModel, owner, bindings);
-
-        return value is null ? null : new ComparisonCondition(mirrored, ComparisonKinds.Mirrored(comparison), value);
-    }
 
     /// <summary>
     /// Reads a bare boolean property as a comparison against true.
@@ -154,5 +104,64 @@ public static class ConditionReader
         var path = MappingSourceReader.ReadPath(expression, semanticModel, owner, bindings);
 
         return path is null ? null : new ComparisonCondition(path, ComparisonKind.Equal, new LiteralSource(true));
+    }
+
+    /// <summary>
+    /// Reads two conditions combined with a logical operator.
+    /// </summary>
+    /// <param name="binary">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
+    /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
+    LogicalCondition? ReadLogical(
+        BinaryExpressionSyntax binary,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        string location,
+        ParameterBindings? bindings)
+    {
+        var left = Read(binary.Left, semanticModel, owner, location, bindings);
+        var right = Read(binary.Right, semanticModel, owner, location, bindings);
+
+        return left is null || right is null ? null : new LogicalCondition(left, binary.IsKind(SyntaxKind.LogicalOrExpression), right);
+    }
+
+    /// <summary>
+    /// Reads a comparison between the command's own input and a value.
+    /// </summary>
+    /// <param name="binary">The expression to read.</param>
+    /// <param name="comparison">The comparison being made.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
+    /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
+    ComparisonCondition? ReadComparison(
+        BinaryExpressionSyntax binary,
+        ComparisonKind comparison,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        string location,
+        ParameterBindings? bindings)
+    {
+        var left = MappingSourceReader.ReadPath(binary.Left, semanticModel, owner, bindings);
+        if (left is not null)
+        {
+            var right = _sources.Read(binary.Right, semanticModel, owner, location, bindings);
+
+            return right is null ? null : new ComparisonCondition(left, comparison, right);
+        }
+
+        var mirrored = MappingSourceReader.ReadPath(binary.Right, semanticModel, owner, bindings);
+        if (mirrored is null)
+        {
+            return null;
+        }
+
+        var value = _sources.Read(binary.Left, semanticModel, owner, location, bindings);
+
+        return value is null ? null : new ComparisonCondition(mirrored, ComparisonKinds.Mirrored(comparison), value);
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Commands/ConditionReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ConditionReader.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reads the condition guarding a branch of a command handler.
+/// </summary>
+/// <remarks>
+/// Screenplay has no parentheses in conditions, so a combined condition only survives a round trip when the tree is
+/// left associative and shallow. Anything deeper, and anything that is not a comparison against the command's own
+/// input, is reported rather than approximated.
+/// </remarks>
+public static class ConditionReader
+{
+    /// <summary>
+    /// Reads a condition.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>The condition, or <see langword="null"/> when it is not expressible.</returns>
+    public static ConditionModel? Read(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    {
+        switch (expression)
+        {
+            case ParenthesizedExpressionSyntax parenthesized:
+                return Read(parenthesized.Expression, semanticModel, owner);
+
+            case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression } negation:
+                return Invert(Read(negation.Operand, semanticModel, owner));
+
+            case BinaryExpressionSyntax binary when IsLogical(binary):
+                return ReadLogical(binary, semanticModel, owner);
+
+            case BinaryExpressionSyntax binary when ToComparison(binary.Kind()) is { } comparison:
+                return ReadComparison(binary, comparison, semanticModel, owner);
+
+            default:
+                return ReadTruthy(expression, semanticModel, owner);
+        }
+    }
+
+    /// <summary>
+    /// Inverts a condition, so that the other branch of a decision can be expressed.
+    /// </summary>
+    /// <param name="condition">The condition to invert.</param>
+    /// <returns>The inverted condition, or <see langword="null"/> when it cannot be inverted.</returns>
+    public static ConditionModel? Invert(ConditionModel? condition) => condition switch
+    {
+        ComparisonCondition comparison => comparison with { Operator = Opposite(comparison.Operator) },
+        LogicalCondition logical when Invert(logical.Left) is { } left && Invert(logical.Right) is { } right =>
+            new LogicalCondition(left, !logical.IsOr, right),
+        _ => null
+    };
+
+    /// <summary>
+    /// Determines whether an operator combines two conditions.
+    /// </summary>
+    /// <param name="binary">The expression to check.</param>
+    /// <returns>True when the expression combines conditions.</returns>
+    static bool IsLogical(BinaryExpressionSyntax binary) =>
+        binary.IsKind(SyntaxKind.LogicalAndExpression) || binary.IsKind(SyntaxKind.LogicalOrExpression);
+
+    /// <summary>
+    /// Reads two conditions combined with a logical operator.
+    /// </summary>
+    /// <param name="binary">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
+    static LogicalCondition? ReadLogical(BinaryExpressionSyntax binary, SemanticModel semanticModel, ITypeSymbol owner)
+    {
+        var left = Read(binary.Left, semanticModel, owner);
+        var right = Read(binary.Right, semanticModel, owner);
+
+        return left is null || right is null ? null : new LogicalCondition(left, binary.IsKind(SyntaxKind.LogicalOrExpression), right);
+    }
+
+    /// <summary>
+    /// Reads a comparison between the command's own input and a value.
+    /// </summary>
+    /// <param name="binary">The expression to read.</param>
+    /// <param name="comparison">The comparison being made.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
+    static ComparisonCondition? ReadComparison(
+        BinaryExpressionSyntax binary,
+        ComparisonKind comparison,
+        SemanticModel semanticModel,
+        ITypeSymbol owner)
+    {
+        var left = MappingSourceReader.ReadPath(binary.Left, semanticModel, owner);
+        if (left is not null)
+        {
+            var right = MappingSourceReader.Read(binary.Right, semanticModel, owner);
+
+            return right is null ? null : new ComparisonCondition(left, comparison, right);
+        }
+
+        var mirrored = MappingSourceReader.ReadPath(binary.Right, semanticModel, owner);
+        if (mirrored is null)
+        {
+            return null;
+        }
+
+        var value = MappingSourceReader.Read(binary.Left, semanticModel, owner);
+
+        return value is null ? null : new ComparisonCondition(mirrored, Mirror(comparison), value);
+    }
+
+    /// <summary>
+    /// Reads a bare boolean property as a comparison against true.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>The condition, or <see langword="null"/> when the expression is not a boolean input.</returns>
+    static ComparisonCondition? ReadTruthy(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    {
+        if (semanticModel.GetTypeInfo(expression).Type?.SpecialType != SpecialType.System_Boolean)
+        {
+            return null;
+        }
+
+        var path = MappingSourceReader.ReadPath(expression, semanticModel, owner);
+
+        return path is null ? null : new ComparisonCondition(path, ComparisonKind.Equal, new LiteralSource(true));
+    }
+
+    /// <summary>
+    /// Converts a syntax kind into the comparison it makes.
+    /// </summary>
+    /// <param name="kind">The kind to convert.</param>
+    /// <returns>The comparison, or <see langword="null"/> when the kind is not a comparison.</returns>
+    static ComparisonKind? ToComparison(SyntaxKind kind) => kind switch
+    {
+        SyntaxKind.EqualsExpression => ComparisonKind.Equal,
+        SyntaxKind.NotEqualsExpression => ComparisonKind.NotEqual,
+        SyntaxKind.GreaterThanExpression => ComparisonKind.GreaterThan,
+        SyntaxKind.GreaterThanOrEqualExpression => ComparisonKind.GreaterThanOrEqual,
+        SyntaxKind.LessThanExpression => ComparisonKind.LessThan,
+        SyntaxKind.LessThanOrEqualExpression => ComparisonKind.LessThanOrEqual,
+        _ => null
+    };
+
+    /// <summary>
+    /// Gets the comparison meaning the same thing with the operands the other way round.
+    /// </summary>
+    /// <param name="kind">The comparison to mirror.</param>
+    /// <returns>The mirrored comparison.</returns>
+    static ComparisonKind Mirror(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.GreaterThan => ComparisonKind.LessThan,
+        ComparisonKind.GreaterThanOrEqual => ComparisonKind.LessThanOrEqual,
+        ComparisonKind.LessThan => ComparisonKind.GreaterThan,
+        ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThanOrEqual,
+        _ => kind
+    };
+
+    /// <summary>
+    /// Gets the comparison that is true exactly when another is false.
+    /// </summary>
+    /// <param name="kind">The comparison to negate.</param>
+    /// <returns>The negated comparison.</returns>
+    static ComparisonKind Opposite(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.Equal => ComparisonKind.NotEqual,
+        ComparisonKind.NotEqual => ComparisonKind.Equal,
+        ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
+        ComparisonKind.GreaterThanOrEqual => ComparisonKind.LessThan,
+        ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
+        _ => ComparisonKind.GreaterThan
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ConditionReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ConditionReader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,6 +16,10 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// Screenplay has no parentheses in conditions, so a combined condition only survives a round trip when the tree is
 /// left associative and shallow. Anything deeper, and anything that is not a comparison against the command's own
 /// input, is reported rather than approximated.
+/// <para>
+/// A condition written inside a body the handler called names that body's parameters, so the bindings of the call
+/// site stand in for them and the comparison is followed back to the input it really compares.
+/// </para>
 /// </remarks>
 public static class ConditionReader
 {
@@ -24,25 +29,30 @@ public static class ConditionReader
     /// <param name="expression">The expression to read.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
     /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
     /// <returns>The condition, or <see langword="null"/> when it is not expressible.</returns>
-    public static ConditionModel? Read(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    public static ConditionModel? Read(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ParameterBindings? bindings = null)
     {
         switch (expression)
         {
             case ParenthesizedExpressionSyntax parenthesized:
-                return Read(parenthesized.Expression, semanticModel, owner);
+                return Read(parenthesized.Expression, semanticModel, owner, bindings);
 
             case PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression } negation:
-                return Invert(Read(negation.Operand, semanticModel, owner));
+                return Invert(Read(negation.Operand, semanticModel, owner, bindings));
 
             case BinaryExpressionSyntax binary when IsLogical(binary):
-                return ReadLogical(binary, semanticModel, owner);
+                return ReadLogical(binary, semanticModel, owner, bindings);
 
-            case BinaryExpressionSyntax binary when ToComparison(binary.Kind()) is { } comparison:
-                return ReadComparison(binary, comparison, semanticModel, owner);
+            case BinaryExpressionSyntax binary when ComparisonKinds.Of(binary.Kind()) is { } comparison:
+                return ReadComparison(binary, comparison, semanticModel, owner, bindings);
 
             default:
-                return ReadTruthy(expression, semanticModel, owner);
+                return ReadTruthy(expression, semanticModel, owner, bindings);
         }
     }
 
@@ -53,7 +63,7 @@ public static class ConditionReader
     /// <returns>The inverted condition, or <see langword="null"/> when it cannot be inverted.</returns>
     public static ConditionModel? Invert(ConditionModel? condition) => condition switch
     {
-        ComparisonCondition comparison => comparison with { Operator = Opposite(comparison.Operator) },
+        ComparisonCondition comparison => comparison with { Operator = ComparisonKinds.Opposite(comparison.Operator) },
         LogicalCondition logical when Invert(logical.Left) is { } left && Invert(logical.Right) is { } right =>
             new LogicalCondition(left, !logical.IsOr, right),
         _ => null
@@ -73,11 +83,16 @@ public static class ConditionReader
     /// <param name="binary">The expression to read.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
     /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
     /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
-    static LogicalCondition? ReadLogical(BinaryExpressionSyntax binary, SemanticModel semanticModel, ITypeSymbol owner)
+    static LogicalCondition? ReadLogical(
+        BinaryExpressionSyntax binary,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ParameterBindings? bindings)
     {
-        var left = Read(binary.Left, semanticModel, owner);
-        var right = Read(binary.Right, semanticModel, owner);
+        var left = Read(binary.Left, semanticModel, owner, bindings);
+        var right = Read(binary.Right, semanticModel, owner, bindings);
 
         return left is null || right is null ? null : new LogicalCondition(left, binary.IsKind(SyntaxKind.LogicalOrExpression), right);
     }
@@ -89,30 +104,32 @@ public static class ConditionReader
     /// <param name="comparison">The comparison being made.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
     /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
     /// <returns>The condition, or <see langword="null"/> when either side is not expressible.</returns>
     static ComparisonCondition? ReadComparison(
         BinaryExpressionSyntax binary,
         ComparisonKind comparison,
         SemanticModel semanticModel,
-        ITypeSymbol owner)
+        ITypeSymbol owner,
+        ParameterBindings? bindings)
     {
-        var left = MappingSourceReader.ReadPath(binary.Left, semanticModel, owner);
+        var left = MappingSourceReader.ReadPath(binary.Left, semanticModel, owner, bindings);
         if (left is not null)
         {
-            var right = MappingSourceReader.Read(binary.Right, semanticModel, owner);
+            var right = MappingSourceReader.Read(binary.Right, semanticModel, owner, bindings);
 
             return right is null ? null : new ComparisonCondition(left, comparison, right);
         }
 
-        var mirrored = MappingSourceReader.ReadPath(binary.Right, semanticModel, owner);
+        var mirrored = MappingSourceReader.ReadPath(binary.Right, semanticModel, owner, bindings);
         if (mirrored is null)
         {
             return null;
         }
 
-        var value = MappingSourceReader.Read(binary.Left, semanticModel, owner);
+        var value = MappingSourceReader.Read(binary.Left, semanticModel, owner, bindings);
 
-        return value is null ? null : new ComparisonCondition(mirrored, Mirror(comparison), value);
+        return value is null ? null : new ComparisonCondition(mirrored, ComparisonKinds.Mirrored(comparison), value);
     }
 
     /// <summary>
@@ -121,61 +138,21 @@ public static class ConditionReader
     /// <param name="expression">The expression to read.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
     /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
     /// <returns>The condition, or <see langword="null"/> when the expression is not a boolean input.</returns>
-    static ComparisonCondition? ReadTruthy(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    static ComparisonCondition? ReadTruthy(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ParameterBindings? bindings)
     {
         if (semanticModel.GetTypeInfo(expression).Type?.SpecialType != SpecialType.System_Boolean)
         {
             return null;
         }
 
-        var path = MappingSourceReader.ReadPath(expression, semanticModel, owner);
+        var path = MappingSourceReader.ReadPath(expression, semanticModel, owner, bindings);
 
         return path is null ? null : new ComparisonCondition(path, ComparisonKind.Equal, new LiteralSource(true));
     }
-
-    /// <summary>
-    /// Converts a syntax kind into the comparison it makes.
-    /// </summary>
-    /// <param name="kind">The kind to convert.</param>
-    /// <returns>The comparison, or <see langword="null"/> when the kind is not a comparison.</returns>
-    static ComparisonKind? ToComparison(SyntaxKind kind) => kind switch
-    {
-        SyntaxKind.EqualsExpression => ComparisonKind.Equal,
-        SyntaxKind.NotEqualsExpression => ComparisonKind.NotEqual,
-        SyntaxKind.GreaterThanExpression => ComparisonKind.GreaterThan,
-        SyntaxKind.GreaterThanOrEqualExpression => ComparisonKind.GreaterThanOrEqual,
-        SyntaxKind.LessThanExpression => ComparisonKind.LessThan,
-        SyntaxKind.LessThanOrEqualExpression => ComparisonKind.LessThanOrEqual,
-        _ => null
-    };
-
-    /// <summary>
-    /// Gets the comparison meaning the same thing with the operands the other way round.
-    /// </summary>
-    /// <param name="kind">The comparison to mirror.</param>
-    /// <returns>The mirrored comparison.</returns>
-    static ComparisonKind Mirror(ComparisonKind kind) => kind switch
-    {
-        ComparisonKind.GreaterThan => ComparisonKind.LessThan,
-        ComparisonKind.GreaterThanOrEqual => ComparisonKind.LessThanOrEqual,
-        ComparisonKind.LessThan => ComparisonKind.GreaterThan,
-        ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThanOrEqual,
-        _ => kind
-    };
-
-    /// <summary>
-    /// Gets the comparison that is true exactly when another is false.
-    /// </summary>
-    /// <param name="kind">The comparison to negate.</param>
-    /// <returns>The negated comparison.</returns>
-    static ComparisonKind Opposite(ComparisonKind kind) => kind switch
-    {
-        ComparisonKind.Equal => ComparisonKind.NotEqual,
-        ComparisonKind.NotEqual => ComparisonKind.Equal,
-        ComparisonKind.GreaterThan => ComparisonKind.LessThanOrEqual,
-        ComparisonKind.GreaterThanOrEqual => ComparisonKind.LessThan,
-        ComparisonKind.LessThan => ComparisonKind.GreaterThanOrEqual,
-        _ => ComparisonKind.GreaterThan
-    };
 }

--- a/Source/DotNET/Screenplay/Analysis/Commands/HandlerBodies.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/HandlerBodies.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Resolves the bodies of a handler and the event types its signature promises.
+/// </summary>
+/// <remarks>
+/// A handler living in a referenced package has metadata but no body, which is the one case where source analysis
+/// degrades to what reflection could see - the events the signature names, with no mappings.
+/// </remarks>
+public static class HandlerBodies
+{
+    /// <summary>
+    /// Gets the body of every declaration of a method.
+    /// </summary>
+    /// <param name="method">The method to read.</param>
+    /// <returns>The bodies, empty when the method has no source.</returns>
+    public static IEnumerable<SyntaxNode> Of(IMethodSymbol method) =>
+        method.DeclaringSyntaxReferences
+            .Select(_ => _.GetSyntax())
+            .Select(BodyOf)
+            .OfType<SyntaxNode>();
+
+    /// <summary>
+    /// Gets every event type named anywhere within a type, walking wrappers, tuples and collections.
+    /// </summary>
+    /// <param name="type">The type to walk.</param>
+    /// <returns>The event types, ordered by name.</returns>
+    public static IEnumerable<INamedTypeSymbol> EventTypesIn(ITypeSymbol? type)
+    {
+        var found = new List<INamedTypeSymbol>();
+        Collect(type, found, new(SymbolEqualityComparer.Default));
+
+        return found.OrderBy(_ => _.Name, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Determines whether a return type yields the identifier of an event source alongside the event.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a tuple carrying an event.</returns>
+    public static bool YieldsEventSourceId(ITypeSymbol? type)
+    {
+        if (type is not INamedTypeSymbol named)
+        {
+            return false;
+        }
+
+        if (named.IsTupleType)
+        {
+            return named.TupleElements.Any(_ => EventReader.IsEvent(_.Type)) && named.TupleElements.Length > 1;
+        }
+
+        return named.TypeArguments.Any(YieldsEventSourceId);
+    }
+
+    /// <summary>
+    /// Gets the body of a declaration.
+    /// </summary>
+    /// <param name="node">The declaration to read.</param>
+    /// <returns>The body, or <see langword="null"/> when the declaration has none.</returns>
+    static SyntaxNode? BodyOf(SyntaxNode node) => node switch
+    {
+        MethodDeclarationSyntax method => (SyntaxNode?)method.Body ?? method.ExpressionBody?.Expression,
+        LocalFunctionStatementSyntax local => (SyntaxNode?)local.Body ?? local.ExpressionBody?.Expression,
+        _ => null
+    };
+
+    /// <summary>
+    /// Collects the event types named within a type.
+    /// </summary>
+    /// <param name="type">The type to walk.</param>
+    /// <param name="found">The event types found so far.</param>
+    /// <param name="visited">The types already walked, guarding against a recursive shape.</param>
+    static void Collect(ITypeSymbol? type, List<INamedTypeSymbol> found, HashSet<ITypeSymbol> visited)
+    {
+        if (type is null || !visited.Add(type))
+        {
+            return;
+        }
+
+        if (type is IArrayTypeSymbol array)
+        {
+            Collect(array.ElementType, found, visited);
+            return;
+        }
+
+        if (type is not INamedTypeSymbol named)
+        {
+            return;
+        }
+
+        if (EventReader.IsEvent(named))
+        {
+            found.Add(named);
+            return;
+        }
+
+        foreach (var argument in named.IsTupleType ? named.TupleElements.Select(_ => _.Type) : named.TypeArguments)
+        {
+            Collect(argument, found, visited);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -13,6 +14,10 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// <remarks>
 /// Only two sources survive into a document - a path into the command's own input, and a constant. Anything else is
 /// code, and a mapping guessing at code would be worse than a mapping that is not there.
+/// <para>
+/// An expression read from a body the handler called rather than from the handler itself names that body's
+/// parameters, so the bindings of the call site stand in for them and the value is followed back to the command.
+/// </para>
 /// </remarks>
 public static class MappingSourceReader
 {
@@ -22,8 +27,13 @@ public static class MappingSourceReader
     /// <param name="expression">The expression to read.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
     /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
     /// <returns>The source, or <see langword="null"/> when the expression is not expressible.</returns>
-    public static MappingSourceModel? Read(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    public static MappingSourceModel? Read(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ParameterBindings? bindings = null)
     {
         var unwrapped = Unwrap(expression);
 
@@ -33,7 +43,12 @@ public static class MappingSourceReader
             return new LiteralSource(constant.Value);
         }
 
-        var path = ReadPath(unwrapped, semanticModel, owner);
+        if (bindings?.Resolve(unwrapped, semanticModel) is { } bound)
+        {
+            return Read(bound.Expression, bound.SemanticModel, owner);
+        }
+
+        var path = ReadPath(unwrapped, semanticModel, owner, bindings);
 
         return path is null ? null : new PropertyPathSource(path);
     }
@@ -44,8 +59,13 @@ public static class MappingSourceReader
     /// <param name="expression">The expression to read.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
     /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
     /// <returns>The path, or <see langword="null"/> when the expression does not walk into the input.</returns>
-    public static string? ReadPath(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    public static string? ReadPath(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ParameterBindings? bindings = null)
     {
         var segments = new List<string>();
         var current = Unwrap(expression);
@@ -61,6 +81,11 @@ public static class MappingSourceReader
 
                 case ThisExpressionSyntax:
                     return segments.Count == 0 ? null : string.Join('.', segments);
+
+                case IdentifierNameSyntax identifier when bindings?.Resolve(identifier, semanticModel) is { } bound:
+                    return ReadPath(bound.Expression, bound.SemanticModel, owner) is { } prefix
+                        ? string.Join('.', segments.Prepend(prefix))
+                        : null;
 
                 case IdentifierNameSyntax identifier:
                     segments.Insert(0, identifier.Identifier.ValueText);

--- a/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
@@ -11,6 +11,7 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// <summary>
 /// Reads where the value of an expression inside a command handler comes from.
 /// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <remarks>
 /// Only two sources survive into a document - a path into the command's own input, and a constant. Anything else is
 /// code, and a mapping guessing at code would be worse than a mapping that is not there.
@@ -19,40 +20,8 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// parameters, so the bindings of the call site stand in for them and the value is followed back to the command.
 /// </para>
 /// </remarks>
-public static class MappingSourceReader
+public class MappingSourceReader(ScreenplayDiagnostics diagnostics)
 {
-    /// <summary>
-    /// Reads the source of an expression.
-    /// </summary>
-    /// <param name="expression">The expression to read.</param>
-    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
-    /// <param name="owner">The type whose properties count as the command's own input.</param>
-    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
-    /// <returns>The source, or <see langword="null"/> when the expression is not expressible.</returns>
-    public static MappingSourceModel? Read(
-        ExpressionSyntax expression,
-        SemanticModel semanticModel,
-        ITypeSymbol owner,
-        ParameterBindings? bindings = null)
-    {
-        var unwrapped = Unwrap(expression);
-
-        var constant = semanticModel.GetConstantValue(unwrapped);
-        if (constant.HasValue)
-        {
-            return new LiteralSource(constant.Value);
-        }
-
-        if (bindings?.Resolve(unwrapped, semanticModel) is { } bound)
-        {
-            return Read(bound.Expression, bound.SemanticModel, owner);
-        }
-
-        var path = ReadPath(unwrapped, semanticModel, owner, bindings);
-
-        return path is null ? null : new PropertyPathSource(path);
-    }
-
     /// <summary>
     /// Reads the dotted path an expression walks into the command's own input.
     /// </summary>
@@ -99,6 +68,40 @@ public static class MappingSourceReader
     }
 
     /// <summary>
+    /// Reads the source of an expression.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
+    /// <returns>The source, or <see langword="null"/> when the expression is not expressible.</returns>
+    public MappingSourceModel? Read(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        string location,
+        ParameterBindings? bindings = null)
+    {
+        var unwrapped = Unwrap(expression);
+
+        var constant = semanticModel.GetConstantValue(unwrapped);
+        if (constant.HasValue)
+        {
+            return new LiteralSource(ConstantOf(expression, semanticModel, constant.Value, location));
+        }
+
+        if (bindings?.Resolve(unwrapped, semanticModel) is { } bound)
+        {
+            return Read(bound.Expression, bound.SemanticModel, owner, location);
+        }
+
+        var path = ReadPath(unwrapped, semanticModel, owner, bindings);
+
+        return path is null ? null : new PropertyPathSource(path);
+    }
+
+    /// <summary>
     /// Determines whether an identifier names a property of the command itself.
     /// </summary>
     /// <param name="identifier">The identifier to check.</param>
@@ -122,4 +125,32 @@ public static class MappingSourceReader
             Unwrap(suppress.Operand),
         _ => expression
     };
+
+    /// <summary>
+    /// Recovers what a constant stands for, naming the member when it belongs to an enumeration.
+    /// </summary>
+    /// <param name="expression">The expression the constant was read from.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="value">The value the compiler handed over.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The value to carry, which for an enumeration is the member it names.</returns>
+    object? ConstantOf(ExpressionSyntax expression, SemanticModel semanticModel, object? value, string location)
+    {
+        if (EnumConstants.EnumerationOf(expression, semanticModel) is not { } enumeration)
+        {
+            return value;
+        }
+
+        if (EnumConstants.TryResolve(enumeration, value, out var member))
+        {
+            return member;
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnnamedEnumerationValue,
+            $"'{enumeration.Name}' declares no member with the value '{value}', so it is written as that number rather than as a name the concept declares",
+            location);
+
+        return value;
+    }
 }

--- a/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reads where the value of an expression inside a command handler comes from.
+/// </summary>
+/// <remarks>
+/// Only two sources survive into a document - a path into the command's own input, and a constant. Anything else is
+/// code, and a mapping guessing at code would be worse than a mapping that is not there.
+/// </remarks>
+public static class MappingSourceReader
+{
+    /// <summary>
+    /// Reads the source of an expression.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>The source, or <see langword="null"/> when the expression is not expressible.</returns>
+    public static MappingSourceModel? Read(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    {
+        var unwrapped = Unwrap(expression);
+
+        var constant = semanticModel.GetConstantValue(unwrapped);
+        if (constant.HasValue)
+        {
+            return new LiteralSource(constant.Value);
+        }
+
+        var path = ReadPath(unwrapped, semanticModel, owner);
+
+        return path is null ? null : new PropertyPathSource(path);
+    }
+
+    /// <summary>
+    /// Reads the dotted path an expression walks into the command's own input.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>The path, or <see langword="null"/> when the expression does not walk into the input.</returns>
+    public static string? ReadPath(ExpressionSyntax expression, SemanticModel semanticModel, ITypeSymbol owner)
+    {
+        var segments = new List<string>();
+        var current = Unwrap(expression);
+
+        while (true)
+        {
+            switch (current)
+            {
+                case MemberAccessExpressionSyntax member:
+                    segments.Insert(0, member.Name.Identifier.ValueText);
+                    current = Unwrap(member.Expression);
+                    continue;
+
+                case ThisExpressionSyntax:
+                    return segments.Count == 0 ? null : string.Join('.', segments);
+
+                case IdentifierNameSyntax identifier:
+                    segments.Insert(0, identifier.Identifier.ValueText);
+
+                    return IsOwnInput(identifier, semanticModel, owner) ? string.Join('.', segments) : null;
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether an identifier names a property of the command itself.
+    /// </summary>
+    /// <param name="identifier">The identifier to check.</param>
+    /// <param name="semanticModel">The semantic model of the tree the identifier lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>True when the identifier resolves to the command's own input.</returns>
+    static bool IsOwnInput(IdentifierNameSyntax identifier, SemanticModel semanticModel, ITypeSymbol owner) =>
+        semanticModel.GetSymbolInfo(identifier).Symbol is IPropertySymbol property &&
+        SymbolEqualityComparer.Default.Equals(property.ContainingType, owner);
+
+    /// <summary>
+    /// Strips the wrappers that do not change what an expression yields.
+    /// </summary>
+    /// <param name="expression">The expression to strip.</param>
+    /// <returns>The wrapped expression.</returns>
+    static ExpressionSyntax Unwrap(ExpressionSyntax expression) => expression switch
+    {
+        ParenthesizedExpressionSyntax parenthesized => Unwrap(parenthesized.Expression),
+        CastExpressionSyntax cast => Unwrap(cast.Expression),
+        PostfixUnaryExpressionSyntax { RawKind: (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.SuppressNullableWarningExpression } suppress =>
+            Unwrap(suppress.Operand),
+        _ => expression
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/PrecedingGuards.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/PrecedingGuards.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reads what the guard clauses a statement sits after say about when it is reached.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A body that leaves early on one outcome and produces the other afterwards has decided between the two just as
+/// much as one that writes both branches out. Without reading the guard, the second event would be stated as always
+/// produced, which describes a different application rather than an incomplete one.
+/// <para>
+/// This is where the state of an aggregate root most often decides something - a behavior refusing to act on what it
+/// has already seen - so a guard reading that state is reported rather than passed over in silence.
+/// </para>
+/// </remarks>
+public class PrecedingGuards(ScreenplayDiagnostics diagnostics)
+{
+    readonly UnmappableConditions _unmappable = new(diagnostics);
+
+    /// <summary>
+    /// Reads the guard clauses standing between the start of a block and a statement in it.
+    /// </summary>
+    /// <param name="block">The block the statement sits in.</param>
+    /// <param name="node">The statement.</param>
+    /// <param name="scope">The <see cref="ProducesScope"/> the block was read in.</param>
+    /// <param name="eventType">The type of the event being produced.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The condition, or <see langword="null"/> when nothing guards the statement.</returns>
+    public ConditionModel? In(
+        BlockSyntax block,
+        SyntaxNode node,
+        ProducesScope scope,
+        ITypeSymbol eventType,
+        string location)
+    {
+        ConditionModel? condition = null;
+
+        foreach (var statement in block.Statements.TakeWhile(_ => !ReferenceEquals(_, node)))
+        {
+            if (statement is not IfStatementSyntax { Else: null } guard || !AlwaysExits(guard.Statement))
+            {
+                continue;
+            }
+
+            var read = ConditionReader.Read(guard.Condition, scope.SemanticModel, scope.Command, scope.Bindings);
+            var inverted = ConditionReader.Invert(read);
+            if (inverted is null)
+            {
+                _unmappable.ReportAggregateState(guard.Condition, scope, eventType, location);
+                continue;
+            }
+
+            condition = condition is null ? inverted : new LogicalCondition(condition, false, inverted);
+        }
+
+        return condition;
+    }
+
+    /// <summary>
+    /// Determines whether a branch always leaves the body, making everything after it the other outcome.
+    /// </summary>
+    /// <param name="statement">The branch to check.</param>
+    /// <returns>True when the branch always exits.</returns>
+    static bool AlwaysExits(StatementSyntax statement) => statement switch
+    {
+        ReturnStatementSyntax or ThrowStatementSyntax => true,
+        BlockSyntax block => block.Statements.Count > 0 && AlwaysExits(block.Statements[^1]),
+        _ => false
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/PrecedingGuards.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/PrecedingGuards.cs
@@ -23,6 +23,7 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 public class PrecedingGuards(ScreenplayDiagnostics diagnostics)
 {
     readonly UnmappableConditions _unmappable = new(diagnostics);
+    readonly ConditionReader _conditions = new(diagnostics);
 
     /// <summary>
     /// Reads the guard clauses standing between the start of a block and a statement in it.
@@ -49,7 +50,7 @@ public class PrecedingGuards(ScreenplayDiagnostics diagnostics)
                 continue;
             }
 
-            var read = ConditionReader.Read(guard.Condition, scope.SemanticModel, scope.Command, scope.Bindings);
+            var read = _conditions.Read(guard.Condition, scope.SemanticModel, scope.Command, location, scope.Bindings);
             var inverted = ConditionReader.Invert(read);
             if (inverted is null)
             {

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesConditionResolver.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesConditionResolver.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Resolves the condition guarding an event construction, from the branches it sits inside.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A handler that decides between two events is the whole reason conditions exist in a document, so the decision is
+/// read from the branch structure rather than left out. A branch that cannot be expressed produces the event
+/// unconditionally and says so, which is wrong in a way the reader can see rather than wrong silently.
+/// </remarks>
+public class ProducesConditionResolver(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Resolves the condition guarding an event construction, by walking out to the body it lives in.
+    /// </summary>
+    /// <param name="creation">The construction to resolve for.</param>
+    /// <param name="body">The body the construction lives in.</param>
+    /// <param name="semanticModel">The semantic model of the tree the construction lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The condition, or <see langword="null"/> when the production is unconditional.</returns>
+    public ConditionModel? Resolve(
+        SyntaxNode creation,
+        SyntaxNode body,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ITypeSymbol eventType,
+        string location)
+    {
+        ConditionModel? condition = null;
+
+        for (var node = creation; node is not null && node != body; node = node.Parent)
+        {
+            var step = StepFor(node, semanticModel, owner, eventType, location);
+            if (step is not null)
+            {
+                condition = condition is null ? step : new LogicalCondition(condition, false, step);
+            }
+        }
+
+        return condition;
+    }
+
+    /// <summary>
+    /// Resolves what the guard clauses a statement sits after say about when it is reached.
+    /// </summary>
+    /// <param name="block">The block the statement sits in.</param>
+    /// <param name="node">The statement.</param>
+    /// <param name="semanticModel">The semantic model of the tree the block lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <returns>The condition, or <see langword="null"/> when nothing guards the statement.</returns>
+    /// <remarks>
+    /// A handler that returns one event from inside a branch and another after it has decided between the two just
+    /// as much as one that writes the second branch out. Without reading the guard, the second event would be
+    /// stated as always produced, which describes a different application rather than an incomplete one.
+    /// </remarks>
+    static ConditionModel? GuardsBefore(BlockSyntax block, SyntaxNode node, SemanticModel semanticModel, ITypeSymbol owner)
+    {
+        ConditionModel? condition = null;
+
+        foreach (var statement in block.Statements.TakeWhile(_ => !ReferenceEquals(_, node)))
+        {
+            if (statement is not IfStatementSyntax { Else: null } guard || !AlwaysExits(guard.Statement))
+            {
+                continue;
+            }
+
+            var inverted = ConditionReader.Invert(ConditionReader.Read(guard.Condition, semanticModel, owner));
+            if (inverted is not null)
+            {
+                condition = condition is null ? inverted : new LogicalCondition(condition, false, inverted);
+            }
+        }
+
+        return condition;
+    }
+
+    /// <summary>
+    /// Determines whether a branch always leaves the handler, making everything after it the other outcome.
+    /// </summary>
+    /// <param name="statement">The branch to check.</param>
+    /// <returns>True when the branch always exits.</returns>
+    static bool AlwaysExits(StatementSyntax statement) => statement switch
+    {
+        ReturnStatementSyntax or ThrowStatementSyntax => true,
+        BlockSyntax block => block.Statements.Count > 0 && AlwaysExits(block.Statements[^1]),
+        _ => false
+    };
+
+    /// <summary>
+    /// Resolves the condition one enclosing decision contributes.
+    /// </summary>
+    /// <param name="node">The node whose parent is the decision.</param>
+    /// <param name="semanticModel">The semantic model of the tree the node lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The condition, or <see langword="null"/> when the decision contributes none.</returns>
+    ConditionModel? StepFor(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ITypeSymbol eventType,
+        string location)
+    {
+        switch (node.Parent)
+        {
+            case IfStatementSyntax statement:
+                return Branch(
+                    ConditionReader.Read(statement.Condition, semanticModel, owner),
+                    ReferenceEquals(node, statement.Statement),
+                    ReferenceEquals(node, statement.Else),
+                    eventType,
+                    location);
+
+            case ConditionalExpressionSyntax conditional:
+                return Branch(
+                    ConditionReader.Read(conditional.Condition, semanticModel, owner),
+                    ReferenceEquals(node, conditional.WhenTrue),
+                    ReferenceEquals(node, conditional.WhenFalse),
+                    eventType,
+                    location);
+
+            case BlockSyntax block:
+                return GuardsBefore(block, node, semanticModel, owner);
+
+            case SwitchSectionSyntax or SwitchExpressionArmSyntax:
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableCommandProduction,
+                    $"'{eventType.Name}' is produced from a switch, which has no counterpart in a produces condition, so it is stated unconditionally",
+                    location);
+
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves which side of a decision a production sits on.
+    /// </summary>
+    /// <param name="condition">The condition of the decision.</param>
+    /// <param name="isPositive">Whether the production sits on the branch taken when the condition holds.</param>
+    /// <param name="isNegative">Whether the production sits on the branch taken when it does not.</param>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The condition for the branch, or <see langword="null"/>.</returns>
+    ConditionModel? Branch(ConditionModel? condition, bool isPositive, bool isNegative, ITypeSymbol eventType, string location)
+    {
+        if (!isPositive && !isNegative)
+        {
+            return null;
+        }
+
+        var resolved = isPositive ? condition : ConditionReader.Invert(condition);
+        if (resolved is null)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableCommandProduction,
+                $"The branch producing '{eventType.Name}' is guarded by code that has no counterpart in a produces condition, so it is stated unconditionally",
+                location);
+        }
+
+        return resolved;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesConditionResolver.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesConditionResolver.cs
@@ -15,24 +15,30 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// A handler that decides between two events is the whole reason conditions exist in a document, so the decision is
 /// read from the branch structure rather than left out. A branch that cannot be expressed produces the event
 /// unconditionally and says so, which is wrong in a way the reader can see rather than wrong silently.
+/// <para>
+/// A body an aggregate root declares is read exactly like the handler's own, with the call site standing in for the
+/// names the aggregate root gave the input. What it decides on its own state is the one thing that stays out,
+/// because the language has nowhere to put it.
+/// </para>
 /// </remarks>
 public class ProducesConditionResolver(ScreenplayDiagnostics diagnostics)
 {
+    readonly UnmappableConditions _unmappable = new(diagnostics);
+    readonly PrecedingGuards _guards = new(diagnostics);
+
     /// <summary>
     /// Resolves the condition guarding an event construction, by walking out to the body it lives in.
     /// </summary>
     /// <param name="creation">The construction to resolve for.</param>
     /// <param name="body">The body the construction lives in.</param>
-    /// <param name="semanticModel">The semantic model of the tree the construction lives in.</param>
-    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="scope">The <see cref="ProducesScope"/> the body was read in.</param>
     /// <param name="eventType">The type of the event being constructed.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <returns>The condition, or <see langword="null"/> when the production is unconditional.</returns>
     public ConditionModel? Resolve(
         SyntaxNode creation,
         SyntaxNode body,
-        SemanticModel semanticModel,
-        ITypeSymbol owner,
+        ProducesScope scope,
         ITypeSymbol eventType,
         string location)
     {
@@ -40,7 +46,7 @@ public class ProducesConditionResolver(ScreenplayDiagnostics diagnostics)
 
         for (var node = creation; node is not null && node != body; node = node.Parent)
         {
-            var step = StepFor(node, semanticModel, owner, eventType, location);
+            var step = StepFor(node, scope, eventType, location);
             if (step is not null)
             {
                 condition = condition is null ? step : new LogicalCondition(condition, false, step);
@@ -51,87 +57,37 @@ public class ProducesConditionResolver(ScreenplayDiagnostics diagnostics)
     }
 
     /// <summary>
-    /// Resolves what the guard clauses a statement sits after say about when it is reached.
-    /// </summary>
-    /// <param name="block">The block the statement sits in.</param>
-    /// <param name="node">The statement.</param>
-    /// <param name="semanticModel">The semantic model of the tree the block lives in.</param>
-    /// <param name="owner">The type whose properties count as the command's own input.</param>
-    /// <returns>The condition, or <see langword="null"/> when nothing guards the statement.</returns>
-    /// <remarks>
-    /// A handler that returns one event from inside a branch and another after it has decided between the two just
-    /// as much as one that writes the second branch out. Without reading the guard, the second event would be
-    /// stated as always produced, which describes a different application rather than an incomplete one.
-    /// </remarks>
-    static ConditionModel? GuardsBefore(BlockSyntax block, SyntaxNode node, SemanticModel semanticModel, ITypeSymbol owner)
-    {
-        ConditionModel? condition = null;
-
-        foreach (var statement in block.Statements.TakeWhile(_ => !ReferenceEquals(_, node)))
-        {
-            if (statement is not IfStatementSyntax { Else: null } guard || !AlwaysExits(guard.Statement))
-            {
-                continue;
-            }
-
-            var inverted = ConditionReader.Invert(ConditionReader.Read(guard.Condition, semanticModel, owner));
-            if (inverted is not null)
-            {
-                condition = condition is null ? inverted : new LogicalCondition(condition, false, inverted);
-            }
-        }
-
-        return condition;
-    }
-
-    /// <summary>
-    /// Determines whether a branch always leaves the handler, making everything after it the other outcome.
-    /// </summary>
-    /// <param name="statement">The branch to check.</param>
-    /// <returns>True when the branch always exits.</returns>
-    static bool AlwaysExits(StatementSyntax statement) => statement switch
-    {
-        ReturnStatementSyntax or ThrowStatementSyntax => true,
-        BlockSyntax block => block.Statements.Count > 0 && AlwaysExits(block.Statements[^1]),
-        _ => false
-    };
-
-    /// <summary>
     /// Resolves the condition one enclosing decision contributes.
     /// </summary>
     /// <param name="node">The node whose parent is the decision.</param>
-    /// <param name="semanticModel">The semantic model of the tree the node lives in.</param>
-    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="scope">The <see cref="ProducesScope"/> the node was read in.</param>
     /// <param name="eventType">The type of the event being constructed.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <returns>The condition, or <see langword="null"/> when the decision contributes none.</returns>
-    ConditionModel? StepFor(
-        SyntaxNode node,
-        SemanticModel semanticModel,
-        ITypeSymbol owner,
-        ITypeSymbol eventType,
-        string location)
+    ConditionModel? StepFor(SyntaxNode node, ProducesScope scope, ITypeSymbol eventType, string location)
     {
         switch (node.Parent)
         {
             case IfStatementSyntax statement:
-                return Branch(
-                    ConditionReader.Read(statement.Condition, semanticModel, owner),
+                return Decision(
+                    statement.Condition,
                     ReferenceEquals(node, statement.Statement),
                     ReferenceEquals(node, statement.Else),
+                    scope,
                     eventType,
                     location);
 
             case ConditionalExpressionSyntax conditional:
-                return Branch(
-                    ConditionReader.Read(conditional.Condition, semanticModel, owner),
+                return Decision(
+                    conditional.Condition,
                     ReferenceEquals(node, conditional.WhenTrue),
                     ReferenceEquals(node, conditional.WhenFalse),
+                    scope,
                     eventType,
                     location);
 
             case BlockSyntax block:
-                return GuardsBefore(block, node, semanticModel, owner);
+                return _guards.In(block, node, scope, eventType, location);
 
             case SwitchSectionSyntax or SwitchExpressionArmSyntax:
                 diagnostics.Warning(
@@ -149,26 +105,31 @@ public class ProducesConditionResolver(ScreenplayDiagnostics diagnostics)
     /// <summary>
     /// Resolves which side of a decision a production sits on.
     /// </summary>
-    /// <param name="condition">The condition of the decision.</param>
-    /// <param name="isPositive">Whether the production sits on the branch taken when the condition holds.</param>
+    /// <param name="guard">The expression the decision is made on.</param>
+    /// <param name="isPositive">Whether the production sits on the branch taken when the guard holds.</param>
     /// <param name="isNegative">Whether the production sits on the branch taken when it does not.</param>
+    /// <param name="scope">The <see cref="ProducesScope"/> the decision was read in.</param>
     /// <param name="eventType">The type of the event being constructed.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <returns>The condition for the branch, or <see langword="null"/>.</returns>
-    ConditionModel? Branch(ConditionModel? condition, bool isPositive, bool isNegative, ITypeSymbol eventType, string location)
+    ConditionModel? Decision(
+        ExpressionSyntax guard,
+        bool isPositive,
+        bool isNegative,
+        ProducesScope scope,
+        ITypeSymbol eventType,
+        string location)
     {
         if (!isPositive && !isNegative)
         {
             return null;
         }
 
+        var condition = ConditionReader.Read(guard, scope.SemanticModel, scope.Command, scope.Bindings);
         var resolved = isPositive ? condition : ConditionReader.Invert(condition);
         if (resolved is null)
         {
-            diagnostics.Warning(
-                ScreenplayDiagnosticCodes.UnmappableCommandProduction,
-                $"The branch producing '{eventType.Name}' is guarded by code that has no counterpart in a produces condition, so it is stated unconditionally",
-                location);
+            _unmappable.Report(guard, scope, eventType, location);
         }
 
         return resolved;

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesConditionResolver.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesConditionResolver.cs
@@ -25,6 +25,7 @@ public class ProducesConditionResolver(ScreenplayDiagnostics diagnostics)
 {
     readonly UnmappableConditions _unmappable = new(diagnostics);
     readonly PrecedingGuards _guards = new(diagnostics);
+    readonly ConditionReader _conditions = new(diagnostics);
 
     /// <summary>
     /// Resolves the condition guarding an event construction, by walking out to the body it lives in.
@@ -125,7 +126,7 @@ public class ProducesConditionResolver(ScreenplayDiagnostics diagnostics)
             return null;
         }
 
-        var condition = ConditionReader.Read(guard, scope.SemanticModel, scope.Command, scope.Bindings);
+        var condition = _conditions.Read(guard, scope.SemanticModel, scope.Command, location, scope.Bindings);
         var resolved = isPositive ? condition : ConditionReader.Invert(condition);
         if (resolved is null)
         {

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesMappingReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesMappingReader.cs
@@ -18,6 +18,8 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// </remarks>
 public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
 {
+    readonly MappingSourceReader _sources = new(diagnostics);
+
     /// <summary>
     /// Reads the mappings of a single event construction.
     /// </summary>
@@ -164,7 +166,7 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
         string location,
         ParameterBindings? bindings)
     {
-        var source = MappingSourceReader.Read(expression, semanticModel, owner, bindings);
+        var source = _sources.Read(expression, semanticModel, owner, location, bindings);
         if (source is null)
         {
             Report(eventType, property, location);

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesMappingReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesMappingReader.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reads the mappings from a command's input onto the properties of an event it constructs.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// This is what reading source buys over reading metadata - the arguments handed to an event's constructor say
+/// exactly where each property's value comes from, rather than being guessed at by matching names.
+/// </remarks>
+public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Reads the mappings of a single event construction.
+    /// </summary>
+    /// <param name="creation">The construction to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the construction lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The mappings, in the order the source declares them.</returns>
+    public IEnumerable<PropertyMappingModel> Read(
+        BaseObjectCreationExpressionSyntax creation,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ITypeSymbol eventType,
+        string location)
+    {
+        var mappings = new List<PropertyMappingModel>();
+        var constructor = semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol;
+
+        ReadArguments(creation, constructor, semanticModel, owner, eventType, location, mappings);
+        ReadInitializer(creation, semanticModel, owner, eventType, location, mappings);
+
+        return mappings;
+    }
+
+    /// <summary>
+    /// Gets the name of the property an argument fills in.
+    /// </summary>
+    /// <param name="argument">The argument to name.</param>
+    /// <param name="constructor">The constructor being called.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The parameter name, or <see langword="null"/> when it cannot be resolved.</returns>
+    static string? NameOf(ArgumentSyntax argument, IMethodSymbol? constructor, int index)
+    {
+        if (argument.NameColon is { } named)
+        {
+            return named.Name.Identifier.ValueText;
+        }
+
+        return constructor is not null && index < constructor.Parameters.Length ? constructor.Parameters[index].Name : null;
+    }
+
+    /// <summary>
+    /// Resolves the declared casing of a property from the name an argument used.
+    /// </summary>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="name">The name to resolve.</param>
+    /// <returns>The property name.</returns>
+    static string PropertyOf(ITypeSymbol eventType, string name) =>
+        eventType.DeclaredProperties().FirstOrDefault(_ => string.Equals(_.Name, name, StringComparison.OrdinalIgnoreCase))?.Name ?? name;
+
+    /// <summary>
+    /// Reads the mappings the constructor arguments declare.
+    /// </summary>
+    /// <param name="creation">The construction to read.</param>
+    /// <param name="constructor">The constructor being called.</param>
+    /// <param name="semanticModel">The semantic model of the tree the construction lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="mappings">The mappings collected so far.</param>
+    void ReadArguments(
+        BaseObjectCreationExpressionSyntax creation,
+        IMethodSymbol? constructor,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ITypeSymbol eventType,
+        string location,
+        List<PropertyMappingModel> mappings)
+    {
+        var arguments = creation.ArgumentList?.Arguments;
+        if (arguments is null)
+        {
+            return;
+        }
+
+        for (var index = 0; index < arguments.Value.Count; index++)
+        {
+            var argument = arguments.Value[index];
+            var name = NameOf(argument, constructor, index);
+            if (name is null)
+            {
+                Report(eventType, $"argument {index + 1}", location);
+                continue;
+            }
+
+            Add(mappings, PropertyOf(eventType, name), argument.Expression, semanticModel, owner, eventType, location);
+        }
+    }
+
+    /// <summary>
+    /// Reads the mappings an object initializer declares.
+    /// </summary>
+    /// <param name="creation">The construction to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the construction lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="mappings">The mappings collected so far.</param>
+    void ReadInitializer(
+        BaseObjectCreationExpressionSyntax creation,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ITypeSymbol eventType,
+        string location,
+        List<PropertyMappingModel> mappings)
+    {
+        foreach (var assignment in creation.Initializer?.Expressions.OfType<AssignmentExpressionSyntax>() ?? [])
+        {
+            if (assignment.Left is not IdentifierNameSyntax identifier)
+            {
+                Report(eventType, assignment.Left.ToString(), location);
+                continue;
+            }
+
+            Add(mappings, PropertyOf(eventType, identifier.Identifier.ValueText), assignment.Right, semanticModel, owner, eventType, location);
+        }
+    }
+
+    /// <summary>
+    /// Adds a mapping, reporting an expression that could not be expressed rather than guessing at it.
+    /// </summary>
+    /// <param name="mappings">The mappings collected so far.</param>
+    /// <param name="property">The property being filled in.</param>
+    /// <param name="expression">The expression filling it in.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="owner">The type whose properties count as the command's own input.</param>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    void Add(
+        List<PropertyMappingModel> mappings,
+        string property,
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol owner,
+        ITypeSymbol eventType,
+        string location)
+    {
+        var source = MappingSourceReader.Read(expression, semanticModel, owner);
+        if (source is null)
+        {
+            Report(eventType, property, location);
+            return;
+        }
+
+        mappings.Add(new(property, source));
+    }
+
+    /// <summary>
+    /// Reports a mapping that could not be expressed.
+    /// </summary>
+    /// <param name="eventType">The type of the event being constructed.</param>
+    /// <param name="property">The property that was being filled in.</param>
+    /// <param name="location">Where the command lives.</param>
+    void Report(ITypeSymbol eventType, string property, string location) =>
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnmappableCommandProduction,
+            $"The value given to '{eventType.Name}.{property}' is code rather than command input or a constant, so the mapping was left out",
+            location);
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesMappingReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesMappingReader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -25,19 +26,21 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
     /// <param name="owner">The type whose properties count as the command's own input.</param>
     /// <param name="eventType">The type of the event being constructed.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read, if it is not the handler's own.</param>
     /// <returns>The mappings, in the order the source declares them.</returns>
     public IEnumerable<PropertyMappingModel> Read(
         BaseObjectCreationExpressionSyntax creation,
         SemanticModel semanticModel,
         ITypeSymbol owner,
         ITypeSymbol eventType,
-        string location)
+        string location,
+        ParameterBindings? bindings = null)
     {
         var mappings = new List<PropertyMappingModel>();
         var constructor = semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol;
 
-        ReadArguments(creation, constructor, semanticModel, owner, eventType, location, mappings);
-        ReadInitializer(creation, semanticModel, owner, eventType, location, mappings);
+        ReadArguments(creation, constructor, semanticModel, owner, eventType, location, mappings, bindings);
+        ReadInitializer(creation, semanticModel, owner, eventType, location, mappings, bindings);
 
         return mappings;
     }
@@ -78,6 +81,7 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
     /// <param name="eventType">The type of the event being constructed.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <param name="mappings">The mappings collected so far.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
     void ReadArguments(
         BaseObjectCreationExpressionSyntax creation,
         IMethodSymbol? constructor,
@@ -85,7 +89,8 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
         ITypeSymbol owner,
         ITypeSymbol eventType,
         string location,
-        List<PropertyMappingModel> mappings)
+        List<PropertyMappingModel> mappings,
+        ParameterBindings? bindings)
     {
         var arguments = creation.ArgumentList?.Arguments;
         if (arguments is null)
@@ -103,7 +108,7 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
                 continue;
             }
 
-            Add(mappings, PropertyOf(eventType, name), argument.Expression, semanticModel, owner, eventType, location);
+            Add(mappings, PropertyOf(eventType, name), argument.Expression, semanticModel, owner, eventType, location, bindings);
         }
     }
 
@@ -116,13 +121,15 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
     /// <param name="eventType">The type of the event being constructed.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <param name="mappings">The mappings collected so far.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
     void ReadInitializer(
         BaseObjectCreationExpressionSyntax creation,
         SemanticModel semanticModel,
         ITypeSymbol owner,
         ITypeSymbol eventType,
         string location,
-        List<PropertyMappingModel> mappings)
+        List<PropertyMappingModel> mappings,
+        ParameterBindings? bindings)
     {
         foreach (var assignment in creation.Initializer?.Expressions.OfType<AssignmentExpressionSyntax>() ?? [])
         {
@@ -132,7 +139,7 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
                 continue;
             }
 
-            Add(mappings, PropertyOf(eventType, identifier.Identifier.ValueText), assignment.Right, semanticModel, owner, eventType, location);
+            Add(mappings, PropertyOf(eventType, identifier.Identifier.ValueText), assignment.Right, semanticModel, owner, eventType, location, bindings);
         }
     }
 
@@ -146,6 +153,7 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
     /// <param name="owner">The type whose properties count as the command's own input.</param>
     /// <param name="eventType">The type of the event being constructed.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="bindings">What the call site gave the parameters of the body being read.</param>
     void Add(
         List<PropertyMappingModel> mappings,
         string property,
@@ -153,9 +161,10 @@ public class ProducesMappingReader(ScreenplayDiagnostics diagnostics)
         SemanticModel semanticModel,
         ITypeSymbol owner,
         ITypeSymbol eventType,
-        string location)
+        string location,
+        ParameterBindings? bindings)
     {
-        var source = MappingSourceReader.Read(expression, semanticModel, owner);
+        var source = MappingSourceReader.Read(expression, semanticModel, owner, bindings);
         if (source is null)
         {
             Report(eventType, property, location);

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reads the events a command produces, from the body of its handler.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Every event the handler constructs is a production, wherever in the body it happens - returned directly, wrapped
+/// in a result, appended to a log or handed to a collection. Reading the construction is what gives the mappings
+/// their values, rather than pairing names up and hoping.
+/// </remarks>
+public class ProducesReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+{
+    readonly ProducesMappingReader _mappings = new(diagnostics);
+    readonly ProducesConditionResolver _conditions = new(diagnostics);
+
+    /// <summary>
+    /// Reads everything the handlers of a command produce.
+    /// </summary>
+    /// <param name="command">The type declaring the command.</param>
+    /// <param name="handlers">The handler methods to read.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The productions, in the order the source declares them.</returns>
+    public IEnumerable<ProducesModel> Read(INamedTypeSymbol command, IReadOnlyList<IMethodSymbol> handlers, string location)
+    {
+        var produces = new List<ProducesModel>();
+
+        foreach (var handler in handlers)
+        {
+            ReportEventSourceIdResult(handler, location);
+
+            foreach (var body in HandlerBodies.Of(handler))
+            {
+                ReadBody(command, body, location, produces);
+            }
+        }
+
+        return produces.Count > 0 ? Deduplicate(produces) : FromSignatures(handlers, location);
+    }
+
+    /// <summary>
+    /// Removes productions the source declared more than once, keeping the first.
+    /// </summary>
+    /// <param name="produces">The productions to reduce.</param>
+    /// <returns>The distinct productions.</returns>
+    static List<ProducesModel> Deduplicate(IEnumerable<ProducesModel> produces)
+    {
+        var kept = new List<ProducesModel>();
+
+        foreach (var production in produces)
+        {
+            if (!kept.Exists(existing => IsSame(existing, production)))
+            {
+                kept.Add(production);
+            }
+        }
+
+        return kept;
+    }
+
+    /// <summary>
+    /// Determines whether two productions say the same thing.
+    /// </summary>
+    /// <param name="left">The first production.</param>
+    /// <param name="right">The second production.</param>
+    /// <returns>True when they are the same.</returns>
+    static bool IsSame(ProducesModel left, ProducesModel right) =>
+        string.Equals(left.EventName, right.EventName, StringComparison.Ordinal) &&
+        Equals(left.When, right.When) &&
+        left.Mappings.SequenceEqual(right.Mappings);
+
+    /// <summary>
+    /// Reads every event constructed within one handler body.
+    /// </summary>
+    /// <param name="command">The type declaring the command.</param>
+    /// <param name="body">The body to read.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="produces">The productions collected so far.</param>
+    void ReadBody(INamedTypeSymbol command, SyntaxNode body, string location, List<ProducesModel> produces)
+    {
+        var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
+
+        foreach (var creation in body.DescendantNodesAndSelf().OfType<BaseObjectCreationExpressionSyntax>())
+        {
+            if (semanticModel.GetTypeInfo(creation).Type is not INamedTypeSymbol type || !EventReader.IsEvent(type))
+            {
+                continue;
+            }
+
+            produces.Add(new(
+                type.Name,
+                _conditions.Resolve(creation, body, semanticModel, command, type, location),
+                _mappings.Read(creation, semanticModel, command, type, location)));
+        }
+    }
+
+    /// <summary>
+    /// Falls back to what the signatures of the handlers promise when no body could be read.
+    /// </summary>
+    /// <param name="handlers">The handler methods to read.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The productions, without mappings.</returns>
+    IEnumerable<ProducesModel> FromSignatures(IReadOnlyList<IMethodSymbol> handlers, string location)
+    {
+        var events = handlers
+            .SelectMany(_ => HandlerBodies.EventTypesIn(_.ReturnType))
+            .Select(_ => _.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var name in events)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableCommandProduction,
+                $"'{name}' is named by the handler's signature but never constructed in a body that could be read, so it is stated without mappings",
+                location);
+        }
+
+        return [.. events.Select(_ => new ProducesModel(_, null, []))];
+    }
+
+    /// <summary>
+    /// Reports a handler yielding the identifier of the event source it appends to.
+    /// </summary>
+    /// <param name="handler">The handler to check.</param>
+    /// <param name="location">Where the command lives.</param>
+    void ReportEventSourceIdResult(IMethodSymbol handler, string location)
+    {
+        if (HandlerBodies.YieldsEventSourceId(handler.ReturnType))
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.UnmappableEventSourceIdResult,
+                "The handler yields the identifier of the event source alongside the event, which Screenplay has no counterpart for",
+                location);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
 using Cratis.Arc.Screenplay.Analysis.Events;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
@@ -12,13 +13,18 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// Reads the events a command produces, from the body of its handler.
 /// </summary>
 /// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="aggregates">The <see cref="AggregateRootCatalog"/> recording which aggregate roots a command reaches.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <remarks>
 /// Every event the handler constructs is a production, wherever in the body it happens - returned directly, wrapped
 /// in a result, appended to a log or handed to a collection. Reading the construction is what gives the mappings
 /// their values, rather than pairing names up and hoping.
+/// <para>
+/// A handler that governs its change through an aggregate root constructs nothing itself, so the behaviors it calls
+/// are read as well. Both ways of writing an Arc command then describe the same thing in the document.
+/// </para>
 /// </remarks>
-public class ProducesReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+public class ProducesReader(Compilation compilation, AggregateRootCatalog aggregates, ScreenplayDiagnostics diagnostics)
 {
     readonly ProducesMappingReader _mappings = new(diagnostics);
     readonly ProducesConditionResolver _conditions = new(diagnostics);
@@ -40,7 +46,13 @@ public class ProducesReader(Compilation compilation, ScreenplayDiagnostics diagn
 
             foreach (var body in HandlerBodies.Of(handler))
             {
-                ReadBody(command, body, location, produces);
+                ReadBody(command, body, location, produces, null);
+
+                foreach (var behavior in AggregateRootBehaviors.ReachedFrom(body, compilation))
+                {
+                    aggregates.Reached(behavior.AggregateRoot);
+                    ReadBody(command, behavior.Body, location, produces, behavior.Bindings);
+                }
             }
         }
 
@@ -85,7 +97,13 @@ public class ProducesReader(Compilation compilation, ScreenplayDiagnostics diagn
     /// <param name="body">The body to read.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <param name="produces">The productions collected so far.</param>
-    void ReadBody(INamedTypeSymbol command, SyntaxNode body, string location, List<ProducesModel> produces)
+    /// <param name="bindings">What the handler gave the body's parameters, when the body is one it called.</param>
+    void ReadBody(
+        INamedTypeSymbol command,
+        SyntaxNode body,
+        string location,
+        List<ProducesModel> produces,
+        ParameterBindings? bindings)
     {
         var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
 
@@ -99,7 +117,7 @@ public class ProducesReader(Compilation compilation, ScreenplayDiagnostics diagn
             produces.Add(new(
                 type.Name,
                 _conditions.Resolve(creation, body, semanticModel, command, type, location),
-                _mappings.Read(creation, semanticModel, command, type, location)));
+                _mappings.Read(creation, semanticModel, command, type, location, bindings)));
         }
     }
 

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
@@ -51,7 +51,7 @@ public class ProducesReader(Compilation compilation, AggregateRootCatalog aggreg
                 foreach (var behavior in AggregateRootBehaviors.ReachedFrom(body, compilation))
                 {
                     aggregates.Reached(behavior.AggregateRoot);
-                    ReadBody(command, behavior.Body, location, produces, behavior.Bindings);
+                    ReadBody(command, behavior.Body, location, produces, behavior);
                 }
             }
         }
@@ -97,15 +97,16 @@ public class ProducesReader(Compilation compilation, AggregateRootCatalog aggreg
     /// <param name="body">The body to read.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <param name="produces">The productions collected so far.</param>
-    /// <param name="bindings">What the handler gave the body's parameters, when the body is one it called.</param>
+    /// <param name="behavior">The behavior the body belongs to, when the handler reached it through an aggregate root.</param>
     void ReadBody(
         INamedTypeSymbol command,
         SyntaxNode body,
         string location,
         List<ProducesModel> produces,
-        ParameterBindings? bindings)
+        AggregateRootInvocation? behavior)
     {
         var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
+        var scope = new ProducesScope(semanticModel, command, behavior?.Bindings, behavior?.AggregateRoot);
 
         foreach (var creation in body.DescendantNodesAndSelf().OfType<BaseObjectCreationExpressionSyntax>())
         {
@@ -116,8 +117,8 @@ public class ProducesReader(Compilation compilation, AggregateRootCatalog aggreg
 
             produces.Add(new(
                 type.Name,
-                _conditions.Resolve(creation, body, semanticModel, command, type, location),
-                _mappings.Read(creation, semanticModel, command, type, location, bindings)));
+                _conditions.Resolve(creation, body, scope, type, location),
+                _mappings.Read(creation, semanticModel, command, type, location, scope.Bindings)));
         }
     }
 

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesScope.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesScope.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Represents the body a production was read from, and everything needed to follow a value in it back to the command.
+/// </summary>
+/// <param name="SemanticModel">The semantic model of the tree the body lives in.</param>
+/// <param name="Command">The type whose properties count as the command's own input.</param>
+/// <param name="Bindings">What the handler gave the body's parameters, when the body is one it called.</param>
+/// <param name="AggregateRoot">The aggregate root declaring the body, when the body is a behavior of one.</param>
+/// <remarks>
+/// A handler's own body and a behavior it hands its work to are read the same way, and the only difference between
+/// them is what stands in for the names they use. Carrying that difference in one place is what lets a condition be
+/// resolved back to command input wherever it was written, rather than only in the handler.
+/// </remarks>
+public record ProducesScope(
+    SemanticModel SemanticModel,
+    ITypeSymbol Command,
+    ParameterBindings? Bindings,
+    INamedTypeSymbol? AggregateRoot);

--- a/Source/DotNET/Screenplay/Analysis/Commands/UnmappableConditions.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/UnmappableConditions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// Reports the guards a <c>produces when</c> condition cannot carry.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Two very different things end up in the same place - a guard that could not be read, and a guard that was read
+/// perfectly well and has nowhere to go. An aggregate root deciding on its own state is the second, and saying which
+/// one happened is the difference between a reader looking for a bug in the generator and a reader understanding
+/// that the language stops there.
+/// </remarks>
+public class UnmappableConditions(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Reports a guard that could not be carried into a condition, whatever the reason.
+    /// </summary>
+    /// <param name="guard">The guard expression.</param>
+    /// <param name="scope">The <see cref="ProducesScope"/> the guard was read in.</param>
+    /// <param name="eventType">The type of the event being produced.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    public void Report(ExpressionSyntax guard, ProducesScope scope, ITypeSymbol eventType, string location)
+    {
+        if (ReportAggregateState(guard, scope, eventType, location))
+        {
+            return;
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnmappableCommandProduction,
+            $"The branch producing '{eventType.Name}' is guarded by code that has no counterpart in a produces condition, so it is stated unconditionally",
+            location);
+    }
+
+    /// <summary>
+    /// Reports a guard reading the state of an aggregate root, and nothing else.
+    /// </summary>
+    /// <param name="guard">The guard expression.</param>
+    /// <param name="scope">The <see cref="ProducesScope"/> the guard was read in.</param>
+    /// <param name="eventType">The type of the event being produced.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>True when the guard reads aggregate root state and was reported.</returns>
+    public bool ReportAggregateState(ExpressionSyntax guard, ProducesScope scope, ITypeSymbol eventType, string location)
+    {
+        if (!AggregateState.IsReadBy(guard, scope.SemanticModel, scope.AggregateRoot))
+        {
+            return false;
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnmappableAggregateStateCondition,
+            $"The branch producing '{eventType.Name}' is guarded by the state '{scope.AggregateRoot!.Name}' holds, and a produces condition can only compare the input of the command, so it is stated unconditionally",
+            location);
+
+        return true;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/ConceptValidations.cs
+++ b/Source/DotNET/Screenplay/Analysis/ConceptValidations.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Attaches the rules a validator declares for a concept to the concept itself.
+/// </summary>
+/// <remarks>
+/// A concept validator is written against the concept's value, and a concept declaration takes its rules against
+/// its own implied value, so the two line up exactly - the property the rule names is dropped by emission.
+/// </remarks>
+public static class ConceptValidations
+{
+    /// <summary>
+    /// Attaches every concept validator's rules to the concept it validates.
+    /// </summary>
+    /// <param name="catalog">The catalogue of everything the compilation declares.</param>
+    /// <param name="readers">The readers holding the concepts and the validators.</param>
+    public static void Link(ArtifactCatalog catalog, ArtifactReaders readers)
+    {
+        var declared = readers.Types.Concepts.Select(_ => _.Name).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var type in catalog.Types.Where(_ => declared.Contains(_.Name)))
+        {
+            if (type.FindBase(WellKnownTypeNames.ConceptAs) is null)
+            {
+                continue;
+            }
+
+            readers.Types.AddValidations(type.Name, readers.Validators.For(type));
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Constraints/ConstraintNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/Constraints/ConstraintNames.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Constraints;
+
+/// <summary>
+/// Resolves the name a constraint rule is declared under.
+/// </summary>
+/// <remarks>
+/// A rule can be named outright, named by a literal handed to it, or not named at all. The last case falls back to
+/// a name derived from what the rule constrains, because a constraint nothing can refer to is of no use to a reader.
+/// </remarks>
+public static class ConstraintNames
+{
+    /// <summary>
+    /// The call naming a uniqueness rule.
+    /// </summary>
+    public const string WithName = "WithName";
+
+    /// <summary>
+    /// Resolves the name a rule is declared under, falling back to a name derived from what it constrains.
+    /// </summary>
+    /// <param name="invocation">The call declaring the rule.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="type">The type declaring the constraint.</param>
+    /// <param name="eventType">The event type being constrained.</param>
+    /// <param name="property">The property being constrained, if there is one.</param>
+    /// <returns>The name.</returns>
+    public static string Resolve(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        INamedTypeSymbol type,
+        ITypeSymbol eventType,
+        string? property = null)
+    {
+        var named = invocation.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(_ => string.Equals(InvocationChain.NameOf(_), WithName, StringComparison.Ordinal));
+
+        if (named is not null && InvocationChain.ArgumentOf(named) is { } argument &&
+            semanticModel.GetConstantValue(argument).Value is string declared && declared.Length > 0)
+        {
+            return declared;
+        }
+
+        var literal = ConstantArgument(invocation, semanticModel);
+
+        return literal ?? (property is null ? $"{type.Name}{eventType.Name}" : $"{type.Name}{eventType.Name}{property}");
+    }
+
+    /// <summary>
+    /// Reads the name a generic uniqueness rule was given directly.
+    /// </summary>
+    /// <param name="invocation">The call declaring the rule.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>The name, or <see langword="null"/> when none was given.</returns>
+    static string? ConstantArgument(InvocationExpressionSyntax invocation, SemanticModel semanticModel) =>
+        invocation.ArgumentList.Arguments
+            .Select(_ => semanticModel.GetConstantValue(_.Expression).Value as string)
+            .FirstOrDefault(_ => !string.IsNullOrEmpty(_));
+}

--- a/Source/DotNET/Screenplay/Analysis/Constraints/ConstraintReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Constraints/ConstraintReader.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Constraints;
+
+/// <summary>
+/// Reads the constraints a slice declares, in both shapes an application can write them.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of the file each constraint lives in.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Screenplay knows exactly two rules - a property of an event has to be unique, and an event may occur once. A
+/// rule declared in code that says anything else is pointed at rather than described as something it is not.
+/// </remarks>
+public class ConstraintReader(Compilation compilation, SourcePaths paths, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The call declaring a uniqueness rule.
+    /// </summary>
+    public const string Unique = "Unique";
+
+    /// <summary>
+    /// The call naming the property a uniqueness rule applies to.
+    /// </summary>
+    public const string On = "On";
+
+    /// <summary>
+    /// The method a constraint declares its rules in.
+    /// </summary>
+    public const string DefineMethod = "Define";
+
+    /// <summary>
+    /// Determines whether a type declares constraints in code.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a constraint.</returns>
+    public static bool IsConstraint(ITypeSymbol type) =>
+        type is { IsAbstract: false, TypeKind: TypeKind.Class } && type.FindInterface(WellKnownTypeNames.Constraint) is not null;
+
+    /// <summary>
+    /// Reads the constraints declared on the properties of an event.
+    /// </summary>
+    /// <param name="type">The type declaring the event.</param>
+    /// <returns>The constraints, ordered by name.</returns>
+    public static IEnumerable<ConstraintModel> FromEvent(INamedTypeSymbol type) =>
+    [
+        .. type.DeclaredProperties()
+            .Select(property => (property, attribute: property.GetAttribute(WellKnownTypeNames.UniqueAttribute)))
+            .Where(_ => _.attribute is not null)
+            .Select(_ => new UniquePropertyConstraintModel(
+                _.attribute!.GetArgument(0) as string ?? $"Unique{type.Name}{_.property.Name}",
+                _.property.Name,
+                type.Name))
+            .OrderBy(_ => _.Name, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Reads a constraint declared in code.
+    /// </summary>
+    /// <param name="type">The type declaring the constraint.</param>
+    /// <param name="location">Where the constraint lives, for use in diagnostics.</param>
+    /// <returns>The constraints it declares, never empty.</returns>
+    public IEnumerable<ConstraintModel> Read(INamedTypeSymbol type, string location)
+    {
+        var declared = new List<ConstraintModel>();
+
+        foreach (var method in type.GetMembers(DefineMethod).OfType<IMethodSymbol>())
+        {
+            foreach (var reference in method.DeclaringSyntaxReferences)
+            {
+                ReadDeclaration(type, reference.GetSyntax(), location, declared);
+            }
+        }
+
+        return declared.Count > 0 ? declared : [Custom(type)];
+    }
+
+    /// <summary>
+    /// Builds the declaration pointing at the file holding a rule that could not be described.
+    /// </summary>
+    /// <param name="type">The type declaring the constraint.</param>
+    /// <returns>The <see cref="CustomConstraintModel"/>.</returns>
+    CustomConstraintModel Custom(INamedTypeSymbol type) => new(type.Name, paths.Relative(type.SourceFilePath()));
+
+    /// <summary>
+    /// Reads every uniqueness rule within one declaration of the defining method.
+    /// </summary>
+    /// <param name="type">The type declaring the constraint.</param>
+    /// <param name="declaration">The declaration to read.</param>
+    /// <param name="location">Where the constraint lives, for use in diagnostics.</param>
+    /// <param name="declared">The constraints collected so far.</param>
+    void ReadDeclaration(INamedTypeSymbol type, SyntaxNode declaration, string location, List<ConstraintModel> declared)
+    {
+        var semanticModel = compilation.GetSemanticModel(declaration.SyntaxTree);
+
+        foreach (var invocation in declaration.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (!string.Equals(InvocationChain.NameOf(invocation), Unique, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var read = ReadUnique(type, invocation, semanticModel);
+            if (read is null)
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableConstraint,
+                    $"The rule '{type.Name}' declares is neither unique on a property nor unique on an event type, so the file holding it is pointed at instead",
+                    location);
+
+                declared.Add(Custom(type));
+                continue;
+            }
+
+            declared.Add(read);
+        }
+    }
+
+    /// <summary>
+    /// Reads one uniqueness rule.
+    /// </summary>
+    /// <param name="type">The type declaring the constraint.</param>
+    /// <param name="invocation">The call declaring the rule.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>The constraint, or <see langword="null"/> when the rule cannot be described.</returns>
+    /// <remarks>
+    /// The generic form names the event type directly and constrains the whole event, while the builder form names
+    /// the property it constrains inside a nested call.
+    /// </remarks>
+    ConstraintModel? ReadUnique(INamedTypeSymbol type, InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    {
+        if (InvocationChain.TypeArgumentOf(invocation) is { } declaredEvent)
+        {
+            var resolved = semanticModel.GetTypeInfo(declaredEvent).Type;
+
+            return resolved is null
+                ? null
+                : new UniqueEventConstraintModel(ConstraintNames.Resolve(invocation, semanticModel, type, resolved), resolved.Name);
+        }
+
+        var body = invocation.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(_ => string.Equals(InvocationChain.NameOf(_), On, StringComparison.Ordinal));
+
+        if (body is null || InvocationChain.TypeArgumentOf(body) is not { } eventType)
+        {
+            return null;
+        }
+
+        var property = LambdaPaths.Read(InvocationChain.ArgumentOf(body));
+        var declaring = semanticModel.GetTypeInfo(eventType).Type;
+
+        return property is null || declaring is null
+            ? null
+            : new UniquePropertyConstraintModel(
+                ConstraintNames.Resolve(invocation, semanticModel, type, declaring, property),
+                property,
+                declaring.Name);
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Controllers/ControllerCommandReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Controllers/ControllerCommandReader.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Controllers;
+
+/// <summary>
+/// Reads the commands a controller exposes.
+/// </summary>
+/// <param name="types">The <see cref="TypeRegistry"/> resolving the type of each parameter.</param>
+/// <param name="properties">The <see cref="PropertyReader"/> reading the input of a body shaped command.</param>
+/// <param name="produces">The <see cref="ProducesReader"/> reading what each command produces.</param>
+/// <param name="validators">The <see cref="ValidatorCatalog"/> holding the rules declared for each command.</param>
+/// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of the file each command lives in.</param>
+/// <remarks>
+/// A controller method taking a request body is a command whose shape is that body, and the method is its handler.
+/// A method taking loose parameters instead is a command whose shape is those parameters, named after the method.
+/// </remarks>
+public class ControllerCommandReader(
+    TypeRegistry types,
+    PropertyReader properties,
+    ProducesReader produces,
+    ValidatorCatalog validators,
+    SourcePaths paths)
+{
+    /// <summary>
+    /// Reads a command exposed by a controller.
+    /// </summary>
+    /// <param name="controller">The controller declaring it.</param>
+    /// <param name="method">The method exposing it.</param>
+    /// <param name="location">Where the controller lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="CommandModel"/>.</returns>
+    public CommandModel Read(INamedTypeSymbol controller, IMethodSymbol method, string location)
+    {
+        var body = BodyOf(method);
+        var shape = body?.Type as INamedTypeSymbol;
+
+        return new(
+            shape?.Name ?? method.Name,
+            Documentation.SummaryOf(method),
+            shape is null ? FromParameters(method) : properties.Read(shape),
+            AuthorizationReader.Read(method, controller),
+            shape is null ? [] : validators.For(shape),
+            produces.Read(controller, [method], location),
+            shape is null ? null : ConcurrencyReader.Read(shape),
+            paths.Relative(method.SourceFilePath() ?? controller.SourceFilePath()));
+    }
+
+    /// <summary>
+    /// Gets the parameter carrying the request body, if the method takes one.
+    /// </summary>
+    /// <param name="method">The method to read.</param>
+    /// <returns>The parameter, or <see langword="null"/> when the method takes loose parameters instead.</returns>
+    /// <remarks>
+    /// The body is the parameter that says it is, and otherwise the single parameter whose type is a model rather
+    /// than a value - a request body is never a primitive.
+    /// </remarks>
+    static IParameterSymbol? BodyOf(IMethodSymbol method)
+    {
+        var declared = method.Parameters.FirstOrDefault(_ => _.HasAttribute(WellKnownTypeNames.FromBodyAttribute));
+        if (declared is not null)
+        {
+            return declared;
+        }
+
+        var candidates = method.Parameters.Where(IsModel).ToList();
+
+        return candidates.Count == 1 ? candidates[0] : null;
+    }
+
+    /// <summary>
+    /// Determines whether a parameter carries a model rather than a value.
+    /// </summary>
+    /// <param name="parameter">The parameter to check.</param>
+    /// <returns>True when the parameter carries a model.</returns>
+    static bool IsModel(IParameterSymbol parameter) =>
+        parameter.Type is INamedTypeSymbol { TypeKind: TypeKind.Class or TypeKind.Struct } named &&
+        named.SpecialType == SpecialType.None &&
+        named.FindBase(WellKnownTypeNames.ConceptAs) is null &&
+        !ScreenplayPrimitiveNames.IsPrimitive(named) &&
+        CollectionElements.ElementOf(named) is null;
+
+    /// <summary>
+    /// Reads the input of a command whose shape is the parameters of the method.
+    /// </summary>
+    /// <param name="method">The method to read.</param>
+    /// <returns>The properties.</returns>
+    IEnumerable<PropertyModel> FromParameters(IMethodSymbol method) =>
+        [.. method.Parameters.Where(_ => _.Type.TypeKind != TypeKind.Interface).Select(_ => new PropertyModel(_.Name, types.Resolve(_.Type)))];
+}

--- a/Source/DotNET/Screenplay/Analysis/Controllers/ControllerRoutes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Controllers/ControllerRoutes.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Controllers;
+
+/// <summary>
+/// Recognizes the methods of a controller and what kind of artifact each one is.
+/// </summary>
+/// <remarks>
+/// Controllers are matched by the name of the base type and of the verb attributes rather than by referencing
+/// ASP.NET Core, which keeps the generator free of a web framework it only ever needs to recognize.
+/// </remarks>
+public static class ControllerRoutes
+{
+    /// <summary>
+    /// The namespace the verb attributes live in.
+    /// </summary>
+    public const string MvcNamespace = "Microsoft.AspNetCore.Mvc";
+
+    static readonly string[] _mutating =
+    [
+        "HttpPostAttribute",
+        "HttpPutAttribute",
+        "HttpDeleteAttribute",
+        "HttpPatchAttribute"
+    ];
+
+    /// <summary>
+    /// Determines whether a type is a controller.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type derives from the ASP.NET Core controller base type.</returns>
+    public static bool IsController(ITypeSymbol type) =>
+        type is { IsAbstract: false, TypeKind: TypeKind.Class } && type.FindBase(WellKnownTypeNames.ControllerBase) is not null;
+
+    /// <summary>
+    /// Determines whether a method changes state.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <returns>True when the method carries a mutating verb.</returns>
+    public static bool IsCommand(IMethodSymbol method) => _mutating.Any(verb => Carries(method, verb));
+
+    /// <summary>
+    /// Determines whether a method reads state.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <returns>True when the method carries the read verb.</returns>
+    public static bool IsQuery(IMethodSymbol method) => Carries(method, "HttpGetAttribute");
+
+    /// <summary>
+    /// Gets the routable methods a controller declares.
+    /// </summary>
+    /// <param name="type">The controller to read.</param>
+    /// <returns>The methods, ordered so that the same controller always reads the same way.</returns>
+    public static IEnumerable<IMethodSymbol> MethodsOf(INamedTypeSymbol type) =>
+        type.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: false, DeclaredAccessibility: Accessibility.Public })
+            .OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal);
+
+    /// <summary>
+    /// Determines whether a method carries an attribute of a given name from the MVC namespace.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <param name="attributeName">The metadata name of the attribute.</param>
+    /// <returns>True when the attribute is applied.</returns>
+    static bool Carries(IMethodSymbol method, string attributeName) =>
+        method.HasAttribute($"{MvcNamespace}.{attributeName}");
+}

--- a/Source/DotNET/Screenplay/Analysis/Documentation.cs
+++ b/Source/DotNET/Screenplay/Analysis/Documentation.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Reads the description an artifact carries in its documentation comment.
+/// </summary>
+/// <remarks>
+/// A summary is the closest thing the source has to the description a Screenplay declaration takes, and it is the
+/// one place a developer has already written down what an artifact is for.
+/// </remarks>
+public static class Documentation
+{
+    /// <summary>
+    /// Gets the summary of a symbol as a single line of text.
+    /// </summary>
+    /// <param name="symbol">The symbol to read.</param>
+    /// <returns>The summary, or <see langword="null"/> when the symbol carries none.</returns>
+    public static string? SummaryOf(ISymbol symbol)
+    {
+        var xml = symbol.GetDocumentationCommentXml(preferredCulture: null, expandIncludes: false);
+        if (string.IsNullOrWhiteSpace(xml))
+        {
+            return null;
+        }
+
+        var summary = TryParse(xml)?.Element("summary")?.Value;
+
+        return Flatten(summary);
+    }
+
+    /// <summary>
+    /// Parses a documentation comment, ignoring one that is not well formed.
+    /// </summary>
+    /// <param name="xml">The documentation comment.</param>
+    /// <returns>The parsed element, or <see langword="null"/>.</returns>
+    static XElement? TryParse(string xml)
+    {
+        try
+        {
+            return XElement.Parse(xml, LoadOptions.PreserveWhitespace);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reduces a summary to a single line, since a description is printed on one.
+    /// </summary>
+    /// <param name="summary">The summary to reduce.</param>
+    /// <returns>The single line, or <see langword="null"/> when there is nothing left.</returns>
+    static string? Flatten(string? summary)
+    {
+        if (string.IsNullOrWhiteSpace(summary))
+        {
+            return null;
+        }
+
+        var words = summary.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var flattened = string.Join(' ', words);
+
+        return flattened.Length == 0 ? null : flattened;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/EnumConstants.cs
+++ b/Source/DotNET/Screenplay/Analysis/EnumConstants.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Recovers the member of an enumeration a constant names.
+/// </summary>
+/// <remarks>
+/// The compiler hands a constant of an enumeration over as the number behind it, which is indistinguishable from any
+/// other number by the time it reaches emission. The type it was written as is the only thing that still knows which
+/// enumeration it belongs to, so the member is recovered here - at the one place holding both - and everything past
+/// it carries a name.
+/// </remarks>
+public static class EnumConstants
+{
+    /// <summary>
+    /// Determines whether a type is an enumeration.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is an enumeration.</returns>
+    public static bool IsEnumeration(ITypeSymbol? type) => type is { TypeKind: TypeKind.Enum };
+
+    /// <summary>
+    /// Gets the enumeration an expression yields a value of.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <returns>The enumeration, or <see langword="null"/> when the expression yields something else.</returns>
+    /// <remarks>
+    /// An expression carries two types - what it is and what it was needed as - and either of them can be the one
+    /// that knows about the enumeration. <c>UserRole.ClientContact</c> handed to a parameter taking anything is the
+    /// first, and a number cast to <c>UserRole</c> is the second, so whichever of them names an enumeration is taken.
+    /// </remarks>
+    public static ITypeSymbol? EnumerationOf(ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        var type = semanticModel.GetTypeInfo(expression);
+
+        return IsEnumeration(type.Type) ? type.Type : IsEnumeration(type.ConvertedType) ? type.ConvertedType : null;
+    }
+
+    /// <summary>
+    /// Resolves the member of an enumeration a constant names.
+    /// </summary>
+    /// <param name="type">The type the constant was written as.</param>
+    /// <param name="value">The value the compiler handed over, which for an enumeration is the number behind a member.</param>
+    /// <param name="member">The member the value names.</param>
+    /// <returns>True when the type is an enumeration declaring a member with that value.</returns>
+    /// <remarks>
+    /// A value no member is declared with - an arbitrary cast, or several flags combined into one - is not resolved.
+    /// Inventing a name for it would describe a value the application does not have, so the caller is left to write
+    /// the number and say what it lost.
+    /// </remarks>
+    public static bool TryResolve(ITypeSymbol? type, object? value, out EnumValue member)
+    {
+        member = null!;
+        if (!IsEnumeration(type) || value is null || MemberOf(type!, value) is not { } name)
+        {
+            return false;
+        }
+
+        member = new(name);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the name of the member an enumeration declares a value with.
+    /// </summary>
+    /// <param name="type">The enumeration to read.</param>
+    /// <param name="value">The value to find.</param>
+    /// <returns>The name, or <see langword="null"/> when no member is declared with the value.</returns>
+    /// <remarks>
+    /// Several members may share one value, and the order the compiler returns them in follows where they were read
+    /// from rather than anything about the source. Ordering the candidates by name and taking the first is what makes
+    /// the same compilation produce the same document, which is the whole point of a document worth committing.
+    /// </remarks>
+    static string? MemberOf(ITypeSymbol type, object value) =>
+        type.GetMembers()
+            .OfType<IFieldSymbol>()
+            .Where(_ => _.HasConstantValue && Equals(_.ConstantValue, value))
+            .Select(_ => _.Name)
+            .Order(StringComparer.Ordinal)
+            .FirstOrDefault();
+}

--- a/Source/DotNET/Screenplay/Analysis/Events/EventReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Events/EventReader.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Events;
+
+/// <summary>
+/// Reads the events a slice declares.
+/// </summary>
+/// <param name="properties">The <see cref="PropertyReader"/> reading the properties of each event.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Generations, tombstones and compensations are all first class in Chronicle and have no counterpart in Screenplay
+/// at all. Rather than inventing syntax for them, each is reported once for the event that declares it, so that a
+/// reader of the document knows exactly what it does not say.
+/// </remarks>
+public class EventReader(PropertyReader properties, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The name of the argument carrying the generation of an event type.
+    /// </summary>
+    public const string GenerationArgument = "Generation";
+
+    /// <summary>
+    /// Determines whether a type is an event.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is an event.</returns>
+    public static bool IsEvent(ITypeSymbol type) => type.HasAttribute(WellKnownTypeNames.EventTypeAttribute);
+
+    /// <summary>
+    /// Reads an event.
+    /// </summary>
+    /// <param name="type">The type declaring the event.</param>
+    /// <param name="location">Where the event lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="EventModel"/>.</returns>
+    public EventModel Read(INamedTypeSymbol type, string location)
+    {
+        ReportWhatIsLost(type, location);
+
+        return new(type.Name, properties.Read(type), Tags(type));
+    }
+
+    /// <summary>
+    /// Gets the tags an event is classified by.
+    /// </summary>
+    /// <param name="type">The type declaring the event.</param>
+    /// <returns>The tags, ordered.</returns>
+    static IEnumerable<string> Tags(ISymbol type) =>
+    [
+        .. type.GetAttributes()
+            .Where(_ => _.AttributeClass.Is(WellKnownTypeNames.TagAttribute) || _.AttributeClass.Is(WellKnownTypeNames.TagsAttribute))
+            .SelectMany(_ => _.ConstructorArguments)
+            .SelectMany(_ => _.Kind == TypedConstantKind.Array ? _.Values.Select(value => value.Value) : [_.Value])
+            .OfType<string>()
+            .Where(_ => _.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Reports everything an event declares that the document cannot say.
+    /// </summary>
+    /// <param name="type">The type declaring the event.</param>
+    /// <param name="location">Where the event lives.</param>
+    void ReportWhatIsLost(INamedTypeSymbol type, string location)
+    {
+        var attribute = type.GetAttribute(WellKnownTypeNames.EventTypeAttribute);
+        var generation = attribute?.GetNamedArgument(GenerationArgument) ?? attribute?.GetArgument(1);
+
+        if (generation is uint declared && declared > 1)
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.EventFeatureWithoutCounterpart,
+                $"The event '{type.Name}' is generation {declared}, and Screenplay describes only the current shape of an event",
+                location);
+        }
+
+        if (type.HasAttribute(WellKnownTypeNames.TombstoneAttribute))
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.EventFeatureWithoutCounterpart,
+                $"The event '{type.Name}' is a tombstone, which Screenplay has no counterpart for",
+                location);
+        }
+
+        if (type.HasAttribute(WellKnownTypeNames.CompensationForAttribute) ||
+            type.GetAttributes().Any(_ => _.AttributeClass.Is(WellKnownTypeNames.CompensationForAttributeOfT)))
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.EventFeatureWithoutCounterpart,
+                $"The event '{type.Name}' compensates another event, which Screenplay has no counterpart for",
+                location);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/IApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/IApplicationModelAnalyzer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Defines a system that recovers the application model from the source of an application.
+/// </summary>
+/// <remarks>
+/// This is the seam between the two halves of the generator. Everything on this side of it works with Roslyn
+/// symbols and syntax; everything on the other side works only with the model, which is what makes the emitted
+/// document reproducible and the emission half testable without a compiler.
+/// </remarks>
+public interface IApplicationModelAnalyzer
+{
+    /// <summary>
+    /// Analyzes a compilation and recovers the model it describes.
+    /// </summary>
+    /// <param name="compilation">The compilation to analyze.</param>
+    /// <param name="options">The options to analyze with, with every value already resolved.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options);
+}

--- a/Source/DotNET/Screenplay/Analysis/MemberAttributes.cs
+++ b/Source/DotNET/Screenplay/Analysis/MemberAttributes.cs
@@ -4,36 +4,46 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Cratis.Arc.Screenplay.Analysis.Projections;
+namespace Cratis.Arc.Screenplay.Analysis;
 
 /// <summary>
-/// Gets the attributes declared on the members of a model-bound read model.
+/// Gets the attributes that apply to a member of a type.
 /// </summary>
 /// <remarks>
-/// A read model is nearly always a positional record, and an attribute written on a positional parameter belongs to
-/// the parameter rather than to the property it produces. Reading only the properties would therefore miss every
-/// mapping the most common way of writing a read model declares.
+/// Commands, events and read models are nearly always positional records, and an attribute written on a positional
+/// parameter belongs to the parameter rather than to the property it produces. Reading only the properties would
+/// therefore miss every attribute the most common way of writing them declares - which is why this is asked once,
+/// here, rather than by each recognizer in turn.
 /// </remarks>
-public static class ModelBoundMembers
+public static class MemberAttributes
 {
     /// <summary>
-    /// Gets the attributes applying to a member of a read model.
+    /// Gets the attributes applying to a member.
     /// </summary>
     /// <param name="property">The property to read.</param>
     /// <returns>The attributes, those of the property first.</returns>
-    public static IEnumerable<AttributeData> AttributesOf(IPropertySymbol property) =>
+    public static IEnumerable<AttributeData> Of(IPropertySymbol property) =>
         ParameterOf(property) is { } parameter
             ? property.GetAttributes().Concat(parameter.GetAttributes())
             : property.GetAttributes();
 
     /// <summary>
-    /// Determines whether an attribute of a given type applies to a member of a read model.
+    /// Gets every attribute of a given type applying to a member.
+    /// </summary>
+    /// <param name="property">The property to read.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
+    /// <returns>The attributes.</returns>
+    public static IEnumerable<AttributeData> Of(IPropertySymbol property, string fullMetadataName) =>
+        Of(property).Where(_ => _.AttributeClass.Is(fullMetadataName));
+
+    /// <summary>
+    /// Determines whether an attribute of a given type applies to a member.
     /// </summary>
     /// <param name="property">The property to check.</param>
     /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
     /// <returns>True when the attribute applies.</returns>
-    public static bool HasAttribute(IPropertySymbol property, string fullMetadataName) =>
-        AttributesOf(property).Any(_ => _.AttributeClass.Is(fullMetadataName));
+    public static bool Has(IPropertySymbol property, string fullMetadataName) =>
+        Of(property).Any(_ => _.AttributeClass.Is(fullMetadataName));
 
     /// <summary>
     /// Gets the positional parameter a property was produced from.

--- a/Source/DotNET/Screenplay/Analysis/Policies/PolicyCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Policies/PolicyCatalog.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Policies;
+
+/// <summary>
+/// Declares a policy for everything the application asks of its callers.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unrecoverable is reported to.</param>
+/// <remarks>
+/// Only what something refers to is declared. A role named by an artifact is a policy whose rule is the role itself;
+/// a policy named by an artifact has its rule looked up where the application registers it. Declaring the ones that
+/// nothing refers to would fill the document with rules it never uses.
+/// </remarks>
+public class PolicyCatalog(Compilation compilation, ScreenplayDiagnostics diagnostics)
+{
+    readonly PolicyRequirementReader _requirements = new(diagnostics);
+
+    /// <summary>
+    /// Declares a policy for every role and every named policy the slices refer to.
+    /// </summary>
+    /// <param name="authorizations">Everything within the application that requires something of the caller.</param>
+    /// <returns>The policies, ordered by name.</returns>
+    public IEnumerable<PolicyModel> Declare(IEnumerable<AuthorizationModel> authorizations)
+    {
+        var declared = authorizations as IReadOnlyCollection<AuthorizationModel> ?? [.. authorizations];
+        var registrations = PolicyRegistrations.In(compilation);
+        var policies = new Dictionary<string, PolicyModel>(StringComparer.Ordinal);
+
+        foreach (var name in Names(declared, _ => _.Policies))
+        {
+            policies[name] = new(name, Requirement(name, registrations));
+        }
+
+        foreach (var role in Names(declared, _ => _.Roles).Where(_ => !policies.ContainsKey(_)))
+        {
+            policies[role] = PolicyModel.ForRole(role);
+        }
+
+        return [.. policies.Values.OrderBy(_ => _.Name, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Gets the names one part of an authorization refers to.
+    /// </summary>
+    /// <param name="authorizations">The authorizations to read.</param>
+    /// <param name="select">The part to read from each of them.</param>
+    /// <returns>The names, distinct and ordered.</returns>
+    static IEnumerable<string> Names(
+        IEnumerable<AuthorizationModel> authorizations,
+        Func<AuthorizationModel, IEnumerable<string>> select) =>
+        authorizations
+            .SelectMany(select)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Looks up what a named policy requires, reporting one that the application never registers.
+    /// </summary>
+    /// <param name="name">The name of the policy.</param>
+    /// <param name="registrations">Every policy the application registers.</param>
+    /// <returns>The requirement, or <see langword="null"/> when it could not be recovered.</returns>
+    PolicyRequirementModel? Requirement(string name, IReadOnlyDictionary<string, PolicyRegistration> registrations)
+    {
+        if (registrations.TryGetValue(name, out var registration))
+        {
+            return _requirements.Read(registration);
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable,
+            $"The policy '{name}' is referred to, but nothing in the compilation registers it, so what it requires is not stated",
+            compilation.AssemblyName);
+
+        return null;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Policies/PolicyRegistration.cs
+++ b/Source/DotNET/Screenplay/Analysis/Policies/PolicyRegistration.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Policies;
+
+/// <summary>
+/// Represents one named authorization policy the application registers.
+/// </summary>
+/// <param name="Name">The name the policy is registered under.</param>
+/// <param name="Configure">The argument declaring what the policy requires.</param>
+/// <param name="SemanticModel">The semantic model of the tree the registration lives in.</param>
+/// <param name="Location">The path of the file the registration lives in.</param>
+public record PolicyRegistration(
+    string Name,
+    ExpressionSyntax? Configure,
+    SemanticModel SemanticModel,
+    string Location);

--- a/Source/DotNET/Screenplay/Analysis/Policies/PolicyRegistrations.cs
+++ b/Source/DotNET/Screenplay/Analysis/Policies/PolicyRegistrations.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Policies;
+
+/// <summary>
+/// Finds every named authorization policy the application registers, wherever it is composed.
+/// </summary>
+/// <remarks>
+/// An artifact names a policy; the composition root says what it means. Both shapes the framework offers are read -
+/// the options form <c>AddAuthorization(options =&gt; options.AddPolicy(...))</c> and the builder form
+/// <c>AddAuthorizationBuilder().AddPolicy(...)</c> - because an application uses whichever it prefers.
+/// </remarks>
+public static class PolicyRegistrations
+{
+    /// <summary>
+    /// The name of the call registering a policy.
+    /// </summary>
+    public const string AddPolicy = "AddPolicy";
+
+    /// <summary>
+    /// Finds every policy a compilation registers.
+    /// </summary>
+    /// <param name="compilation">The compilation to read.</param>
+    /// <returns>The registrations, keyed by the name each policy is registered under.</returns>
+    /// <remarks>
+    /// The first registration of a name wins, which is the framework's own behavior for the options form and is the
+    /// only choice that keeps the same compilation yielding the same document.
+    /// </remarks>
+    public static IReadOnlyDictionary<string, PolicyRegistration> In(Compilation compilation)
+    {
+        var registrations = new Dictionary<string, PolicyRegistration>(StringComparer.Ordinal);
+
+        foreach (var tree in compilation.SyntaxTrees.OrderBy(_ => _.FilePath, StringComparer.Ordinal))
+        {
+            Collect(compilation.GetSemanticModel(tree), tree, registrations);
+        }
+
+        return registrations;
+    }
+
+    /// <summary>
+    /// Collects the registrations one syntax tree holds.
+    /// </summary>
+    /// <param name="semanticModel">The semantic model of the tree.</param>
+    /// <param name="tree">The tree to read.</param>
+    /// <param name="registrations">The registrations collected so far.</param>
+    static void Collect(SemanticModel semanticModel, SyntaxTree tree, Dictionary<string, PolicyRegistration> registrations)
+    {
+        foreach (var invocation in tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (!IsRegistration(invocation, semanticModel))
+            {
+                continue;
+            }
+
+            var name = NameOf(invocation, semanticModel);
+            if (name is null || registrations.ContainsKey(name))
+            {
+                continue;
+            }
+
+            registrations[name] = new(
+                name,
+                InvocationChain.ArgumentOf(invocation, 1),
+                semanticModel,
+                tree.FilePath);
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a call registers a named policy.
+    /// </summary>
+    /// <param name="invocation">The call to check.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>True when the call registers a policy.</returns>
+    static bool IsRegistration(InvocationExpressionSyntax invocation, SemanticModel semanticModel) =>
+        string.Equals(InvocationChain.NameOf(invocation), AddPolicy, StringComparison.Ordinal) &&
+        semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method &&
+        (method.ContainingType.Is(WellKnownTypeNames.AuthorizationOptions) ||
+         method.ContainingType.Is(WellKnownTypeNames.AuthorizationBuilder));
+
+    /// <summary>
+    /// Reads the name a policy is registered under.
+    /// </summary>
+    /// <param name="invocation">The call to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>The name, or <see langword="null"/> when it is not a constant.</returns>
+    static string? NameOf(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    {
+        if (InvocationChain.ArgumentOf(invocation) is not { } argument)
+        {
+            return null;
+        }
+
+        var name = semanticModel.GetConstantValue(argument).Value as string;
+
+        return string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Policies/PolicyRequirementReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Policies/PolicyRequirementReader.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Policies;
+
+/// <summary>
+/// Reads what a registered policy requires of the caller, from the builder its registration configures.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unrecoverable is reported to.</param>
+/// <remarks>
+/// Requirements declared one after the other all have to hold, so they combine with <c>and</c>. The several values
+/// one requirement accepts are alternatives, so they combine with <c>or</c>. A requirement that only code can decide
+/// is reported and left out, which states less than the truth rather than something other than it.
+/// </remarks>
+public class PolicyRequirementReader(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The call requiring nothing of the caller beyond being authenticated.
+    /// </summary>
+    public const string RequireAuthenticatedUser = "RequireAuthenticatedUser";
+
+    /// <summary>
+    /// The call requiring the caller to hold one of a set of roles.
+    /// </summary>
+    public const string RequireRole = "RequireRole";
+
+    /// <summary>
+    /// The call requiring the caller to carry a claim.
+    /// </summary>
+    public const string RequireClaim = "RequireClaim";
+
+    /// <summary>
+    /// Reads what a policy requires.
+    /// </summary>
+    /// <param name="registration">The registration to read.</param>
+    /// <returns>The requirement, or <see langword="null"/> when nothing could be recovered.</returns>
+    public PolicyRequirementModel? Read(PolicyRegistration registration)
+    {
+        if (registration.Configure is not AnonymousFunctionExpressionSyntax configure)
+        {
+            Report(registration, "it is registered from a policy built in code rather than configured inline");
+
+            return null;
+        }
+
+        var calls = Calls(configure.Body, registration.SemanticModel).ToList();
+        var steps = calls.Select(_ => Step(_, registration)).OfType<PolicyRequirementModel>().ToList();
+
+        if (calls.Count == 0)
+        {
+            Report(registration, "it declares no requirement at all");
+        }
+
+        return steps.Count == 0 ? null : steps.Aggregate((left, right) => new CombinedRequirement(left, false, right));
+    }
+
+    /// <summary>
+    /// Gets the requirements a configuration declares, in the order they were written.
+    /// </summary>
+    /// <param name="body">The body of the configuration.</param>
+    /// <param name="semanticModel">The semantic model of the tree the configuration lives in.</param>
+    /// <returns>The calls, ordered by where the name of each one was written.</returns>
+    /// <remarks>
+    /// A chain is nested outermost first in the tree while a block is written top to bottom, so both are ordered by
+    /// where each call names itself. That is the order the developer reads, and the order the document has to keep.
+    /// </remarks>
+    static IEnumerable<InvocationExpressionSyntax> Calls(SyntaxNode body, SemanticModel semanticModel) =>
+        body.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(_ => semanticModel.GetSymbolInfo(_).Symbol is IMethodSymbol method &&
+                        method.ContainingType.Is(WellKnownTypeNames.AuthorizationPolicyBuilder))
+            .OrderBy(_ => (_.Expression as MemberAccessExpressionSyntax)?.Name.SpanStart ?? _.SpanStart);
+
+    /// <summary>
+    /// Combines a set of alternatives into one requirement.
+    /// </summary>
+    /// <param name="alternatives">The alternatives to combine, of which there is at least one.</param>
+    /// <returns>The requirement.</returns>
+    static PolicyRequirementModel AnyOf(IEnumerable<PolicyRequirementModel> alternatives) =>
+        alternatives.Aggregate((left, right) => new CombinedRequirement(left, true, right));
+
+    /// <summary>
+    /// Reads one requirement.
+    /// </summary>
+    /// <param name="call">The call declaring it.</param>
+    /// <param name="registration">The registration the call belongs to.</param>
+    /// <returns>The requirement, or <see langword="null"/> when it has no counterpart.</returns>
+    PolicyRequirementModel? Step(InvocationExpressionSyntax call, PolicyRegistration registration)
+    {
+        var name = InvocationChain.NameOf(call);
+        var arguments = call.ArgumentList.Arguments.Select(_ => _.Expression).ToList();
+
+        if (string.Equals(name, RequireAuthenticatedUser, StringComparison.Ordinal))
+        {
+            return AuthenticatedRequirement.Instance;
+        }
+
+        if (string.Equals(name, RequireRole, StringComparison.Ordinal) &&
+            PolicyValues.Of(arguments, registration.SemanticModel) is { Count: > 0 } roles)
+        {
+            return AnyOf(roles.Select(_ => new RoleRequirement(_)));
+        }
+
+        if (string.Equals(name, RequireClaim, StringComparison.Ordinal) &&
+            arguments.Count > 1 &&
+            PolicyValues.Of(arguments, registration.SemanticModel) is { Count: > 1 } claim)
+        {
+            return AnyOf(claim.Skip(1).Select(_ => new ClaimRequirement(claim[0], _)));
+        }
+
+        Report(registration, $"'{name}' has no counterpart in a policy condition");
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reports what could not be recovered about a policy.
+    /// </summary>
+    /// <param name="registration">The registration being read.</param>
+    /// <param name="reason">Why it could not be recovered.</param>
+    void Report(PolicyRegistration registration, string reason) =>
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable,
+            $"The policy '{registration.Name}' is referred to, but {reason}, so that part of what it requires is not stated",
+            registration.Location);
+}

--- a/Source/DotNET/Screenplay/Analysis/Policies/PolicyValues.cs
+++ b/Source/DotNET/Screenplay/Analysis/Policies/PolicyValues.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Policies;
+
+/// <summary>
+/// Reads the constant values a policy requirement is given.
+/// </summary>
+/// <remarks>
+/// A requirement takes its values either one by one or as a collection, and both forms mean the same thing. Only
+/// constants are read - a value computed at startup is not something a document can state.
+/// </remarks>
+public static class PolicyValues
+{
+    /// <summary>
+    /// Reads the constant strings a run of arguments yields.
+    /// </summary>
+    /// <param name="arguments">The arguments to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the arguments live in.</param>
+    /// <returns>The values, or <see langword="null"/> when any argument is not made of constants.</returns>
+    public static IReadOnlyList<string>? Of(IEnumerable<ExpressionSyntax> arguments, SemanticModel semanticModel)
+    {
+        var values = new List<string>();
+
+        foreach (var argument in arguments)
+        {
+            if (!Collect(argument, semanticModel, values))
+            {
+                return null;
+            }
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Collects the constant strings one argument yields.
+    /// </summary>
+    /// <param name="expression">The argument to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the argument lives in.</param>
+    /// <param name="values">The values collected so far.</param>
+    /// <returns>True when the argument is made of constants.</returns>
+    static bool Collect(ExpressionSyntax expression, SemanticModel semanticModel, List<string> values)
+    {
+        if (semanticModel.GetConstantValue(expression).Value is string constant)
+        {
+            values.Add(constant);
+
+            return true;
+        }
+
+        return Elements(expression) is { } elements && elements.All(_ => Collect(_, semanticModel, values));
+    }
+
+    /// <summary>
+    /// Gets the elements a collection of values is written as.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <returns>The elements, or <see langword="null"/> when the expression is not a collection of values.</returns>
+    static IEnumerable<ExpressionSyntax>? Elements(ExpressionSyntax expression) => expression switch
+    {
+        ArrayCreationExpressionSyntax { Initializer: { } initializer } => initializer.Expressions,
+        ImplicitArrayCreationExpressionSyntax implicitArray => implicitArray.Initializer.Expressions,
+        CollectionExpressionSyntax collection => collection.Elements.OfType<ExpressionElementSyntax>().Select(_ => _.Expression),
+        _ => null
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/ProjectionEvents.cs
+++ b/Source/DotNET/Screenplay/Analysis/ProjectionEvents.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Gets the events a projection refers to, wherever in its scopes they are named.
+/// </summary>
+public static class ProjectionEvents
+{
+    /// <summary>
+    /// Gets the names of every event a projection refers to.
+    /// </summary>
+    /// <param name="projection">The projection to read.</param>
+    /// <returns>The names, distinct.</returns>
+    public static IEnumerable<string> In(ProjectionModel? projection) =>
+        projection is null ? [] : In(projection.Scope).Distinct(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the names of every event a scope refers to, including its child and nested scopes.
+    /// </summary>
+    /// <param name="scope">The scope to read.</param>
+    /// <returns>The names.</returns>
+    static IEnumerable<string> In(ProjectionScopeModel scope) =>
+        scope.From.SelectMany(_ => _.EventTypes)
+            .Concat(scope.Joins.Select(_ => _.EventType))
+            .Concat(scope.RemovedWith.Select(_ => _.EventType))
+            .Concat(scope.RemovedWithJoin.Select(_ => _.EventType))
+            .Concat(scope.Children.SelectMany(_ => In(_.Scope)))
+            .Concat(scope.Nested.SelectMany(_ => In(_.Scope)));
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentBlockReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentBlockReader.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the keys and mappings declared inside one block of a fluent projection.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+public class FluentBlockReader(ScreenplayDiagnostics diagnostics)
+{
+    readonly FluentMappings _mappings = new(diagnostics);
+
+    /// <summary>
+    /// Gets the mappings the block declares, keyed by the read model property they fill in.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Properties => _mappings.Properties;
+
+    /// <summary>
+    /// Gets the key expression the block declares, if it declares one.
+    /// </summary>
+    public string? Key { get; private set; }
+
+    /// <summary>
+    /// Gets the parent key expression the block declares, if it declares one.
+    /// </summary>
+    public string? ParentKey { get; private set; }
+
+    /// <summary>
+    /// Gets the read model property the block keys a join on, if it declares one.
+    /// </summary>
+    public string? On { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the block excludes child objects.
+    /// </summary>
+    public bool ExcludesChildren { get; private set; }
+
+    /// <summary>
+    /// Reads every chain declared within a block.
+    /// </summary>
+    /// <param name="scope">The body of the block.</param>
+    /// <param name="semanticModel">The semantic model of the tree the block lives in.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    public void Read(SyntaxNode scope, SemanticModel semanticModel, string location)
+    {
+        foreach (var chain in ProjectionPaths.ChainsIn(scope))
+        {
+            ReadChain(InvocationChain.Sequence(chain), semanticModel, location);
+        }
+    }
+
+    /// <summary>
+    /// Builds the expression naming a value from the event context.
+    /// </summary>
+    /// <param name="argument">The lambda selecting the context property.</param>
+    /// <returns>The expression, or <see langword="null"/> when the lambda does not select a property.</returns>
+    static string? Context(ExpressionSyntax? argument) =>
+        ProjectionPaths.Read(argument) is { } path ? ProjectionExpressions.EventContext(path) : null;
+
+    /// <summary>
+    /// Reads one chain of calls, pairing each mapping with the call that gives it a value.
+    /// </summary>
+    /// <param name="calls">The calls of the chain, in source order.</param>
+    /// <param name="semanticModel">The semantic model of the tree the chain lives in.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    void ReadChain(IReadOnlyList<InvocationExpressionSyntax> calls, SemanticModel semanticModel, string location)
+    {
+        string? pending = null;
+
+        foreach (var call in calls)
+        {
+            pending = ReadCall(call, pending, semanticModel, location);
+        }
+
+        if (pending is not null)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                $"The mapping onto '{pending}' was never given a value that could be read, so it was left out",
+                location);
+        }
+    }
+
+    /// <summary>
+    /// Reads one call of a chain.
+    /// </summary>
+    /// <param name="call">The call to read.</param>
+    /// <param name="pending">The read model property waiting for a value, if there is one.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <returns>The read model property still waiting for a value, if there is one.</returns>
+    string? ReadCall(InvocationExpressionSyntax call, string? pending, SemanticModel semanticModel, string location)
+    {
+        var name = InvocationChain.NameOf(call);
+        var argument = InvocationChain.ArgumentOf(call);
+
+        switch (name)
+        {
+            case FluentMappings.Set or FluentMappings.Add or FluentMappings.Subtract:
+                return FluentMappings.Begin(name, argument);
+
+            case "To" or "With":
+                return _mappings.Complete(pending, ProjectionPaths.Read(argument), location);
+
+            case "ToEventSourceId":
+                return _mappings.Complete(pending, ProjectionExpressions.EventSourceId, location);
+
+            case "ToValue":
+                return _mappings.Complete(pending, ProjectionExpressions.Value(semanticModel.GetConstantValue(argument!).Value), location);
+
+            case "ToEventContextProperty":
+                return _mappings.Complete(pending, Context(argument), location);
+
+            case "Increment" or "Decrement" or "Count":
+                _mappings.Counter(name, argument);
+
+                return null;
+
+            default:
+                return ReadKey(call, name, argument, pending, semanticModel, location);
+        }
+    }
+
+    /// <summary>
+    /// Reads a call that says how the block is keyed rather than what it maps.
+    /// </summary>
+    /// <param name="call">The call to read.</param>
+    /// <param name="name">The name of the call.</param>
+    /// <param name="argument">The first argument of the call.</param>
+    /// <param name="pending">The read model property waiting for a value, if there is one.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <returns>The read model property still waiting for a value, if there is one.</returns>
+    string? ReadKey(
+        InvocationExpressionSyntax call,
+        string name,
+        ExpressionSyntax? argument,
+        string? pending,
+        SemanticModel semanticModel,
+        string location)
+    {
+        switch (name)
+        {
+            case "UsingKey":
+                Key = ProjectionPaths.Read(argument);
+                break;
+
+            case "UsingKeyFromContext":
+                Key = Context(argument);
+                break;
+
+            case "UsingConstantKey":
+                Key = ProjectionExpressions.Value(semanticModel.GetConstantValue(argument!).Value);
+                break;
+
+            case "UsingParentKey":
+                ParentKey = ProjectionPaths.Read(argument);
+                break;
+
+            case "UsingCompositeKey":
+                Key = FluentCompositeKeys.Read(call, semanticModel);
+                break;
+
+            case "On":
+                On = ProjectionPaths.ReadDeclared(argument);
+                break;
+
+            case "ExcludeChildProjections":
+                ExcludesChildren = true;
+                break;
+
+            default:
+                _mappings.Report(name, location);
+
+                return pending;
+        }
+
+        return null;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentBlocks.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentBlocks.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the blocks of a fluent projection that observe or remove, as opposed to the ones that nest.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Each of these turns one call and the body it was given into one block, and none of them recurses. Keeping them
+/// apart from the scope reader leaves that reader with only the two things that do recurse - a child collection and
+/// a nested object.
+/// </remarks>
+public class FluentBlocks(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Gets the name of the event type a call names as its type argument.
+    /// </summary>
+    /// <param name="call">The call to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>The name, or <see langword="null"/> when the call names none.</returns>
+    public static string? EventTypeOf(InvocationExpressionSyntax call, SemanticModel semanticModel) =>
+        InvocationChain.TypeArgumentOf(call) is { } argument ? semanticModel.GetTypeInfo(argument).Type?.Name : null;
+
+    /// <summary>
+    /// Reads a block observing an event type.
+    /// </summary>
+    /// <param name="call">The call declaring the block.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="scope">The scope being collected into.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    public void ReadFrom(InvocationExpressionSyntax call, SemanticModel semanticModel, FluentScope scope, string location)
+    {
+        var eventType = EventTypeOf(call, semanticModel);
+        if (eventType is null)
+        {
+            return;
+        }
+
+        var block = ReadBlock(InvocationChain.ArgumentOf(call), semanticModel, location);
+
+        scope.From.Add(new([eventType], block.Key, block.ParentKey, block.Properties));
+    }
+
+    /// <summary>
+    /// Reads a block joining data from another event.
+    /// </summary>
+    /// <param name="call">The call declaring the block.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="scope">The scope being collected into.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <remarks>
+    /// The fluent form names no property to hold the joined data, so the join is named after the first property it
+    /// fills in - which is the closest the declaration comes to saying what the joined data is.
+    /// </remarks>
+    public void ReadJoin(InvocationExpressionSyntax call, SemanticModel semanticModel, FluentScope scope, string location)
+    {
+        var eventType = EventTypeOf(call, semanticModel);
+        if (eventType is null)
+        {
+            return;
+        }
+
+        var block = ReadBlock(InvocationChain.ArgumentOf(call), semanticModel, location);
+        var named = block.Properties.Keys.Order(StringComparer.Ordinal).FirstOrDefault() ?? block.On;
+
+        scope.Joins.Add(new(named ?? string.Empty, eventType, block.On ?? string.Empty, block.Properties));
+    }
+
+    /// <summary>
+    /// Reads a block applying to every observed event.
+    /// </summary>
+    /// <param name="call">The call declaring the block.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="ProjectionEveryModel"/>.</returns>
+    public ProjectionEveryModel ReadEvery(InvocationExpressionSyntax call, SemanticModel semanticModel, string location)
+    {
+        var block = ReadBlock(InvocationChain.ArgumentOf(call), semanticModel, location);
+
+        return new(block.Properties, !block.ExcludesChildren, ProjectionAutoMapMode.Inherit);
+    }
+
+    /// <summary>
+    /// Reads a block removing an instance when an event occurs.
+    /// </summary>
+    /// <param name="call">The call declaring the block.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="removals">The removals being collected into.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    public void Remove(
+        InvocationExpressionSyntax call,
+        SemanticModel semanticModel,
+        IList<ProjectionRemoveModel> removals,
+        string location)
+    {
+        var eventType = EventTypeOf(call, semanticModel);
+        if (eventType is null)
+        {
+            return;
+        }
+
+        var block = ReadBlock(InvocationChain.ArgumentOf(call), semanticModel, location);
+
+        removals.Add(new(eventType, block.Key, block.ParentKey));
+    }
+
+    /// <summary>
+    /// Reads the mappings and keys of one block.
+    /// </summary>
+    /// <param name="body">The body of the block.</param>
+    /// <param name="semanticModel">The semantic model of the tree the block lives in.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="FluentBlockReader"/> holding what was read.</returns>
+    FluentBlockReader ReadBlock(ExpressionSyntax? body, SemanticModel semanticModel, string location)
+    {
+        var block = new FluentBlockReader(diagnostics);
+        if (body is not null)
+        {
+            block.Read(body, semanticModel, location);
+        }
+
+        return block;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentCompositeKeys.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentCompositeKeys.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads a key that identifies a read model by several properties at once.
+/// </summary>
+/// <remarks>
+/// A composite key names the type it identifies as well as its parts, and the type comes from the type argument the
+/// builder was given rather than from anything inside the body.
+/// </remarks>
+public static class FluentCompositeKeys
+{
+    /// <summary>
+    /// Reads a composite key.
+    /// </summary>
+    /// <param name="call">The call declaring the key.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>The key expression, or <see langword="null"/> when no part could be read.</returns>
+    public static string? Read(InvocationExpressionSyntax call, SemanticModel semanticModel)
+    {
+        var type = InvocationChain.TypeArgumentOf(call) is { } argument
+            ? semanticModel.GetTypeInfo(argument).Type?.Name
+            : null;
+
+        var body = InvocationChain.ArgumentOf(call);
+        if (type is null || body is null)
+        {
+            return null;
+        }
+
+        var parts = Parts(body).ToList();
+
+        return parts.Count == 0 ? null : ProjectionExpressions.Composite(type, parts);
+    }
+
+    /// <summary>
+    /// Reads the parts a composite key is made of.
+    /// </summary>
+    /// <param name="body">The body declaring the parts.</param>
+    /// <returns>The property to expression pairs.</returns>
+    static IEnumerable<KeyValuePair<string, string>> Parts(ExpressionSyntax body)
+    {
+        foreach (var chain in ProjectionPaths.ChainsIn(body))
+        {
+            string? property = null;
+
+            foreach (var call in InvocationChain.Sequence(chain))
+            {
+                var name = InvocationChain.NameOf(call);
+                var argument = InvocationChain.ArgumentOf(call);
+
+                if (string.Equals(name, "Set", StringComparison.Ordinal))
+                {
+                    property = ProjectionPaths.ReadDeclared(argument);
+                }
+                else if (string.Equals(name, "To", StringComparison.Ordinal) &&
+                    property is not null &&
+                    ProjectionPaths.Read(argument) is { } source)
+                {
+                    yield return new(property, source);
+                    property = null;
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentMappings.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentMappings.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Collects the property mappings of one block of a fluent projection.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A mapping is written across two calls - one naming the read model property, the next giving it a value - so the
+/// property has to be held between them. The kind of mapping is held with it, because what the value means depends
+/// on whether the property was being set, added to or subtracted from.
+/// </remarks>
+public class FluentMappings(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The call setting a read model property to a value.
+    /// </summary>
+    public const string Set = "Set";
+
+    /// <summary>
+    /// The call adding a value to a read model property.
+    /// </summary>
+    public const string Add = "Add";
+
+    /// <summary>
+    /// The call subtracting a value from a read model property.
+    /// </summary>
+    public const string Subtract = "Subtract";
+
+    readonly Dictionary<string, string> _properties = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the mappings collected so far, keyed by the read model property they fill in.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Properties => _properties;
+
+    /// <summary>
+    /// Begins a mapping, remembering which property is waiting for a value and what will be done with it.
+    /// </summary>
+    /// <param name="kind">The name of the call beginning the mapping.</param>
+    /// <param name="argument">The lambda selecting the read model property.</param>
+    /// <returns>What is now pending, or <see langword="null"/> when the property could not be read.</returns>
+    public static string? Begin(string kind, ExpressionSyntax? argument) =>
+        ProjectionPaths.ReadDeclared(argument) is { } property ? $"{kind}:{property}" : null;
+
+    /// <summary>
+    /// Records a mapping that needs no value of its own.
+    /// </summary>
+    /// <param name="name">The name of the call.</param>
+    /// <param name="argument">The lambda selecting the read model property.</param>
+    public void Counter(string name, ExpressionSyntax? argument)
+    {
+        if (ProjectionPaths.ReadDeclared(argument) is not { } property)
+        {
+            return;
+        }
+
+        _properties[property] = name switch
+        {
+            "Increment" => ProjectionExpressions.Increment,
+            "Decrement" => ProjectionExpressions.Decrement,
+            _ => ProjectionExpressions.Count
+        };
+    }
+
+    /// <summary>
+    /// Completes a mapping that was waiting for a value.
+    /// </summary>
+    /// <param name="pending">The property waiting for a value, if there is one.</param>
+    /// <param name="source">The value it was given.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <returns>Nothing further is pending.</returns>
+    public string? Complete(string? pending, string? source, string location)
+    {
+        if (pending is null || source is null)
+        {
+            Report("a value", location);
+
+            return null;
+        }
+
+        var separator = pending.IndexOf(':', StringComparison.Ordinal);
+        var kind = pending[..separator];
+        var property = pending[(separator + 1)..];
+
+        _properties[property] = kind switch
+        {
+            Add => ProjectionExpressions.Add(source),
+            Subtract => ProjectionExpressions.Subtract(source),
+            _ => source
+        };
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reports a call that has no counterpart in the projection definition language.
+    /// </summary>
+    /// <param name="name">The name of the call.</param>
+    /// <param name="location">Where the projection lives.</param>
+    public void Report(string name, string location) =>
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+            $"'{name}' has no counterpart in the projection definition language and was left out",
+            location);
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentProjectionReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentProjectionReader.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the projection a type declares by defining it against a builder.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Reading the chain from the source is what makes a fluent projection expressible at all - at runtime it is an
+/// expression tree that has already been compiled down to something a document cannot be recovered from.
+/// </remarks>
+public class FluentProjectionReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The method a projection is defined in.
+    /// </summary>
+    public const string DefineMethod = "Define";
+
+    /// <summary>
+    /// The identifier of the sequence a projection observes unless it says otherwise.
+    /// </summary>
+    public const string EventLogSequence = "event-log";
+
+    readonly FluentScopeReader _scopes = new(diagnostics);
+
+    /// <summary>
+    /// Determines whether a type defines a projection against a builder, and for what read model.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>The read model, or <see langword="null"/> when the type is not a projection.</returns>
+    public static ITypeSymbol? ReadModelOf(ITypeSymbol type) =>
+        type is { IsAbstract: false, TypeKind: TypeKind.Class }
+            ? type.FindInterface(WellKnownTypeNames.ProjectionFor)?.TypeArguments[0]
+            : null;
+
+    /// <summary>
+    /// Reads the projection a type defines.
+    /// </summary>
+    /// <param name="type">The type declaring the projection.</param>
+    /// <param name="readModel">The read model the projection builds.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="ProjectionModel"/>, or <see langword="null"/> when nothing could be read.</returns>
+    public ProjectionModel? Read(INamedTypeSymbol type, ITypeSymbol readModel, string location)
+    {
+        var scope = new FluentScope();
+
+        foreach (var body in Bodies(type))
+        {
+            _scopes.Read(body, compilation.GetSemanticModel(body.SyntaxTree), scope, location);
+        }
+
+        if (scope.IsEmpty)
+        {
+            return null;
+        }
+
+        var attribute = type.GetAttribute(WellKnownTypeNames.ProjectionAttribute);
+
+        return new(
+            attribute?.GetArgument(0) as string is { Length: > 0 } id ? id : type.ToDisplayString(),
+            readModel.Name,
+            scope.Sequence ?? attribute?.GetArgument(1) as string ?? EventLogSequence,
+            scope.AutoMap,
+            scope.SubscribesToAllEvents,
+            scope.ToModel());
+    }
+
+    /// <summary>
+    /// Gets the bodies of the defining method.
+    /// </summary>
+    /// <param name="type">The type declaring the projection.</param>
+    /// <returns>The bodies, empty when the type has no source.</returns>
+    static IEnumerable<SyntaxNode> Bodies(INamedTypeSymbol type) =>
+        type.GetMembers(DefineMethod)
+            .OfType<IMethodSymbol>()
+            .SelectMany(_ => _.DeclaringSyntaxReferences)
+            .Select(_ => _.GetSyntax())
+            .Select(BodyOf)
+            .OfType<SyntaxNode>();
+
+    /// <summary>
+    /// Gets the body of a declaration.
+    /// </summary>
+    /// <param name="node">The declaration to read.</param>
+    /// <returns>The body, or <see langword="null"/> when the declaration has none.</returns>
+    static SyntaxNode? BodyOf(SyntaxNode node) =>
+        node is MethodDeclarationSyntax method ? (SyntaxNode?)method.Body ?? method.ExpressionBody?.Expression : null;
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentScope.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentScope.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Collects everything one scope of a fluent projection declares, while the chain is being read.
+/// </summary>
+public class FluentScope
+{
+    /// <summary>
+    /// Gets the blocks observing specific event types.
+    /// </summary>
+    public IList<ProjectionFromModel> From { get; } = [];
+
+    /// <summary>
+    /// Gets the blocks joining data from other events.
+    /// </summary>
+    public IList<ProjectionJoinModel> Joins { get; } = [];
+
+    /// <summary>
+    /// Gets the child collections of the scope.
+    /// </summary>
+    public IList<ProjectionChildScopeModel> Children { get; } = [];
+
+    /// <summary>
+    /// Gets the nested objects of the scope.
+    /// </summary>
+    public IList<ProjectionChildScopeModel> Nested { get; } = [];
+
+    /// <summary>
+    /// Gets the blocks removing instances when an event occurs.
+    /// </summary>
+    public IList<ProjectionRemoveModel> RemovedWith { get; } = [];
+
+    /// <summary>
+    /// Gets the blocks removing joined instances when an event occurs.
+    /// </summary>
+    public IList<ProjectionRemoveModel> RemovedWithJoin { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the block applying to every observed event.
+    /// </summary>
+    public ProjectionEveryModel? Every { get; set; }
+
+    /// <summary>
+    /// Gets or sets how automatic property mapping applies.
+    /// </summary>
+    public ProjectionAutoMapMode AutoMap { get; set; } = ProjectionAutoMapMode.Inherit;
+
+    /// <summary>
+    /// Gets or sets the identifier of the sequence the projection observes.
+    /// </summary>
+    public string? Sequence { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the projection observes every event type in the system.
+    /// </summary>
+    public bool SubscribesToAllEvents { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the scope declares nothing at all.
+    /// </summary>
+    public bool IsEmpty =>
+        From.Count == 0 &&
+        Joins.Count == 0 &&
+        Children.Count == 0 &&
+        Nested.Count == 0 &&
+        RemovedWith.Count == 0 &&
+        RemovedWithJoin.Count == 0 &&
+        Every is null;
+
+    /// <summary>
+    /// Turns what was collected into the model of a scope.
+    /// </summary>
+    /// <returns>The <see cref="ProjectionScopeModel"/>.</returns>
+    public ProjectionScopeModel ToModel() => new(From, Every, Joins, Children, Nested, RemovedWith, RemovedWithJoin);
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentScopeReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentScopeReader.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads one scope of a fluent projection - the projection itself, or a child or nested object within it.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+public class FluentScopeReader(ScreenplayDiagnostics diagnostics)
+{
+    readonly FluentBlocks _blocks = new(diagnostics);
+
+    /// <summary>
+    /// Reads every chain declared within a scope.
+    /// </summary>
+    /// <param name="node">The node holding the scope.</param>
+    /// <param name="semanticModel">The semantic model of the tree the scope lives in.</param>
+    /// <param name="scope">The scope being collected into.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    public void Read(SyntaxNode node, SemanticModel semanticModel, FluentScope scope, string location)
+    {
+        foreach (var chain in ProjectionPaths.ChainsIn(node))
+        {
+            foreach (var call in InvocationChain.Sequence(chain))
+            {
+                ReadCall(call, semanticModel, scope, location);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the expression identifying each instance of a child collection.
+    /// </summary>
+    /// <param name="body">The body declaring the child collection.</param>
+    /// <returns>The expression, or <see langword="null"/> when the body declares none.</returns>
+    static string? IdentifiedBy(SyntaxNode body) =>
+        body.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(_ => string.Equals(InvocationChain.NameOf(_), "IdentifiedBy", StringComparison.Ordinal))
+            .Select(_ => ProjectionPaths.Read(InvocationChain.ArgumentOf(_)))
+            .FirstOrDefault(_ => _ is not null);
+
+    /// <summary>
+    /// Reads one call of a scope's chain.
+    /// </summary>
+    /// <param name="call">The call to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="scope">The scope being collected into.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    void ReadCall(InvocationExpressionSyntax call, SemanticModel semanticModel, FluentScope scope, string location)
+    {
+        switch (InvocationChain.NameOf(call))
+        {
+            case "AutoMap":
+                scope.AutoMap = ProjectionAutoMapMode.Enabled;
+                break;
+
+            case "NoAutoMap":
+                scope.AutoMap = ProjectionAutoMapMode.Disabled;
+                break;
+
+            case "FromEventSequence":
+                scope.Sequence = semanticModel.GetConstantValue(InvocationChain.ArgumentOf(call)!).Value as string;
+                break;
+
+            case "From":
+                _blocks.ReadFrom(call, semanticModel, scope, location);
+                break;
+
+            case "Join":
+                _blocks.ReadJoin(call, semanticModel, scope, location);
+                break;
+
+            case "FromEvery":
+                scope.Every = _blocks.ReadEvery(call, semanticModel, location);
+                break;
+
+            case "FromAll":
+                scope.Every = _blocks.ReadEvery(call, semanticModel, location);
+                scope.SubscribesToAllEvents = true;
+                break;
+
+            case "RemovedWith":
+                _blocks.Remove(call, semanticModel, scope.RemovedWith, location);
+                break;
+
+            case "RemovedWithJoin":
+                _blocks.Remove(call, semanticModel, scope.RemovedWithJoin, location);
+                break;
+
+            case "Children":
+                ReadChild(call, semanticModel, scope.Children, location, identified: true);
+                break;
+
+            case "Nested":
+                ReadChild(call, semanticModel, scope.Nested, location, identified: false);
+                break;
+
+            case "Passive" or "NotRewindable" or "ContainerName" or "WithInitialValues":
+                diagnostics.Information(
+                    ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                    $"'{InvocationChain.NameOf(call)}' configures how the projection runs, which a document does not describe",
+                    location);
+                break;
+
+            case "" or "IdentifiedBy" or "FromEventProperty":
+                break;
+
+            default:
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                    $"'{InvocationChain.NameOf(call)}' has no counterpart in the projection definition language and was left out",
+                    location);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Reads a child collection or a nested object.
+    /// </summary>
+    /// <param name="call">The call declaring the scope.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="scopes">The scopes being collected into.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <param name="identified">Whether each instance of the scope is identified by an expression.</param>
+    void ReadChild(
+        InvocationExpressionSyntax call,
+        SemanticModel semanticModel,
+        IList<ProjectionChildScopeModel> scopes,
+        string location,
+        bool identified)
+    {
+        var property = ProjectionPaths.ReadDeclared(InvocationChain.ArgumentOf(call));
+        var body = InvocationChain.ArgumentOf(call, 1);
+        if (property is null || body is null)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                "A child or nested object does not name the property it fills in directly, so it was left out",
+                location);
+
+            return;
+        }
+
+        var inner = new FluentScope();
+        Read(body, semanticModel, inner, location);
+
+        scopes.Add(new(property, identified ? IdentifiedBy(body) ?? string.Empty : string.Empty, inner.AutoMap, inner.ToModel()));
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundAttributes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundAttributes.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the arguments the attributes of a model-bound projection carry.
+/// </summary>
+/// <remarks>
+/// Every one of these attributes names the event it binds to through a type argument and everything else through
+/// optional arguments, so the same two questions are asked of all of them.
+/// </remarks>
+public static class ModelBoundAttributes
+{
+    /// <summary>
+    /// Gets the event type an attribute is bound to.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <returns>The type, or <see langword="null"/> when the attribute names none.</returns>
+    public static ITypeSymbol? EventTypeSymbolOf(AttributeData attribute) =>
+        attribute.AttributeClass?.TypeArguments.FirstOrDefault();
+
+    /// <summary>
+    /// Gets the name of the event type an attribute is bound to.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <returns>The name, or <see langword="null"/> when the attribute names none.</returns>
+    public static string? EventTypeOf(AttributeData attribute) => EventTypeSymbolOf(attribute)?.Name;
+
+    /// <summary>
+    /// Gets an argument of an attribute, in either the named or the positional form.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The value, or <see langword="null"/> when the argument carries nothing.</returns>
+    public static string? Argument(AttributeData attribute, string name, int index) =>
+        (attribute.GetNamedArgument(name) ?? attribute.GetArgument(index)) as string is { Length: > 0 } value ? value : null;
+
+    /// <summary>
+    /// Gets an argument naming a property path, in the casing a projection body references it by.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The path, or <see langword="null"/> when the argument carries nothing.</returns>
+    /// <remarks>
+    /// A declaration names properties the way C# declares them, while a projection body references them the way they
+    /// are serialized, so the casing is converted here rather than left for the printer, which writes an expression
+    /// verbatim. That is also what lets the same declaration made fluently and made with attributes agree.
+    /// </remarks>
+    public static string? Path(AttributeData attribute, string name, int index) =>
+        ProjectionPaths.Convert(Argument(attribute, name, index));
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundChild.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundChild.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Represents a child collection or nested object a model-bound read model declares with attributes.
+/// </summary>
+/// <param name="Property">The read model property holding the children or nested object.</param>
+/// <param name="Type">The type each instance is of.</param>
+/// <param name="IdentifiedBy">The expression identifying each child, empty for a nested object.</param>
+/// <param name="AutoMap">How automatic property mapping applies within the scope.</param>
+/// <param name="From">The blocks the declaring attributes state themselves, which create the instances.</param>
+public record ModelBoundChild(
+    string Property,
+    INamedTypeSymbol Type,
+    string IdentifiedBy,
+    ProjectionAutoMapMode AutoMap,
+    IEnumerable<ProjectionFromModel> From)
+{
+    /// <summary>
+    /// Builds the scope of the child, folding what the declaring attributes state into what its type declares.
+    /// </summary>
+    /// <param name="inner">Everything the type of the child declares itself.</param>
+    /// <returns>The <see cref="ProjectionChildScopeModel"/>.</returns>
+    /// <remarks>
+    /// The attribute on the parent says which event brings an instance into being and how it is keyed, while the
+    /// type of the instance says what that event fills in. Both describe the same block, so the two are merged
+    /// rather than emitted as a block that keys nothing and a block that maps nothing.
+    /// </remarks>
+    public ProjectionChildScopeModel ToScope(ProjectionScopeModel inner)
+    {
+        var blocks = new Dictionary<string, ProjectionFromModel>(StringComparer.Ordinal);
+
+        foreach (var block in inner.From)
+        {
+            blocks[EventNameOf(block)] = block;
+        }
+
+        foreach (var declared in From)
+        {
+            var name = EventNameOf(declared);
+            blocks[name] = blocks.TryGetValue(name, out var existing)
+                ? existing with { Key = declared.Key, ParentKey = declared.ParentKey }
+                : declared;
+        }
+
+        return new(Property, IdentifiedBy, AutoMap, inner with
+        {
+            From = [.. blocks.Values.OrderBy(EventNameOf, StringComparer.Ordinal)]
+        });
+    }
+
+    /// <summary>
+    /// Gets the name of the event a block observes.
+    /// </summary>
+    /// <param name="from">The block to read.</param>
+    /// <returns>The name, empty when the block names none.</returns>
+    static string EventNameOf(ProjectionFromModel from) => from.EventTypes.FirstOrDefault() ?? string.Empty;
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundChildren.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundChildren.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the child collections and nested objects a model-bound read model declares with attributes.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// The property says where the instances live and the type of the instances says what fills them in, so a child is
+/// only half declared where it is written - the other half is read from the type it holds.
+/// </remarks>
+public class ModelBoundChildren(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The name of the property a read model is identified by unless it says otherwise.
+    /// </summary>
+    public const string ConventionalKey = "Id";
+
+    /// <summary>
+    /// Reads the child collections a read model declares.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="location">Where the read model lives, for use in diagnostics.</param>
+    /// <returns>The children, ordered by the property holding them.</returns>
+    public IEnumerable<ModelBoundChild> In(ITypeSymbol readModel, string location)
+    {
+        var children = new List<ModelBoundChild>();
+
+        foreach (var property in readModel.DeclaredProperties())
+        {
+            var declarations = Declarations(property, ModelBoundNames.ChildrenFrom);
+            if (declarations.Count == 0)
+            {
+                continue;
+            }
+
+            if (CollectionElements.ElementOf(property.Type) is not INamedTypeSymbol child)
+            {
+                Report(property, "children", location);
+                continue;
+            }
+
+            ReportRemovals(property, location);
+
+            children.Add(new(
+                property.Name,
+                child,
+                IdentifiedByOf(declarations[0], child),
+                AutoMapOf(child),
+                [.. declarations.Select(_ => FromOf(_, readModel)).OrderBy(_ => _.EventTypes.First(), StringComparer.Ordinal)]));
+        }
+
+        return [.. children.OrderBy(_ => _.Property, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Reads the nested objects a read model declares.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="location">Where the read model lives, for use in diagnostics.</param>
+    /// <returns>The nested objects, ordered by the property holding them.</returns>
+    /// <remarks>
+    /// A nested object carries no key of its own - there is only ever one of it - and the events filling it in are
+    /// declared by its own type rather than by the property, so the attribute itself carries nothing to read.
+    /// </remarks>
+    public IEnumerable<ModelBoundChild> NestedIn(ITypeSymbol readModel, string location)
+    {
+        var nested = new List<ModelBoundChild>();
+
+        foreach (var property in readModel.DeclaredProperties().Where(_ => ModelBoundMembers.HasAttribute(_, ModelBoundNames.Nested)))
+        {
+            if (UnderlyingOf(property.Type) is not { } type)
+            {
+                Report(property, "nested object", location);
+                continue;
+            }
+
+            nested.Add(new(property.Name, type, string.Empty, AutoMapOf(type), []));
+        }
+
+        return [.. nested.OrderBy(_ => _.Property, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Gets the attributes of a given type declaring something about a member.
+    /// </summary>
+    /// <param name="property">The property to read.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
+    /// <returns>The attributes, in declaration order.</returns>
+    static List<AttributeData> Declarations(IPropertySymbol property, string fullMetadataName) =>
+        [.. ModelBoundMembers.AttributesOf(property).Where(_ => _.AttributeClass.Is(fullMetadataName))];
+
+    /// <summary>
+    /// Builds the block bringing an instance of a child into being.
+    /// </summary>
+    /// <param name="attribute">The attribute declaring the child.</param>
+    /// <param name="readModel">The read model holding the child.</param>
+    /// <returns>The <see cref="ProjectionFromModel"/>.</returns>
+    static ProjectionFromModel FromOf(AttributeData attribute, ITypeSymbol readModel) =>
+        new(
+            [ModelBoundAttributes.EventTypeOf(attribute) ?? string.Empty],
+            ModelBoundAttributes.Path(attribute, "Key", 0),
+            ModelBoundParentKeys.Of(attribute, readModel),
+            new Dictionary<string, string>(StringComparer.Ordinal));
+
+    /// <summary>
+    /// Gets the expression identifying each instance of a child collection.
+    /// </summary>
+    /// <param name="attribute">The attribute declaring the child.</param>
+    /// <param name="child">The type each instance is of.</param>
+    /// <returns>The expression.</returns>
+    /// <remarks>
+    /// A declaration that names nothing falls back to what the type itself says - the property marked as its key,
+    /// then one named by convention - and finally to the event source, which is what a child with no identity of
+    /// its own is distinguished by.
+    /// </remarks>
+    static string IdentifiedByOf(AttributeData attribute, ITypeSymbol child) =>
+        ModelBoundAttributes.Path(attribute, "IdentifiedBy", 1) ??
+        ProjectionPaths.Convert(KeyPropertyOf(child)) ??
+        ProjectionExpressions.EventSourceId;
+
+    /// <summary>
+    /// Gets the property a type says identifies it.
+    /// </summary>
+    /// <param name="type">The type to read.</param>
+    /// <returns>The name, or <see langword="null"/> when the type names none.</returns>
+    static string? KeyPropertyOf(ITypeSymbol type) =>
+        type.DeclaredProperties().FirstOrDefault(_ => ModelBoundMembers.HasAttribute(_, ModelBoundNames.Key))?.Name ??
+        type.DeclaredProperties().FirstOrDefault(_ => string.Equals(_.Name, ConventionalKey, StringComparison.OrdinalIgnoreCase))?.Name;
+
+    /// <summary>
+    /// Gets how automatic property mapping applies within a scope.
+    /// </summary>
+    /// <param name="type">The type the scope builds.</param>
+    /// <returns>The mode, inherited from the enclosing scope unless the type turns mapping off.</returns>
+    static ProjectionAutoMapMode AutoMapOf(ITypeSymbol type) =>
+        type.HasAttribute(ModelBoundNames.NoAutoMap) ? ProjectionAutoMapMode.Disabled : ProjectionAutoMapMode.Inherit;
+
+    /// <summary>
+    /// Gets the type a nested object is of, seeing through the nullability every one of them is declared with.
+    /// </summary>
+    /// <param name="type">The type of the property.</param>
+    /// <returns>The type, or <see langword="null"/> when it is not one a scope can be read from.</returns>
+    static INamedTypeSymbol? UnderlyingOf(ITypeSymbol type) =>
+        type is not INamedTypeSymbol named
+            ? null
+            : named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                ? named.TypeArguments[0] as INamedTypeSymbol
+                : named;
+
+    /// <summary>
+    /// Reports a declaration whose property holds nothing a scope can be read from.
+    /// </summary>
+    /// <param name="property">The property declaring it.</param>
+    /// <param name="kind">What the property was declared to hold.</param>
+    /// <param name="location">Where the read model lives.</param>
+    void Report(IPropertySymbol property, string kind, string location) =>
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnmappableProjectionScope,
+            $"'{property.Name}' is declared to hold a {kind}, but its type is not one whose contents can be read, so it was left out",
+            location);
+
+    /// <summary>
+    /// Reports a removal declared beside a child collection rather than by the type of the child.
+    /// </summary>
+    /// <param name="property">The property holding the children.</param>
+    /// <param name="location">Where the read model lives.</param>
+    /// <remarks>
+    /// What removes an instance is read from the type of the instance, which is where the events filling it in are
+    /// read from as well. The same removal written beside the collection instead is a form nothing reads yet, so it
+    /// is reported rather than leaving a child collection nothing ever removes anything from.
+    /// </remarks>
+    void ReportRemovals(IPropertySymbol property, string location)
+    {
+        foreach (var attribute in ModelBoundMembers.AttributesOf(property)
+            .Where(_ => _.AttributeClass.Is(ModelBoundNames.RemovedWith) || _.AttributeClass.Is(ModelBoundNames.RemovedWithJoin)))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionScope,
+                $"'{property.Name}' declares that '{ModelBoundAttributes.EventTypeOf(attribute)}' removes one of its children, which is read back only when the type of the child declares it, so it was left out",
+                location);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundChildren.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundChildren.cs
@@ -73,7 +73,7 @@ public class ModelBoundChildren(ScreenplayDiagnostics diagnostics)
     {
         var nested = new List<ModelBoundChild>();
 
-        foreach (var property in readModel.DeclaredProperties().Where(_ => ModelBoundMembers.HasAttribute(_, ModelBoundNames.Nested)))
+        foreach (var property in readModel.DeclaredProperties().Where(_ => MemberAttributes.Has(_, ModelBoundNames.Nested)))
         {
             if (UnderlyingOf(property.Type) is not { } type)
             {
@@ -94,7 +94,7 @@ public class ModelBoundChildren(ScreenplayDiagnostics diagnostics)
     /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
     /// <returns>The attributes, in declaration order.</returns>
     static List<AttributeData> Declarations(IPropertySymbol property, string fullMetadataName) =>
-        [.. ModelBoundMembers.AttributesOf(property).Where(_ => _.AttributeClass.Is(fullMetadataName))];
+        [.. MemberAttributes.Of(property).Where(_ => _.AttributeClass.Is(fullMetadataName))];
 
     /// <summary>
     /// Builds the block bringing an instance of a child into being.
@@ -131,7 +131,7 @@ public class ModelBoundChildren(ScreenplayDiagnostics diagnostics)
     /// <param name="type">The type to read.</param>
     /// <returns>The name, or <see langword="null"/> when the type names none.</returns>
     static string? KeyPropertyOf(ITypeSymbol type) =>
-        type.DeclaredProperties().FirstOrDefault(_ => ModelBoundMembers.HasAttribute(_, ModelBoundNames.Key))?.Name ??
+        type.DeclaredProperties().FirstOrDefault(_ => MemberAttributes.Has(_, ModelBoundNames.Key))?.Name ??
         type.DeclaredProperties().FirstOrDefault(_ => string.Equals(_.Name, ConventionalKey, StringComparison.OrdinalIgnoreCase))?.Name;
 
     /// <summary>
@@ -178,7 +178,7 @@ public class ModelBoundChildren(ScreenplayDiagnostics diagnostics)
     /// </remarks>
     void ReportRemovals(IPropertySymbol property, string location)
     {
-        foreach (var attribute in ModelBoundMembers.AttributesOf(property)
+        foreach (var attribute in MemberAttributes.Of(property)
             .Where(_ => _.AttributeClass.Is(ModelBoundNames.RemovedWith) || _.AttributeClass.Is(ModelBoundNames.RemovedWithJoin)))
         {
             diagnostics.Warning(

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundMembers.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundMembers.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Gets the attributes declared on the members of a model-bound read model.
+/// </summary>
+/// <remarks>
+/// A read model is nearly always a positional record, and an attribute written on a positional parameter belongs to
+/// the parameter rather than to the property it produces. Reading only the properties would therefore miss every
+/// mapping the most common way of writing a read model declares.
+/// </remarks>
+public static class ModelBoundMembers
+{
+    /// <summary>
+    /// Gets the attributes applying to a member of a read model.
+    /// </summary>
+    /// <param name="property">The property to read.</param>
+    /// <returns>The attributes, those of the property first.</returns>
+    public static IEnumerable<AttributeData> AttributesOf(IPropertySymbol property) =>
+        ParameterOf(property) is { } parameter
+            ? property.GetAttributes().Concat(parameter.GetAttributes())
+            : property.GetAttributes();
+
+    /// <summary>
+    /// Determines whether an attribute of a given type applies to a member of a read model.
+    /// </summary>
+    /// <param name="property">The property to check.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
+    /// <returns>True when the attribute applies.</returns>
+    public static bool HasAttribute(IPropertySymbol property, string fullMetadataName) =>
+        AttributesOf(property).Any(_ => _.AttributeClass.Is(fullMetadataName));
+
+    /// <summary>
+    /// Gets the positional parameter a property was produced from.
+    /// </summary>
+    /// <param name="property">The property to read.</param>
+    /// <returns>The parameter, or <see langword="null"/> when the property has none.</returns>
+    static IParameterSymbol? ParameterOf(IPropertySymbol property) =>
+        PrimaryConstructorOf(property.ContainingType)?.Parameters
+            .FirstOrDefault(_ => string.Equals(_.Name, property.Name, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Gets the constructor a type declares in its own header rather than as a member.
+    /// </summary>
+    /// <param name="type">The type to read.</param>
+    /// <returns>The constructor, or <see langword="null"/> when the type declares none.</returns>
+    static IMethodSymbol? PrimaryConstructorOf(INamedTypeSymbol? type) =>
+        type?.InstanceConstructors.FirstOrDefault(_ =>
+            _.Parameters.Length > 0 &&
+            _.DeclaringSyntaxReferences.Any(reference => reference.GetSyntax() is TypeDeclarationSyntax));
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundNames.cs
@@ -64,4 +64,7 @@ public static class ModelBoundNames
 
     /// <summary>The attribute turning automatic property mapping off.</summary>
     public const string NoAutoMap = "Cratis.Chronicle.Projections.NoAutoMapAttribute";
+
+    /// <summary>The attribute naming the property a read model is identified by.</summary>
+    public const string Key = "Cratis.Chronicle.Keys.KeyAttribute";
 }

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundNames.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Holds the fully qualified metadata names of the attributes a model-bound projection is declared with.
+/// </summary>
+public static class ModelBoundNames
+{
+    /// <summary>The namespace the model-bound projection attributes live in.</summary>
+    public const string Namespace = "Cratis.Chronicle.Projections.ModelBound";
+
+    /// <summary>The attribute observing an event type.</summary>
+    public const string FromEvent = $"{Namespace}.FromEventAttribute`1";
+
+    /// <summary>The attribute applying a mapping to every observed event.</summary>
+    public const string FromEvery = $"{Namespace}.FromEveryAttribute";
+
+    /// <summary>The attribute applying a mapping to every event type in the system.</summary>
+    public const string FromAll = $"{Namespace}.FromAllAttribute";
+
+    /// <summary>The attribute mapping an event property onto a read model property.</summary>
+    public const string SetFrom = $"{Namespace}.SetFromAttribute`1";
+
+    /// <summary>The attribute mapping a constant onto a read model property.</summary>
+    public const string SetValue = $"{Namespace}.SetValueAttribute`1";
+
+    /// <summary>The attribute mapping an event context value onto a read model property.</summary>
+    public const string SetFromContext = $"{Namespace}.SetFromContextAttribute`1";
+
+    /// <summary>The attribute counting occurrences into a read model property.</summary>
+    public const string Count = $"{Namespace}.CountAttribute`1";
+
+    /// <summary>The attribute incrementing a read model property.</summary>
+    public const string Increment = $"{Namespace}.IncrementAttribute`1";
+
+    /// <summary>The attribute decrementing a read model property.</summary>
+    public const string Decrement = $"{Namespace}.DecrementAttribute`1";
+
+    /// <summary>The attribute adding an event property to a read model property.</summary>
+    public const string AddFrom = $"{Namespace}.AddFromAttribute`1";
+
+    /// <summary>The attribute subtracting an event property from a read model property.</summary>
+    public const string SubtractFrom = $"{Namespace}.SubtractFromAttribute`1";
+
+    /// <summary>The attribute joining data from another event onto a read model property.</summary>
+    public const string Join = $"{Namespace}.JoinAttribute`1";
+
+    /// <summary>The attribute building a child collection from an event.</summary>
+    public const string ChildrenFrom = $"{Namespace}.ChildrenFromAttribute`1";
+
+    /// <summary>The attribute marking a read model property as a nested object.</summary>
+    public const string Nested = $"{Namespace}.NestedAttribute";
+
+    /// <summary>The attribute clearing a nested object when an event occurs.</summary>
+    public const string ClearWith = $"{Namespace}.ClearWithAttribute`1";
+
+    /// <summary>The attribute removing a read model instance when an event occurs.</summary>
+    public const string RemovedWith = $"{Namespace}.RemovedWithAttribute`1";
+
+    /// <summary>The attribute removing a joined read model instance when an event occurs.</summary>
+    public const string RemovedWithJoin = $"{Namespace}.RemovedWithJoinAttribute`1";
+
+    /// <summary>The attribute turning automatic property mapping off.</summary>
+    public const string NoAutoMap = "Cratis.Chronicle.Projections.NoAutoMapAttribute";
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundParentKeys.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundParentKeys.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Resolves the expression a child collection finds its parent by.
+/// </summary>
+/// <remarks>
+/// A declaration that names no parent key does not mean the parent is the event source - the runtime looks for a
+/// property of the event carrying the same kind of value the parent is identified by, and uses that. A document
+/// saying nothing would therefore describe a hierarchy that is assembled differently from the one that really runs,
+/// so the same search is made here rather than the default being assumed.
+/// </remarks>
+public static class ModelBoundParentKeys
+{
+    /// <summary>
+    /// Gets the expression a child finds its parent by.
+    /// </summary>
+    /// <param name="attribute">The attribute declaring the child.</param>
+    /// <param name="readModel">The read model holding the child.</param>
+    /// <returns>The expression, or <see langword="null"/> when the event source identifies the parent.</returns>
+    public static string? Of(AttributeData attribute, ITypeSymbol readModel) =>
+        ModelBoundAttributes.Path(attribute, "ParentKey", 2) ??
+        Discover(
+            ModelBoundAttributes.EventTypeSymbolOf(attribute),
+            readModel,
+            ModelBoundAttributes.Argument(attribute, "Key", 0));
+
+    /// <summary>
+    /// Searches an event for the property carrying the identifier of the parent.
+    /// </summary>
+    /// <param name="eventType">The event type bringing an instance of the child into being.</param>
+    /// <param name="readModel">The read model holding the child.</param>
+    /// <param name="key">The property the child itself is keyed on, which is never also the parent.</param>
+    /// <returns>The expression, or <see langword="null"/> when nothing matches.</returns>
+    /// <remarks>
+    /// More than one property may carry the same kind of value, in which case the first one declared is used - the
+    /// declaration really is ambiguous, and naming the parent key explicitly is what resolves it.
+    /// </remarks>
+    static string? Discover(ITypeSymbol? eventType, ITypeSymbol readModel, string? key)
+    {
+        if (eventType is null || IdentifierTypeOf(readModel) is not { } identifier)
+        {
+            return null;
+        }
+
+        var match = eventType.DeclaredProperties()
+            .FirstOrDefault(_ =>
+                SymbolEqualityComparer.Default.Equals(_.Type, identifier) &&
+                !string.Equals(_.Name, key, StringComparison.OrdinalIgnoreCase));
+
+        return match is null ? null : ProjectionPaths.Convert(match.Name);
+    }
+
+    /// <summary>
+    /// Gets the kind of value a read model is identified by.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <returns>The type, or <see langword="null"/> when the read model carries no identifier.</returns>
+    static ITypeSymbol? IdentifierTypeOf(ITypeSymbol readModel) =>
+        readModel.DeclaredProperties()
+            .FirstOrDefault(_ => string.Equals(_.Name, ModelBoundChildren.ConventionalKey, StringComparison.OrdinalIgnoreCase))
+            ?.Type;
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundProjectionReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundProjectionReader.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the projection a model-bound read model declares through attributes.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Automatic property mapping is on unless the read model turns it off, which is the opposite of what a fluent
+/// projection defaults to, so it is stated explicitly rather than inherited.
+/// </remarks>
+public class ModelBoundProjectionReader(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The identifier of the sequence a projection observes unless it says otherwise.
+    /// </summary>
+    public const string EventLogSequence = "event-log";
+
+    /// <summary>
+    /// Reads the projection a read model declares.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="location">Where the read model lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="ProjectionModel"/>, or <see langword="null"/> when the read model declares none.</returns>
+    public ProjectionModel? Read(INamedTypeSymbol readModel, string location)
+    {
+        var mappings = ModelBoundPropertyMappings.From(readModel);
+        var from = ReadFrom(readModel, mappings).ToList();
+        var removed = ReadRemovals(readModel, ModelBoundNames.RemovedWith).ToList();
+        var removedViaJoin = ReadRemovals(readModel, ModelBoundNames.RemovedWithJoin).ToList();
+        var joins = mappings.Joins.ToList();
+
+        if (from.Count == 0 && removed.Count == 0 && removedViaJoin.Count == 0 && joins.Count == 0 && mappings.Every.Count == 0)
+        {
+            return null;
+        }
+
+        ReportWhatIsNotRead(readModel, location);
+
+        var attribute = readModel.GetAttribute(WellKnownTypeNames.ProjectionAttribute);
+
+        return new(
+            attribute?.GetArgument(0) as string is { Length: > 0 } id ? id : readModel.ToDisplayString(),
+            readModel.Name,
+            attribute?.GetArgument(1) as string ?? EventLogSequence,
+            readModel.HasAttribute(ModelBoundNames.NoAutoMap) ? ProjectionAutoMapMode.Disabled : ProjectionAutoMapMode.Enabled,
+            readModel.HasAttribute(ModelBoundNames.FromAll),
+            new(from, EveryOf(mappings), joins, [], [], removed, removedViaJoin));
+    }
+
+    /// <summary>
+    /// Builds the block applying to every observed event.
+    /// </summary>
+    /// <param name="mappings">The mappings the read model declares.</param>
+    /// <returns>The block, or <see langword="null"/> when the read model declares none.</returns>
+    static ProjectionEveryModel? EveryOf(ModelBoundPropertyMappings mappings) =>
+        mappings.Every.Count == 0 ? null : new(mappings.Every, true, ProjectionAutoMapMode.Inherit);
+
+    /// <summary>
+    /// Reads the blocks observing specific event types.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="mappings">The mappings the read model declares.</param>
+    /// <returns>The blocks, ordered by the event they observe.</returns>
+    /// <remarks>
+    /// An event named only by a property is observed just as much as one named by the read model itself, so both
+    /// sources of event types are merged rather than the declaration having to say it twice.
+    /// </remarks>
+    static IEnumerable<ProjectionFromModel> ReadFrom(INamedTypeSymbol readModel, ModelBoundPropertyMappings mappings)
+    {
+        var declared = readModel.GetAttributes(ModelBoundNames.FromEvent)
+            .Select(_ => (Name: EventTypeOf(_), Attribute: _))
+            .Where(_ => _.Name is not null)
+            .ToDictionary(_ => _.Name!, _ => _.Attribute, StringComparer.Ordinal);
+
+        var names = declared.Keys.Concat(mappings.EventTypes()).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal);
+
+        return
+        [
+            .. names.Select(name => new ProjectionFromModel(
+                [name],
+                declared.TryGetValue(name, out var attribute) ? Argument(attribute, "Key", 0) : null,
+                declared.TryGetValue(name, out var parent) ? Argument(parent, "ParentKey", 1) : null,
+                mappings.For(name)))
+        ];
+    }
+
+    /// <summary>
+    /// Reads the blocks removing an instance when an event occurs.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="attributeName">The fully qualified metadata name of the attribute declaring the removal.</param>
+    /// <returns>The blocks, ordered by the event they observe.</returns>
+    static IEnumerable<ProjectionRemoveModel> ReadRemovals(INamedTypeSymbol readModel, string attributeName) =>
+    [
+        .. readModel.GetAttributes(attributeName)
+            .Select(_ => new ProjectionRemoveModel(EventTypeOf(_) ?? string.Empty, Argument(_, "Key", 0), Argument(_, "ParentKey", 1)))
+            .Where(_ => _.EventType.Length > 0)
+            .OrderBy(_ => _.EventType, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Gets the name of the event type an attribute is bound to.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <returns>The name, or <see langword="null"/> when the attribute names none.</returns>
+    static string? EventTypeOf(AttributeData attribute) => attribute.AttributeClass?.TypeArguments.FirstOrDefault()?.Name;
+
+    /// <summary>
+    /// Gets an argument of an attribute, in either the named or the positional form.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The value, or <see langword="null"/> when the argument carries nothing.</returns>
+    static string? Argument(AttributeData attribute, string name, int index) =>
+        (attribute.GetNamedArgument(name) ?? attribute.GetArgument(index)) as string is { Length: > 0 } value ? value : null;
+
+    /// <summary>
+    /// Reports the parts of a model-bound projection that are not read back.
+    /// </summary>
+    /// <param name="readModel">The read model to check.</param>
+    /// <param name="location">Where the read model lives.</param>
+    void ReportWhatIsNotRead(INamedTypeSymbol readModel, string location)
+    {
+        foreach (var property in readModel.DeclaredProperties())
+        {
+            if (property.HasAttribute(ModelBoundNames.ChildrenFrom) || property.HasAttribute(ModelBoundNames.Nested))
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                    $"The child or nested object '{property.Name}' is declared with attributes, which source analysis does not read back yet, so it was left out",
+                    location);
+            }
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundProjectionReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundProjectionReader.cs
@@ -21,6 +21,8 @@ public class ModelBoundProjectionReader(ScreenplayDiagnostics diagnostics)
     /// </summary>
     public const string EventLogSequence = "event-log";
 
+    readonly ModelBoundScopeReader _scopes = new(diagnostics);
+
     /// <summary>
     /// Reads the projection a read model declares.
     /// </summary>
@@ -29,18 +31,11 @@ public class ModelBoundProjectionReader(ScreenplayDiagnostics diagnostics)
     /// <returns>The <see cref="ProjectionModel"/>, or <see langword="null"/> when the read model declares none.</returns>
     public ProjectionModel? Read(INamedTypeSymbol readModel, string location)
     {
-        var mappings = ModelBoundPropertyMappings.From(readModel);
-        var from = ReadFrom(readModel, mappings).ToList();
-        var removed = ReadRemovals(readModel, ModelBoundNames.RemovedWith).ToList();
-        var removedViaJoin = ReadRemovals(readModel, ModelBoundNames.RemovedWithJoin).ToList();
-        var joins = mappings.Joins.ToList();
-
-        if (from.Count == 0 && removed.Count == 0 && removedViaJoin.Count == 0 && joins.Count == 0 && mappings.Every.Count == 0)
+        var scope = _scopes.Read(readModel, location);
+        if (ModelBoundScopeReader.IsEmpty(scope))
         {
             return null;
         }
-
-        ReportWhatIsNotRead(readModel, location);
 
         var attribute = readModel.GetAttribute(WellKnownTypeNames.ProjectionAttribute);
 
@@ -50,93 +45,6 @@ public class ModelBoundProjectionReader(ScreenplayDiagnostics diagnostics)
             attribute?.GetArgument(1) as string ?? EventLogSequence,
             readModel.HasAttribute(ModelBoundNames.NoAutoMap) ? ProjectionAutoMapMode.Disabled : ProjectionAutoMapMode.Enabled,
             readModel.HasAttribute(ModelBoundNames.FromAll),
-            new(from, EveryOf(mappings), joins, [], [], removed, removedViaJoin));
-    }
-
-    /// <summary>
-    /// Builds the block applying to every observed event.
-    /// </summary>
-    /// <param name="mappings">The mappings the read model declares.</param>
-    /// <returns>The block, or <see langword="null"/> when the read model declares none.</returns>
-    static ProjectionEveryModel? EveryOf(ModelBoundPropertyMappings mappings) =>
-        mappings.Every.Count == 0 ? null : new(mappings.Every, true, ProjectionAutoMapMode.Inherit);
-
-    /// <summary>
-    /// Reads the blocks observing specific event types.
-    /// </summary>
-    /// <param name="readModel">The read model to read.</param>
-    /// <param name="mappings">The mappings the read model declares.</param>
-    /// <returns>The blocks, ordered by the event they observe.</returns>
-    /// <remarks>
-    /// An event named only by a property is observed just as much as one named by the read model itself, so both
-    /// sources of event types are merged rather than the declaration having to say it twice.
-    /// </remarks>
-    static IEnumerable<ProjectionFromModel> ReadFrom(INamedTypeSymbol readModel, ModelBoundPropertyMappings mappings)
-    {
-        var declared = readModel.GetAttributes(ModelBoundNames.FromEvent)
-            .Select(_ => (Name: EventTypeOf(_), Attribute: _))
-            .Where(_ => _.Name is not null)
-            .ToDictionary(_ => _.Name!, _ => _.Attribute, StringComparer.Ordinal);
-
-        var names = declared.Keys.Concat(mappings.EventTypes()).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal);
-
-        return
-        [
-            .. names.Select(name => new ProjectionFromModel(
-                [name],
-                declared.TryGetValue(name, out var attribute) ? Argument(attribute, "Key", 0) : null,
-                declared.TryGetValue(name, out var parent) ? Argument(parent, "ParentKey", 1) : null,
-                mappings.For(name)))
-        ];
-    }
-
-    /// <summary>
-    /// Reads the blocks removing an instance when an event occurs.
-    /// </summary>
-    /// <param name="readModel">The read model to read.</param>
-    /// <param name="attributeName">The fully qualified metadata name of the attribute declaring the removal.</param>
-    /// <returns>The blocks, ordered by the event they observe.</returns>
-    static IEnumerable<ProjectionRemoveModel> ReadRemovals(INamedTypeSymbol readModel, string attributeName) =>
-    [
-        .. readModel.GetAttributes(attributeName)
-            .Select(_ => new ProjectionRemoveModel(EventTypeOf(_) ?? string.Empty, Argument(_, "Key", 0), Argument(_, "ParentKey", 1)))
-            .Where(_ => _.EventType.Length > 0)
-            .OrderBy(_ => _.EventType, StringComparer.Ordinal)
-    ];
-
-    /// <summary>
-    /// Gets the name of the event type an attribute is bound to.
-    /// </summary>
-    /// <param name="attribute">The attribute to read.</param>
-    /// <returns>The name, or <see langword="null"/> when the attribute names none.</returns>
-    static string? EventTypeOf(AttributeData attribute) => attribute.AttributeClass?.TypeArguments.FirstOrDefault()?.Name;
-
-    /// <summary>
-    /// Gets an argument of an attribute, in either the named or the positional form.
-    /// </summary>
-    /// <param name="attribute">The attribute to read.</param>
-    /// <param name="name">The name of the argument.</param>
-    /// <param name="index">The position of the argument.</param>
-    /// <returns>The value, or <see langword="null"/> when the argument carries nothing.</returns>
-    static string? Argument(AttributeData attribute, string name, int index) =>
-        (attribute.GetNamedArgument(name) ?? attribute.GetArgument(index)) as string is { Length: > 0 } value ? value : null;
-
-    /// <summary>
-    /// Reports the parts of a model-bound projection that are not read back.
-    /// </summary>
-    /// <param name="readModel">The read model to check.</param>
-    /// <param name="location">Where the read model lives.</param>
-    void ReportWhatIsNotRead(INamedTypeSymbol readModel, string location)
-    {
-        foreach (var property in readModel.DeclaredProperties())
-        {
-            if (property.HasAttribute(ModelBoundNames.ChildrenFrom) || property.HasAttribute(ModelBoundNames.Nested))
-            {
-                diagnostics.Warning(
-                    ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
-                    $"The child or nested object '{property.Name}' is declared with attributes, which source analysis does not read back yet, so it was left out",
-                    location);
-            }
-        }
+            scope);
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
@@ -120,7 +120,7 @@ public class ModelBoundPropertyMappings
     /// <param name="property">The property to read.</param>
     void ReadProperty(IPropertySymbol property)
     {
-        foreach (var attribute in ModelBoundMembers.AttributesOf(property))
+        foreach (var attribute in MemberAttributes.Of(property))
         {
             var name = attribute.AttributeClass is null ? string.Empty : attribute.AttributeClass.FullMetadataName();
             var expression = ExpressionOf(name, attribute, property);

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
@@ -62,14 +62,6 @@ public class ModelBoundPropertyMappings
     public IEnumerable<string> EventTypes() => _byEvent.Keys.Order(StringComparer.Ordinal);
 
     /// <summary>
-    /// Gets the name of the event type an attribute is bound to.
-    /// </summary>
-    /// <param name="attribute">The attribute to read.</param>
-    /// <returns>The name, or <see langword="null"/> when the attribute names none.</returns>
-    static string? EventTypeOf(AttributeData attribute) =>
-        attribute.AttributeClass?.TypeArguments.FirstOrDefault()?.Name;
-
-    /// <summary>
     /// Builds the expression an attribute maps a property with.
     /// </summary>
     /// <param name="name">The fully qualified metadata name of the attribute.</param>
@@ -98,9 +90,11 @@ public class ModelBoundPropertyMappings
     /// <returns>The expression.</returns>
     static string Ambient(AttributeData attribute, IPropertySymbol property)
     {
-        var context = Argument(attribute, "ContextProperty", 1);
+        var context = ModelBoundAttributes.Path(attribute, "ContextProperty", 1);
 
-        return context is null ? Argument(attribute, "Property", 0) ?? property.Name : ProjectionExpressions.EventContext(context);
+        return context is null
+            ? ModelBoundAttributes.Path(attribute, "Property", 0) ?? Named(property)
+            : ProjectionExpressions.EventContext(context);
     }
 
     /// <summary>
@@ -109,19 +103,16 @@ public class ModelBoundPropertyMappings
     /// <param name="attribute">The attribute to read.</param>
     /// <param name="argument">The name of the argument carrying the source.</param>
     /// <param name="property">The property being mapped onto.</param>
-    /// <returns>The source.</returns>
+    /// <returns>The source, in the casing a projection body references it by.</returns>
     static string Source(AttributeData attribute, string argument, IPropertySymbol property) =>
-        Argument(attribute, argument, 0) ?? property.Name;
+        ModelBoundAttributes.Path(attribute, argument, 0) ?? Named(property);
 
     /// <summary>
-    /// Gets an argument of an attribute, in either the named or the positional form.
+    /// Gets the name of a property in the casing a projection body references it by.
     /// </summary>
-    /// <param name="attribute">The attribute to read.</param>
-    /// <param name="name">The name of the argument.</param>
-    /// <param name="index">The position of the argument.</param>
-    /// <returns>The value, or <see langword="null"/> when the argument carries nothing.</returns>
-    static string? Argument(AttributeData attribute, string name, int index) =>
-        (attribute.GetNamedArgument(name) ?? attribute.GetArgument(index)) as string is { Length: > 0 } value ? value : null;
+    /// <param name="property">The property to name.</param>
+    /// <returns>The name.</returns>
+    static string Named(IPropertySymbol property) => ProjectionPaths.Convert(property.Name) ?? property.Name;
 
     /// <summary>
     /// Reads the mappings one property declares.
@@ -129,12 +120,12 @@ public class ModelBoundPropertyMappings
     /// <param name="property">The property to read.</param>
     void ReadProperty(IPropertySymbol property)
     {
-        foreach (var attribute in property.GetAttributes())
+        foreach (var attribute in ModelBoundMembers.AttributesOf(property))
         {
             var name = attribute.AttributeClass is null ? string.Empty : attribute.AttributeClass.FullMetadataName();
             var expression = ExpressionOf(name, attribute, property);
 
-            if (expression is not null && EventTypeOf(attribute) is { } eventType)
+            if (expression is not null && ModelBoundAttributes.EventTypeOf(attribute) is { } eventType)
             {
                 Add(eventType, property.Name, expression);
             }
@@ -156,12 +147,12 @@ public class ModelBoundPropertyMappings
     /// <param name="property">The property holding the joined data.</param>
     void ReadJoin(AttributeData attribute, IPropertySymbol property)
     {
-        var on = Argument(attribute, "On", 0) ?? string.Empty;
-        var source = Argument(attribute, "EventPropertyName", 1) ?? property.Name;
+        var on = ModelBoundAttributes.Argument(attribute, "On", 0) ?? string.Empty;
+        var source = ModelBoundAttributes.Path(attribute, "EventPropertyName", 1) ?? Named(property);
 
         _joins.Add(new(
             property.Name,
-            EventTypeOf(attribute) ?? string.Empty,
+            ModelBoundAttributes.EventTypeOf(attribute) ?? string.Empty,
             on,
             new Dictionary<string, string>(StringComparer.Ordinal) { [property.Name] = source }));
     }

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
@@ -9,12 +9,14 @@ namespace Cratis.Arc.Screenplay.Analysis.Projections;
 /// <summary>
 /// Reads the mappings the properties of a model-bound read model declare, grouped by the event each one observes.
 /// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <param name="location">Where the read model lives, for use in diagnostics.</param>
 /// <remarks>
 /// A model-bound projection is declared upside down compared to a fluent one - the read model's properties say
 /// which event they come from, rather than the event saying which properties it fills in. Regrouping them by event
 /// is what turns the declaration back into the blocks a document is written in.
 /// </remarks>
-public class ModelBoundPropertyMappings
+public class ModelBoundPropertyMappings(ScreenplayDiagnostics diagnostics, string location)
 {
     readonly Dictionary<string, Dictionary<string, string>> _byEvent = new(StringComparer.Ordinal);
     readonly Dictionary<string, string> _every = new(StringComparer.Ordinal);
@@ -34,10 +36,12 @@ public class ModelBoundPropertyMappings
     /// Reads the mappings of a read model.
     /// </summary>
     /// <param name="readModel">The read model to read.</param>
+    /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+    /// <param name="location">Where the read model lives, for use in diagnostics.</param>
     /// <returns>The <see cref="ModelBoundPropertyMappings"/>.</returns>
-    public static ModelBoundPropertyMappings From(ITypeSymbol readModel)
+    public static ModelBoundPropertyMappings From(ITypeSymbol readModel, ScreenplayDiagnostics diagnostics, string location)
     {
-        var mappings = new ModelBoundPropertyMappings();
+        var mappings = new ModelBoundPropertyMappings(diagnostics, location);
 
         foreach (var property in readModel.DeclaredProperties())
         {
@@ -60,27 +64,6 @@ public class ModelBoundPropertyMappings
     /// </summary>
     /// <returns>The names, ordered.</returns>
     public IEnumerable<string> EventTypes() => _byEvent.Keys.Order(StringComparer.Ordinal);
-
-    /// <summary>
-    /// Builds the expression an attribute maps a property with.
-    /// </summary>
-    /// <param name="name">The fully qualified metadata name of the attribute.</param>
-    /// <param name="attribute">The attribute to read.</param>
-    /// <param name="property">The property being mapped onto.</param>
-    /// <returns>The expression, or <see langword="null"/> when the attribute is not a mapping.</returns>
-    static string? ExpressionOf(string name, AttributeData attribute, IPropertySymbol property) => name switch
-    {
-        ModelBoundNames.SetFrom => Source(attribute, "EventPropertyName", property),
-        ModelBoundNames.SetValue => ProjectionExpressions.Value(attribute.GetArgument(0)),
-        ModelBoundNames.SetFromContext => ProjectionExpressions.EventContext(Source(attribute, "ContextPropertyName", property)),
-        ModelBoundNames.Count => ProjectionExpressions.Count,
-        ModelBoundNames.Increment => ProjectionExpressions.Increment,
-        ModelBoundNames.Decrement => ProjectionExpressions.Decrement,
-        ModelBoundNames.AddFrom => ProjectionExpressions.Add(Source(attribute, "EventPropertyName", property)),
-        ModelBoundNames.SubtractFrom => ProjectionExpressions.Subtract(Source(attribute, "EventPropertyName", property)),
-        ModelBoundNames.FromEvery or ModelBoundNames.FromAll => Ambient(attribute, property),
-        _ => null
-    };
 
     /// <summary>
     /// Builds the expression an attribute applying to every observed event maps a property with.
@@ -113,6 +96,61 @@ public class ModelBoundPropertyMappings
     /// <param name="property">The property to name.</param>
     /// <returns>The name.</returns>
     static string Named(IPropertySymbol property) => ProjectionPaths.Convert(property.Name) ?? property.Name;
+
+    /// <summary>
+    /// Builds the expression an attribute maps a property with.
+    /// </summary>
+    /// <param name="name">The fully qualified metadata name of the attribute.</param>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="property">The property being mapped onto.</param>
+    /// <returns>The expression, or <see langword="null"/> when the attribute is not a mapping.</returns>
+    string? ExpressionOf(string name, AttributeData attribute, IPropertySymbol property) => name switch
+    {
+        ModelBoundNames.SetFrom => Source(attribute, "EventPropertyName", property),
+        ModelBoundNames.SetValue => ConstantOf(attribute, property),
+        ModelBoundNames.SetFromContext => ProjectionExpressions.EventContext(Source(attribute, "ContextPropertyName", property)),
+        ModelBoundNames.Count => ProjectionExpressions.Count,
+        ModelBoundNames.Increment => ProjectionExpressions.Increment,
+        ModelBoundNames.Decrement => ProjectionExpressions.Decrement,
+        ModelBoundNames.AddFrom => ProjectionExpressions.Add(Source(attribute, "EventPropertyName", property)),
+        ModelBoundNames.SubtractFrom => ProjectionExpressions.Subtract(Source(attribute, "EventPropertyName", property)),
+        ModelBoundNames.FromEvery or ModelBoundNames.FromAll => Ambient(attribute, property),
+        _ => null
+    };
+
+    /// <summary>
+    /// Builds the expression a constant value maps a property with.
+    /// </summary>
+    /// <param name="attribute">The attribute carrying the value.</param>
+    /// <param name="property">The property being mapped onto.</param>
+    /// <returns>The expression.</returns>
+    /// <remarks>
+    /// A member of an enumeration arrives as the number behind it, which would have the document set the property to
+    /// a number while the concept it refers to declares names. The type the value was written as is what turns the
+    /// number back into the member, and only the attribute still knows it.
+    /// </remarks>
+    string ConstantOf(AttributeData attribute, IPropertySymbol property)
+    {
+        if (attribute.GetTypedArgument(0) is not { } argument)
+        {
+            return ProjectionExpressions.Value(null);
+        }
+
+        if (EnumConstants.TryResolve(argument.Type, argument.Value, out var member))
+        {
+            return ProjectionExpressions.Enumeration(ProjectionPaths.ConvertMember(member.Member));
+        }
+
+        if (EnumConstants.IsEnumeration(argument.Type))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnnamedEnumerationValue,
+                $"'{argument.Type!.Name}' declares no member with the value '{argument.Value}' given to '{property.Name}', so it is written as that number rather than as a name the concept declares",
+                location);
+        }
+
+        return ProjectionExpressions.Value(argument.Value);
+    }
 
     /// <summary>
     /// Reads the mappings one property declares.

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundPropertyMappings.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the mappings the properties of a model-bound read model declare, grouped by the event each one observes.
+/// </summary>
+/// <remarks>
+/// A model-bound projection is declared upside down compared to a fluent one - the read model's properties say
+/// which event they come from, rather than the event saying which properties it fills in. Regrouping them by event
+/// is what turns the declaration back into the blocks a document is written in.
+/// </remarks>
+public class ModelBoundPropertyMappings
+{
+    readonly Dictionary<string, Dictionary<string, string>> _byEvent = new(StringComparer.Ordinal);
+    readonly Dictionary<string, string> _every = new(StringComparer.Ordinal);
+    readonly List<ProjectionJoinModel> _joins = [];
+
+    /// <summary>
+    /// Gets the mappings applying to every observed event.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Every => _every;
+
+    /// <summary>
+    /// Gets the joins the read model declares.
+    /// </summary>
+    public IEnumerable<ProjectionJoinModel> Joins => _joins;
+
+    /// <summary>
+    /// Reads the mappings of a read model.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <returns>The <see cref="ModelBoundPropertyMappings"/>.</returns>
+    public static ModelBoundPropertyMappings From(ITypeSymbol readModel)
+    {
+        var mappings = new ModelBoundPropertyMappings();
+
+        foreach (var property in readModel.DeclaredProperties())
+        {
+            mappings.ReadProperty(property);
+        }
+
+        return mappings;
+    }
+
+    /// <summary>
+    /// Gets the mappings declared for an event type.
+    /// </summary>
+    /// <param name="eventTypeName">The name of the event type.</param>
+    /// <returns>The mappings, ordered by property.</returns>
+    public IReadOnlyDictionary<string, string> For(string eventTypeName) =>
+        _byEvent.TryGetValue(eventTypeName, out var mappings) ? mappings : new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the event types any property names.
+    /// </summary>
+    /// <returns>The names, ordered.</returns>
+    public IEnumerable<string> EventTypes() => _byEvent.Keys.Order(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the name of the event type an attribute is bound to.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <returns>The name, or <see langword="null"/> when the attribute names none.</returns>
+    static string? EventTypeOf(AttributeData attribute) =>
+        attribute.AttributeClass?.TypeArguments.FirstOrDefault()?.Name;
+
+    /// <summary>
+    /// Builds the expression an attribute maps a property with.
+    /// </summary>
+    /// <param name="name">The fully qualified metadata name of the attribute.</param>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="property">The property being mapped onto.</param>
+    /// <returns>The expression, or <see langword="null"/> when the attribute is not a mapping.</returns>
+    static string? ExpressionOf(string name, AttributeData attribute, IPropertySymbol property) => name switch
+    {
+        ModelBoundNames.SetFrom => Source(attribute, "EventPropertyName", property),
+        ModelBoundNames.SetValue => ProjectionExpressions.Value(attribute.GetArgument(0)),
+        ModelBoundNames.SetFromContext => ProjectionExpressions.EventContext(Source(attribute, "ContextPropertyName", property)),
+        ModelBoundNames.Count => ProjectionExpressions.Count,
+        ModelBoundNames.Increment => ProjectionExpressions.Increment,
+        ModelBoundNames.Decrement => ProjectionExpressions.Decrement,
+        ModelBoundNames.AddFrom => ProjectionExpressions.Add(Source(attribute, "EventPropertyName", property)),
+        ModelBoundNames.SubtractFrom => ProjectionExpressions.Subtract(Source(attribute, "EventPropertyName", property)),
+        ModelBoundNames.FromEvery or ModelBoundNames.FromAll => Ambient(attribute, property),
+        _ => null
+    };
+
+    /// <summary>
+    /// Builds the expression an attribute applying to every observed event maps a property with.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="property">The property being mapped onto.</param>
+    /// <returns>The expression.</returns>
+    static string Ambient(AttributeData attribute, IPropertySymbol property)
+    {
+        var context = Argument(attribute, "ContextProperty", 1);
+
+        return context is null ? Argument(attribute, "Property", 0) ?? property.Name : ProjectionExpressions.EventContext(context);
+    }
+
+    /// <summary>
+    /// Gets the source an attribute names, falling back to the property it is applied to.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="argument">The name of the argument carrying the source.</param>
+    /// <param name="property">The property being mapped onto.</param>
+    /// <returns>The source.</returns>
+    static string Source(AttributeData attribute, string argument, IPropertySymbol property) =>
+        Argument(attribute, argument, 0) ?? property.Name;
+
+    /// <summary>
+    /// Gets an argument of an attribute, in either the named or the positional form.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="name">The name of the argument.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The value, or <see langword="null"/> when the argument carries nothing.</returns>
+    static string? Argument(AttributeData attribute, string name, int index) =>
+        (attribute.GetNamedArgument(name) ?? attribute.GetArgument(index)) as string is { Length: > 0 } value ? value : null;
+
+    /// <summary>
+    /// Reads the mappings one property declares.
+    /// </summary>
+    /// <param name="property">The property to read.</param>
+    void ReadProperty(IPropertySymbol property)
+    {
+        foreach (var attribute in property.GetAttributes())
+        {
+            var name = attribute.AttributeClass is null ? string.Empty : attribute.AttributeClass.FullMetadataName();
+            var expression = ExpressionOf(name, attribute, property);
+
+            if (expression is not null && EventTypeOf(attribute) is { } eventType)
+            {
+                Add(eventType, property.Name, expression);
+            }
+            else if (expression is not null)
+            {
+                _every[property.Name] = expression;
+            }
+            else if (string.Equals(name, ModelBoundNames.Join, StringComparison.Ordinal))
+            {
+                ReadJoin(attribute, property);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the join a property declares.
+    /// </summary>
+    /// <param name="attribute">The attribute declaring the join.</param>
+    /// <param name="property">The property holding the joined data.</param>
+    void ReadJoin(AttributeData attribute, IPropertySymbol property)
+    {
+        var on = Argument(attribute, "On", 0) ?? string.Empty;
+        var source = Argument(attribute, "EventPropertyName", 1) ?? property.Name;
+
+        _joins.Add(new(
+            property.Name,
+            EventTypeOf(attribute) ?? string.Empty,
+            on,
+            new Dictionary<string, string>(StringComparer.Ordinal) { [property.Name] = source }));
+    }
+
+    /// <summary>
+    /// Adds a mapping for an event type.
+    /// </summary>
+    /// <param name="eventType">The name of the event type.</param>
+    /// <param name="property">The property being mapped onto.</param>
+    /// <param name="expression">The expression mapping it.</param>
+    void Add(string eventType, string property, string expression)
+    {
+        if (!_byEvent.TryGetValue(eventType, out var mappings))
+        {
+            mappings = new(StringComparer.Ordinal);
+            _byEvent[eventType] = mappings;
+        }
+
+        mappings[property] = expression;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundScopeReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundScopeReader.cs
@@ -104,7 +104,7 @@ public class ModelBoundScopeReader(ScreenplayDiagnostics diagnostics)
     /// <returns>The <see cref="ProjectionScopeModel"/>.</returns>
     ProjectionScopeModel Read(INamedTypeSymbol readModel, string location, IReadOnlyCollection<ISymbol> visited)
     {
-        var mappings = ModelBoundPropertyMappings.From(readModel);
+        var mappings = ModelBoundPropertyMappings.From(readModel, diagnostics, location);
 
         var scope = new ProjectionScopeModel(
             ReadFrom(readModel, mappings),

--- a/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundScopeReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ModelBoundScopeReader.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads one scope of a model-bound projection - the read model itself, or a child or nested object within it.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A model-bound projection is declared upside down compared to a fluent one - the read model's properties say which
+/// event they come from, rather than the event saying which properties it fills in. Regrouping them by event is what
+/// turns the declaration back into the blocks a document is written in.
+/// </remarks>
+public class ModelBoundScopeReader(ScreenplayDiagnostics diagnostics)
+{
+    readonly ModelBoundChildren _children = new(diagnostics);
+
+    /// <summary>
+    /// Determines whether a scope declares nothing at all.
+    /// </summary>
+    /// <param name="scope">The scope to check.</param>
+    /// <returns>True when there is nothing to express.</returns>
+    public static bool IsEmpty(ProjectionScopeModel scope) =>
+        !scope.From.Any() &&
+        scope.Every is null &&
+        !scope.Joins.Any() &&
+        !scope.Children.Any() &&
+        !scope.Nested.Any() &&
+        !scope.RemovedWith.Any() &&
+        !scope.RemovedWithJoin.Any();
+
+    /// <summary>
+    /// Reads everything a read model declares, following the types it holds.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="location">Where the read model lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="ProjectionScopeModel"/>.</returns>
+    public ProjectionScopeModel Read(INamedTypeSymbol readModel, string location) => Read(readModel, location, [readModel]);
+
+    /// <summary>
+    /// Builds the block applying to every observed event.
+    /// </summary>
+    /// <param name="mappings">The mappings the read model declares.</param>
+    /// <returns>The block, or <see langword="null"/> when the read model declares none.</returns>
+    static ProjectionEveryModel? EveryOf(ModelBoundPropertyMappings mappings) =>
+        mappings.Every.Count == 0 ? null : new(mappings.Every, true, ProjectionAutoMapMode.Inherit);
+
+    /// <summary>
+    /// Reads the blocks observing specific event types.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="mappings">The mappings the read model declares.</param>
+    /// <returns>The blocks, ordered by the event they observe.</returns>
+    /// <remarks>
+    /// An event named only by a property is observed just as much as one named by the read model itself, so both
+    /// sources of event types are merged rather than the declaration having to say it twice.
+    /// </remarks>
+    static IEnumerable<ProjectionFromModel> ReadFrom(INamedTypeSymbol readModel, ModelBoundPropertyMappings mappings)
+    {
+        var declared = readModel.GetAttributes(ModelBoundNames.FromEvent)
+            .Select(_ => (Name: ModelBoundAttributes.EventTypeOf(_), Attribute: _))
+            .Where(_ => _.Name is not null)
+            .ToDictionary(_ => _.Name!, _ => _.Attribute, StringComparer.Ordinal);
+
+        var names = declared.Keys.Concat(mappings.EventTypes()).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal);
+
+        return
+        [
+            .. names.Select(name => new ProjectionFromModel(
+                [name],
+                declared.TryGetValue(name, out var attribute) ? ModelBoundAttributes.Path(attribute, "Key", 0) : null,
+                declared.TryGetValue(name, out var parent) ? ModelBoundAttributes.Path(parent, "ParentKey", 1) : null,
+                mappings.For(name)))
+        ];
+    }
+
+    /// <summary>
+    /// Reads the blocks removing an instance when an event occurs.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="attributeName">The fully qualified metadata name of the attribute declaring the removal.</param>
+    /// <returns>The blocks, ordered by the event they observe.</returns>
+    static IEnumerable<ProjectionRemoveModel> ReadRemovals(INamedTypeSymbol readModel, string attributeName) =>
+    [
+        .. readModel.GetAttributes(attributeName)
+            .Select(_ => new ProjectionRemoveModel(
+                ModelBoundAttributes.EventTypeOf(_) ?? string.Empty,
+                ModelBoundAttributes.Path(_, "Key", 0),
+                ModelBoundAttributes.Path(_, "ParentKey", 1)))
+            .Where(_ => _.EventType.Length > 0)
+            .OrderBy(_ => _.EventType, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Reads everything a read model declares, without following a type it is already within.
+    /// </summary>
+    /// <param name="readModel">The read model to read.</param>
+    /// <param name="location">Where the read model lives, for use in diagnostics.</param>
+    /// <param name="visited">The types the scope is already within.</param>
+    /// <returns>The <see cref="ProjectionScopeModel"/>.</returns>
+    ProjectionScopeModel Read(INamedTypeSymbol readModel, string location, IReadOnlyCollection<ISymbol> visited)
+    {
+        var mappings = ModelBoundPropertyMappings.From(readModel);
+
+        var scope = new ProjectionScopeModel(
+            ReadFrom(readModel, mappings),
+            EveryOf(mappings),
+            [.. mappings.Joins],
+            ReadScopes(_children.In(readModel, location), location, visited),
+            ReadScopes(_children.NestedIn(readModel, location), location, visited),
+            ReadRemovals(readModel, ModelBoundNames.RemovedWith),
+            ReadRemovals(readModel, ModelBoundNames.RemovedWithJoin));
+
+        ReportWhatIsNotRead(readModel, scope, location);
+
+        return scope;
+    }
+
+    /// <summary>
+    /// Reads the child collections or nested objects of a scope.
+    /// </summary>
+    /// <param name="children">The children or nested objects declared.</param>
+    /// <param name="location">Where the read model lives, for use in diagnostics.</param>
+    /// <param name="visited">The types the scope is already within.</param>
+    /// <returns>The scopes, in the order they were declared in.</returns>
+    /// <remarks>
+    /// A type holding itself describes a hierarchy of no fixed depth, which a document writes out one level at a
+    /// time and therefore cannot express. The level that is expressible is kept and the rest is reported, rather
+    /// than the whole child being dropped or the reader following it forever.
+    /// </remarks>
+    List<ProjectionChildScopeModel> ReadScopes(
+        IEnumerable<ModelBoundChild> children,
+        string location,
+        IReadOnlyCollection<ISymbol> visited)
+    {
+        var scopes = new List<ProjectionChildScopeModel>();
+
+        foreach (var child in children)
+        {
+            if (visited.Any(_ => SymbolEqualityComparer.Default.Equals(_, child.Type)))
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableProjectionScope,
+                    $"'{child.Property}' holds objects of a type it is already within, which a document cannot nest without end, so what they contain was left out",
+                    location);
+
+                scopes.Add(child.ToScope(ProjectionScopeModel.Empty));
+                continue;
+            }
+
+            scopes.Add(child.ToScope(Read(child.Type, location, [.. visited, child.Type])));
+        }
+
+        return scopes;
+    }
+
+    /// <summary>
+    /// Reports the parts of a scope that are not read back, leaving a read model declaring no projection alone.
+    /// </summary>
+    /// <param name="readModel">The read model to check.</param>
+    /// <param name="scope">What was read from it.</param>
+    /// <param name="location">Where the read model lives.</param>
+    void ReportWhatIsNotRead(INamedTypeSymbol readModel, ProjectionScopeModel scope, string location)
+    {
+        if (IsEmpty(scope))
+        {
+            return;
+        }
+
+        foreach (var attribute in readModel.GetAttributes(ModelBoundNames.ClearWith))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                $"'{readModel.Name}' is emptied again when '{ModelBoundAttributes.EventTypeOf(attribute)}' occurs, which the model a projection is built from carries nowhere, so it was left out",
+                location);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ProjectionExpressions.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ProjectionExpressions.cs
@@ -45,6 +45,18 @@ public static class ProjectionExpressions
     public static string Value(object? value) => $"$value({Format(value)})";
 
     /// <summary>
+    /// Builds the expression yielding a member of an enumeration.
+    /// </summary>
+    /// <param name="member">The name of the member, in the casing the concept declares it.</param>
+    /// <returns>The expression.</returns>
+    /// <remarks>
+    /// A member is always written as a string naming it, while a constant is written as whatever it is - so the two
+    /// are kept apart rather than a member being handed to <see cref="Value"/> and read back as a number or a boolean
+    /// by whichever of them its name happens to look like.
+    /// </remarks>
+    public static string Enumeration(string member) => $"$enum({member})";
+
+    /// <summary>
     /// Builds the expression adding an event property to a read model property.
     /// </summary>
     /// <param name="property">The event property.</param>

--- a/Source/DotNET/Screenplay/Analysis/Projections/ProjectionExpressions.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ProjectionExpressions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Builds the property expressions a projection maps with.
+/// </summary>
+/// <remarks>
+/// These are the expressions the emission half already knows how to convert, so analysis writes the same mini
+/// language whichever shape the projection was declared in. That is what lets a fluent projection and a model-bound
+/// one produce the same document when they say the same thing.
+/// </remarks>
+public static class ProjectionExpressions
+{
+    /// <summary>The expression yielding the identifier of the event source an event belongs to.</summary>
+    public const string EventSourceId = "$eventSourceId";
+
+    /// <summary>The expression yielding the identity that caused an event.</summary>
+    public const string CausedBy = "$causedBy";
+
+    /// <summary>The expression incrementing a read model property.</summary>
+    public const string Increment = "$increment";
+
+    /// <summary>The expression decrementing a read model property.</summary>
+    public const string Decrement = "$decrement";
+
+    /// <summary>The expression counting occurrences into a read model property.</summary>
+    public const string Count = "$count";
+
+    /// <summary>
+    /// Builds the expression yielding a value from the event context.
+    /// </summary>
+    /// <param name="path">The path within the context.</param>
+    /// <returns>The expression.</returns>
+    public static string EventContext(string path) => $"$eventContext({path})";
+
+    /// <summary>
+    /// Builds the expression yielding a constant value.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <returns>The expression.</returns>
+    public static string Value(object? value) => $"$value({Format(value)})";
+
+    /// <summary>
+    /// Builds the expression adding an event property to a read model property.
+    /// </summary>
+    /// <param name="property">The event property.</param>
+    /// <returns>The expression.</returns>
+    public static string Add(string property) => $"$add({property})";
+
+    /// <summary>
+    /// Builds the expression subtracting an event property from a read model property.
+    /// </summary>
+    /// <param name="property">The event property.</param>
+    /// <returns>The expression.</returns>
+    public static string Subtract(string property) => $"$subtract({property})";
+
+    /// <summary>
+    /// Builds the expression identifying a read model by several properties at once.
+    /// </summary>
+    /// <param name="type">The name of the type the key identifies.</param>
+    /// <param name="parts">The property to expression pairs making up the key.</param>
+    /// <returns>The expression.</returns>
+    public static string Composite(string type, IEnumerable<KeyValuePair<string, string>> parts) =>
+        $"$composite({type}, {string.Join(", ", parts.Select(_ => $"{_.Key}={_.Value}"))})";
+
+    /// <summary>
+    /// Formats a constant the way the mini language reads it back.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <returns>The formatted value.</returns>
+    static string Format(object? value) => value switch
+    {
+        null => "null",
+        bool boolean => boolean ? "true" : "false",
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? string.Empty
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ProjectionPaths.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ProjectionPaths.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads the property paths a projection names on the event side.
+/// </summary>
+/// <remarks>
+/// Event properties are referenced in a projection body exactly as they are serialized, which is lower camel case.
+/// The printer writes an expression verbatim, so the casing has to be right before it gets there - unlike a read
+/// model property, which emission camel cases itself.
+/// </remarks>
+public static class ProjectionPaths
+{
+    static readonly ScreenplayNaming _naming = new();
+
+    /// <summary>
+    /// Reads the event property path a lambda selects.
+    /// </summary>
+    /// <param name="expression">The lambda to read.</param>
+    /// <returns>The path, or <see langword="null"/> when the lambda does not simply select a property.</returns>
+    public static string? Read(ExpressionSyntax? expression) => Convert(Validation.LambdaPaths.Read(expression));
+
+    /// <summary>
+    /// Converts a property path onto the casing a projection body references it by.
+    /// </summary>
+    /// <param name="path">The path to convert.</param>
+    /// <returns>The path, or <see langword="null"/> when there is none.</returns>
+    public static string? Convert(string? path) =>
+        string.IsNullOrWhiteSpace(path) ? null : _naming.ToPropertyPath(path);
+
+    /// <summary>
+    /// Reads the read model property path a lambda selects, in the casing the model declares it.
+    /// </summary>
+    /// <param name="expression">The lambda to read.</param>
+    /// <returns>The path, or <see langword="null"/> when the lambda does not simply select a property.</returns>
+    public static string? ReadDeclared(ExpressionSyntax? expression) => Validation.LambdaPaths.Read(expression);
+
+    /// <summary>
+    /// Gets the calls of a chain that belong to one scope, never descending into a nested lambda.
+    /// </summary>
+    /// <param name="scope">The node holding the scope.</param>
+    /// <returns>The chains, outermost call first.</returns>
+    public static IEnumerable<InvocationExpressionSyntax> ChainsIn(SyntaxNode scope) =>
+        scope.DescendantNodesAndSelf(_ => ReferenceEquals(_, scope) || _ is not AnonymousFunctionExpressionSyntax)
+            .OfType<InvocationExpressionSyntax>()
+            .Where(_ => _.Parent is not MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax });
+}

--- a/Source/DotNET/Screenplay/Analysis/Projections/ProjectionPaths.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ProjectionPaths.cs
@@ -35,6 +35,18 @@ public static class ProjectionPaths
         string.IsNullOrWhiteSpace(path) ? null : _naming.ToPropertyPath(path);
 
     /// <summary>
+    /// Converts the name of an enumeration member onto the casing the concept declares it in.
+    /// </summary>
+    /// <param name="member">The name to convert.</param>
+    /// <returns>The name.</returns>
+    /// <remarks>
+    /// A member is written into a projection body verbatim for the same reason an event property is, so it is cased
+    /// here rather than at the printer. What comes out has to match the value the concept declaration carries, which
+    /// emission writes through the same conversion.
+    /// </remarks>
+    public static string ConvertMember(string member) => _naming.ToPropertyName(member);
+
+    /// <summary>
     /// Reads the read model property path a lambda selects, in the casing the model declares it.
     /// </summary>
     /// <param name="expression">The lambda to read.</param>

--- a/Source/DotNET/Screenplay/Analysis/Projections/ReducerReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ReducerReader.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Projections;
+
+/// <summary>
+/// Reads what a reducer can be said about, and reports what it cannot.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A reducer folds events into a read model with code, and Screenplay has no construct for a fold. The events it
+/// observes and the read model it builds are still worth stating, so a projection observing exactly those events is
+/// recovered and the fold itself is reported as lost rather than silently invented.
+/// </remarks>
+public class ReducerReader(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The identifier of the sequence a reducer observes unless it says otherwise.
+    /// </summary>
+    public const string EventLogSequence = "event-log";
+
+    /// <summary>
+    /// Determines whether a type is a reducer, and for what read model.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>The read model, or <see langword="null"/> when the type is not a reducer.</returns>
+    public static ITypeSymbol? ReadModelOf(ITypeSymbol type) =>
+        type is { IsAbstract: false, TypeKind: TypeKind.Class }
+            ? type.FindInterface(WellKnownTypeNames.ReducerFor)?.TypeArguments[0]
+            : null;
+
+    /// <summary>
+    /// Reads the events a reducer observes.
+    /// </summary>
+    /// <param name="type">The type declaring the reducer.</param>
+    /// <param name="readModel">The read model the reducer builds.</param>
+    /// <param name="location">Where the reducer lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="ProjectionModel"/>, or <see langword="null"/> when it observes nothing.</returns>
+    public ProjectionModel? Read(INamedTypeSymbol type, ITypeSymbol readModel, string location)
+    {
+        var observed = type.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: false, DeclaredAccessibility: Accessibility.Public } &&
+                _.Parameters.Length > 0 && EventReader.IsEvent(_.Parameters[0].Type))
+            .Select(_ => _.Parameters[0].Type.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        if (observed.Count == 0)
+        {
+            return null;
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.ReducerWithoutCounterpart,
+            $"'{type.Name}' folds events into '{readModel.Name}' with code, which Screenplay has no counterpart for, so only the events it observes are stated",
+            location);
+
+        return new(
+            type.ToDisplayString(),
+            readModel.Name,
+            EventLogSequence,
+            ProjectionAutoMapMode.Enabled,
+            false,
+            ProjectionScopeModel.Empty with { From = [.. observed.Select(_ => new ProjectionFromModel([_], null, null, EmptyMap()))] });
+    }
+
+    /// <summary>
+    /// Gets a property map declaring nothing, which is all a fold can be said to map.
+    /// </summary>
+    /// <returns>The empty map.</returns>
+    static Dictionary<string, string> EmptyMap() => new(StringComparer.Ordinal);
+}

--- a/Source/DotNET/Screenplay/Analysis/PropertyReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/PropertyReader.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Reads the properties a command, an event or a model declares.
+/// </summary>
+/// <param name="types">The <see cref="TypeRegistry"/> resolving the type of each property.</param>
+public class PropertyReader(TypeRegistry types)
+{
+    /// <summary>
+    /// Reads the properties of a type, in the order the source declares them.
+    /// </summary>
+    /// <param name="type">The type to read.</param>
+    /// <returns>The properties.</returns>
+    /// <remarks>
+    /// Declaration order is kept rather than sorted, because the order of a record's positional parameters is what
+    /// the developer wrote and is stable for a given compilation.
+    /// </remarks>
+    public IEnumerable<PropertyModel> Read(ITypeSymbol type)
+    {
+        var properties = new List<PropertyModel>();
+
+        foreach (var property in type.DeclaredProperties())
+        {
+            if (property.HasAttribute(WellKnownTypeNames.PiiAttribute))
+            {
+                types.MarkAsPii(property.Type);
+            }
+
+            properties.Add(new(property.Name, types.Resolve(property.Type)));
+        }
+
+        return properties;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/PropertyReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/PropertyReader.cs
@@ -20,7 +20,13 @@ public class PropertyReader(TypeRegistry types)
     /// <returns>The properties.</returns>
     /// <remarks>
     /// Declaration order is kept rather than sorted, because the order of a record's positional parameters is what
-    /// the developer wrote and is stable for a given compilation.
+    /// the developer wrote.
+    /// <para>
+    /// Whether a value is personally identifiable is asked of the member rather than of the property alone, because
+    /// the canonical way of writing an event is a positional record, and an attribute written there belongs to the
+    /// parameter. Chronicle reads it from the constructor parameter too, so reading only the property would leave
+    /// the document saying a value is not sensitive when the runtime encrypts it.
+    /// </para>
     /// </remarks>
     public IEnumerable<PropertyModel> Read(ITypeSymbol type)
     {
@@ -28,7 +34,7 @@ public class PropertyReader(TypeRegistry types)
 
         foreach (var property in type.DeclaredProperties())
         {
-            if (property.HasAttribute(WellKnownTypeNames.PiiAttribute))
+            if (MemberAttributes.Has(property, WellKnownTypeNames.PiiAttribute))
             {
                 types.MarkAsPii(property.Type);
             }

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
@@ -30,11 +30,18 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
     /// </summary>
     /// <param name="type">The read model to read.</param>
     /// <returns>The methods, ordered so that the same read model always reads the same way.</returns>
+    /// <remarks>
+    /// Arc exposes a static method on a read model as a query when it returns that read model - one of it or many of
+    /// it, however the return type dresses that up - and its accessibility never enters into it. Both halves of that
+    /// matter: a read model routinely carries static helpers returning something else, and stating them as endpoints
+    /// would put routes in the document that no application serves, while a query that happens not to be public is a
+    /// route the application really does serve.
+    /// </remarks>
     public static IEnumerable<IMethodSymbol> MethodsOf(INamedTypeSymbol type) =>
         type.GetMembers()
             .OfType<IMethodSymbol>()
-            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: true, DeclaredAccessibility: Accessibility.Public } &&
-                !_.ReturnsVoid && _.TypeParameters.Length == 0)
+            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: true } &&
+                !_.ReturnsVoid && _.TypeParameters.Length == 0 && Returns(_, type))
             .OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal);
 
     /// <summary>
@@ -73,6 +80,19 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
     /// part of the query's shape.
     /// </remarks>
     static bool IsInput(IParameterSymbol parameter) => parameter.Type.TypeKind != TypeKind.Interface;
+
+    /// <summary>
+    /// Determines whether a method returns the read model declaring it.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <param name="readModel">The read model declaring it.</param>
+    /// <returns>True when the method returns the read model.</returns>
+    static bool Returns(IMethodSymbol method, INamedTypeSymbol readModel)
+    {
+        var collection = false;
+
+        return SymbolEqualityComparer.Default.Equals(QueryReturnTypes.Unwrap(method.ReturnType, ref collection), readModel);
+    }
 
     /// <summary>
     /// Reads the type a query returns, stripping every wrapper that only says how it arrives.

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Queries;
+
+/// <summary>
+/// Reads the queries a read model or a controller exposes.
+/// </summary>
+/// <param name="types">The <see cref="TypeRegistry"/> resolving the type of each parameter and return value.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A query returns one instance or many, however the signature dresses that up - awaited, streamed, observed or
+/// queryable. The first parameter that has to be given identifies the instance; everything else narrows the result.
+/// </remarks>
+public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Determines whether a type is a model-bound read model.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a read model.</returns>
+    public static bool IsReadModel(ITypeSymbol type) => type.HasAttribute(WellKnownTypeNames.ReadModelAttribute);
+
+    /// <summary>
+    /// Gets the static methods a read model exposes as queries.
+    /// </summary>
+    /// <param name="type">The read model to read.</param>
+    /// <returns>The methods, ordered so that the same read model always reads the same way.</returns>
+    public static IEnumerable<IMethodSymbol> MethodsOf(INamedTypeSymbol type) =>
+        type.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: true, DeclaredAccessibility: Accessibility.Public } &&
+                !_.ReturnsVoid && _.TypeParameters.Length == 0)
+            .OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal);
+
+    /// <summary>
+    /// Reads a query.
+    /// </summary>
+    /// <param name="method">The method exposing the query.</param>
+    /// <param name="declaring">The type declaring it.</param>
+    /// <param name="location">Where the query lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="QueryModel"/>, or <see langword="null"/> when what it reads cannot be named.</returns>
+    public QueryModel? Read(IMethodSymbol method, INamedTypeSymbol declaring, string location)
+    {
+        var returnType = ReturnTypeOf(method, location);
+        if (returnType is null)
+        {
+            return null;
+        }
+
+        var parameters = method.Parameters.Where(IsInput).ToList();
+        var required = parameters.Find(_ => !_.HasExplicitDefaultValue);
+
+        return new(
+            method.Name,
+            returnType,
+            required is null ? null : ToParameter(required),
+            [.. parameters.Where(_ => !SymbolEqualityComparer.Default.Equals(_, required)).Select(ToParameter)],
+            AuthorizationReader.Read(method, declaring));
+    }
+
+    /// <summary>
+    /// Determines whether a parameter is part of what a caller sends.
+    /// </summary>
+    /// <param name="parameter">The parameter to check.</param>
+    /// <returns>True when the parameter is input rather than infrastructure.</returns>
+    /// <remarks>
+    /// An interface parameter is a collaborator the host injects, never something a caller can send, so it is not
+    /// part of the query's shape.
+    /// </remarks>
+    static bool IsInput(IParameterSymbol parameter) => parameter.Type.TypeKind != TypeKind.Interface;
+
+    /// <summary>
+    /// Reads the type a query returns, stripping every wrapper that only says how it arrives.
+    /// </summary>
+    /// <param name="method">The method exposing the query.</param>
+    /// <param name="location">Where the query lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="TypeReferenceModel"/>, or <see langword="null"/> when it cannot be named.</returns>
+    /// <remarks>
+    /// A transport level result is not a read model, and emitting one as if it were would put a type from the web
+    /// framework into a document describing the domain. There is nothing to recover in that case, so the query is
+    /// left out and reported rather than described wrongly.
+    /// </remarks>
+    TypeReferenceModel? ReturnTypeOf(IMethodSymbol method, string location)
+    {
+        var collection = false;
+        var current = QueryReturnTypes.Unwrap(method.ReturnType, ref collection);
+
+        if (QueryReturnTypes.IsTransport(current))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableQuery,
+                $"The query '{method.Name}' returns '{current.Name}', which says how the result is transported rather than what it is, so the query was left out",
+                location);
+
+            return null;
+        }
+
+        if (current.TypeKind == TypeKind.TypeParameter)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableQuery,
+                $"The query '{method.Name}' returns a type parameter, which no declaration can name, so the query was left out",
+                location);
+
+            return null;
+        }
+
+        var resolved = types.Resolve(current);
+
+        return collection ? resolved with { IsCollection = true } : resolved;
+    }
+
+    /// <summary>
+    /// Converts a parameter of the query.
+    /// </summary>
+    /// <param name="parameter">The parameter to convert.</param>
+    /// <returns>The <see cref="PropertyModel"/>.</returns>
+    PropertyModel ToParameter(IParameterSymbol parameter) => new(parameter.Name, types.Resolve(parameter.Type));
+}

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReturnTypes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReturnTypes.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Queries;
+
+/// <summary>
+/// Strips the wrappers a query's return type is dressed in.
+/// </summary>
+/// <remarks>
+/// Awaiting, streaming, observing and querying are all how a result arrives, never what it is. A document says what
+/// a query returns and whether there is one or many of it, so every wrapper is peeled away until that is all left.
+/// </remarks>
+public static class QueryReturnTypes
+{
+    static readonly string[] _wrappers =
+    [
+        "System.Threading.Tasks.Task`1",
+        "System.Threading.Tasks.ValueTask`1",
+        "System.Reactive.Subjects.ISubject`1",
+        "Cratis.Arc.Queries.IQueryable`1",
+        WellKnownTypeNames.ActionResultOfT
+    ];
+
+    static readonly string[] _sequences =
+    [
+        "System.Collections.Generic.IAsyncEnumerable`1",
+        "System.Linq.IQueryable`1"
+    ];
+
+    /// <summary>
+    /// Determines whether a type says only how a result was transported, and nothing about what it is.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a transport level result.</returns>
+    /// <remarks>
+    /// A controller method returning a bare action result has thrown away the read model at the type level, and no
+    /// amount of reading recovers it. Every derived result - the ok, the json, the file - is caught by the base type
+    /// and the interface rather than by listing them, because that list is the web framework's to grow, not ours.
+    /// </remarks>
+    public static bool IsTransport(ITypeSymbol type) =>
+        type.Is(WellKnownTypeNames.ActionResultInterface) ||
+        type.Is(WellKnownTypeNames.ActionResult) ||
+        type.FindInterface(WellKnownTypeNames.ActionResultInterface) is not null ||
+        type.FindBase(WellKnownTypeNames.ActionResult) is not null;
+
+    /// <summary>
+    /// Strips every wrapper from a return type.
+    /// </summary>
+    /// <param name="type">The type to strip.</param>
+    /// <param name="collection">Set when a wrapper said the query returns many.</param>
+    /// <returns>The type the query returns.</returns>
+    public static ITypeSymbol Unwrap(ITypeSymbol type, ref bool collection)
+    {
+        var current = type;
+
+        while (true)
+        {
+            if (current is INamedTypeSymbol named && Matches(named, _sequences))
+            {
+                collection = true;
+                current = named.TypeArguments[0];
+                continue;
+            }
+
+            if (current is INamedTypeSymbol wrapper && Matches(wrapper, _wrappers))
+            {
+                current = wrapper.TypeArguments[0];
+                continue;
+            }
+
+            if (CollectionElements.ElementOf(current) is { } element)
+            {
+                collection = true;
+                current = element;
+                continue;
+            }
+
+            return current;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a type is one of a set of wrappers, by name and by the interfaces it implements.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="names">The fully qualified metadata names to match.</param>
+    /// <returns>True when the type matches.</returns>
+    static bool Matches(INamedTypeSymbol type, string[] names)
+    {
+        if (type.TypeArguments.Length != 1)
+        {
+            return false;
+        }
+
+        var name = type.FullMetadataName();
+
+        return names.Contains(name, StringComparer.Ordinal) ||
+            type.AllInterfaces.Any(_ => _.TypeArguments.Length == 1 && names.Contains(_.FullMetadataName(), StringComparer.Ordinal));
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Reactors/ReactorReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Reactors/ReactorReader.cs
@@ -64,10 +64,15 @@ public class ReactorReader(Compilation compilation, SourcePaths paths)
     /// </summary>
     /// <param name="type">The type declaring the reactor.</param>
     /// <returns>The handlers, ordered so that the same reactor always reads the same way.</returns>
+    /// <remarks>
+    /// Accessibility says nothing about whether a method handles an event. Chronicle dispatches to every instance
+    /// method whose first parameter is an event type, public or not, so a reactor whose handlers are private observes
+    /// those events at runtime and the document has to say so.
+    /// </remarks>
     static IEnumerable<IMethodSymbol> Handlers(INamedTypeSymbol type) =>
         type.GetMembers()
             .OfType<IMethodSymbol>()
-            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: false, DeclaredAccessibility: Accessibility.Public } &&
+            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: false } &&
                 _.Parameters.Length > 0 && EventReader.IsEvent(_.Parameters[0].Type))
             .OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal);
 

--- a/Source/DotNET/Screenplay/Analysis/Reactors/ReactorReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Reactors/ReactorReader.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Reactors;
+
+/// <summary>
+/// Reads the reactors a slice declares.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of the file each reactor lives in.</param>
+/// <remarks>
+/// A reactor translates rather than automates when it turns what happened into something else that happens - by
+/// returning further events, by executing a command, or by observing a sequence other than the event log. That is
+/// read from the body, so a reactor that merely holds a command pipeline without using it is still an automation.
+/// </remarks>
+public class ReactorReader(Compilation compilation, SourcePaths paths)
+{
+    /// <summary>
+    /// The name of the argument naming the sequence a reactor observes.
+    /// </summary>
+    public const string EventSequenceArgument = "EventSequenceId";
+
+    /// <summary>
+    /// The identifier of the sequence a reactor observes unless it says otherwise.
+    /// </summary>
+    public const string EventLogSequence = "event-log";
+
+    /// <summary>
+    /// The method a command pipeline is executed through.
+    /// </summary>
+    public const string ExecuteMethod = "Execute";
+
+    /// <summary>
+    /// Determines whether a type is a reactor.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a reactor.</returns>
+    public static bool IsReactor(ITypeSymbol type) =>
+        type is { IsAbstract: false, TypeKind: TypeKind.Class } && type.FindInterface(WellKnownTypeNames.Reactor) is not null;
+
+    /// <summary>
+    /// Reads a reactor.
+    /// </summary>
+    /// <param name="type">The type declaring the reactor.</param>
+    /// <returns>The <see cref="ReactorModel"/>.</returns>
+    public ReactorModel Read(INamedTypeSymbol type)
+    {
+        var handlers = Handlers(type).ToList();
+
+        return new(
+            type.Name,
+            [.. handlers.Select(_ => _.Parameters[0].Type.Name).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)],
+            IsTranslating(type, handlers),
+            paths.Relative(type.SourceFilePath()));
+    }
+
+    /// <summary>
+    /// Gets the methods dispatched to by event type.
+    /// </summary>
+    /// <param name="type">The type declaring the reactor.</param>
+    /// <returns>The handlers, ordered so that the same reactor always reads the same way.</returns>
+    static IEnumerable<IMethodSymbol> Handlers(INamedTypeSymbol type) =>
+        type.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: false, DeclaredAccessibility: Accessibility.Public } &&
+                _.Parameters.Length > 0 && EventReader.IsEvent(_.Parameters[0].Type))
+            .OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal);
+
+    /// <summary>
+    /// Determines whether a reactor produces further events rather than only causing an effect.
+    /// </summary>
+    /// <param name="handler">The handler to check.</param>
+    /// <returns>True when the handler returns something.</returns>
+    static bool ProducesFurtherEvents(IMethodSymbol handler)
+    {
+        if (handler.ReturnsVoid)
+        {
+            return false;
+        }
+
+        return handler.ReturnType is not INamedTypeSymbol { TypeArguments.Length: 0, Name: "Task" or "ValueTask" };
+    }
+
+    /// <summary>
+    /// Gets the identifier of the sequence a reactor observes.
+    /// </summary>
+    /// <param name="type">The type declaring the reactor.</param>
+    /// <returns>The identifier, or <see langword="null"/> when the reactor does not name one.</returns>
+    static string? SequenceOf(INamedTypeSymbol type)
+    {
+        var attribute = type.GetAttribute(WellKnownTypeNames.ReactorAttribute);
+
+        return (attribute?.GetNamedArgument(EventSequenceArgument) ?? attribute?.GetArgument(1)) as string;
+    }
+
+    /// <summary>
+    /// Determines whether an invocation executes a command through a pipeline.
+    /// </summary>
+    /// <param name="invocation">The invocation to check.</param>
+    /// <param name="semanticModel">The semantic model of the tree the invocation lives in.</param>
+    /// <returns>True when the invocation is a command execution.</returns>
+    static bool IsPipelineExecution(InvocationExpressionSyntax invocation, SemanticModel semanticModel) =>
+        semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method &&
+        string.Equals(method.Name, ExecuteMethod, StringComparison.Ordinal) &&
+        (method.ContainingType.Is(WellKnownTypeNames.CommandPipeline) ||
+            method.ContainingType.FindInterface(WellKnownTypeNames.CommandPipeline) is not null);
+
+    /// <summary>
+    /// Determines whether a reactor turns what happened into something else that happens.
+    /// </summary>
+    /// <param name="type">The type declaring the reactor.</param>
+    /// <param name="handlers">The handlers of the reactor.</param>
+    /// <returns>True when the reactor translates.</returns>
+    bool IsTranslating(INamedTypeSymbol type, IReadOnlyList<IMethodSymbol> handlers)
+    {
+        var sequence = SequenceOf(type);
+        if (!string.IsNullOrEmpty(sequence) && !string.Equals(sequence, EventLogSequence, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return handlers.Any(ProducesFurtherEvents) || handlers.Any(ExecutesACommand);
+    }
+
+    /// <summary>
+    /// Determines whether a handler executes a command.
+    /// </summary>
+    /// <param name="handler">The handler to check.</param>
+    /// <returns>True when the body calls into a command pipeline.</returns>
+    bool ExecutesACommand(IMethodSymbol handler)
+    {
+        foreach (var reference in handler.DeclaringSyntaxReferences)
+        {
+            var node = reference.GetSyntax();
+            var semanticModel = compilation.GetSemanticModel(node.SyntaxTree);
+
+            if (node.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(_ => IsPipelineExecution(_, semanticModel)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/AmbiguousScreens.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/AmbiguousScreens.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Reports the user interface files whose relationship to a slice is not certain.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> to report to.</param>
+/// <remarks>
+/// A screen is recovered from where a file sits rather than from anything the source states, so the answer is only
+/// as good as the folder structure. Where the convention holds - one folder, one slice - it is exact. Where it does
+/// not, saying so is the whole difference between a document a reader can act on and one they have to double check.
+/// One instance is used per generation, because the folder a slice claims is only shared once another slice claims
+/// it too.
+/// </remarks>
+public class AmbiguousScreens(ScreenplayDiagnostics diagnostics)
+{
+    readonly Dictionary<string, string> _claimed = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Reports the directories a slice takes its screens from, when more than one slice or more than one folder is
+    /// involved.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="directories">The directories the source of the slice lives in.</param>
+    public void ReportDirectories(string @namespace, IReadOnlyList<string> directories)
+    {
+        if (directories.Count > 1)
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.AmbiguousScreenFile,
+                $"The source of the slice is spread over {directories.Count} folders ({string.Join(", ", directories)}), so every user interface file in any of them is taken to be a screen of it",
+                @namespace);
+        }
+
+        foreach (var directory in directories)
+        {
+            ReportShared(@namespace, directory);
+        }
+    }
+
+    /// <summary>
+    /// Reports a file left out because another file already named the screen.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="path">The path of the file left out.</param>
+    /// <param name="kept">The path of the file that named the screen first.</param>
+    /// <param name="name">The name both files give the screen.</param>
+    public void ReportRepeatedName(string @namespace, string path, string kept, string name) =>
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.AmbiguousScreenFile,
+            $"'{path}' names the screen '{name}', which '{kept}' already names, so it was left out",
+            @namespace);
+
+    /// <summary>
+    /// Reports a directory a second slice takes its screens from.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="directory">The directory to claim.</param>
+    void ReportShared(string @namespace, string directory)
+    {
+        if (!_claimed.TryGetValue(directory, out var owner))
+        {
+            _claimed[directory] = @namespace;
+            return;
+        }
+
+        diagnostics.Information(
+            ScreenplayDiagnosticCodes.AmbiguousScreenFile,
+            $"'{directory}' holds the source of '{owner}' as well, so every user interface file in it is taken to be a screen of both",
+            @namespace);
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/IUserInterfaceFiles.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/IUserInterfaceFiles.cs
@@ -24,4 +24,21 @@ public interface IUserInterfaceFiles
     /// slice convention, and its files belong to it rather than to the slice above.
     /// </remarks>
     IEnumerable<string> In(string directory);
+
+    /// <summary>
+    /// Gets the text of a user interface file.
+    /// </summary>
+    /// <param name="path">The path of the file, spelled exactly as <see cref="In"/> gave it.</param>
+    /// <returns>The text, or <see langword="null"/> when the file cannot be read.</returns>
+    /// <remarks>
+    /// A component's import statements name the queries it binds, which is the one thing about a screen the model
+    /// already knows enough to check. Asking for the text through the same seam that answered which files exist is
+    /// what keeps every specification hermetic - a specification answers both questions itself, and nothing in
+    /// analysis ever reaches around to a disk.
+    /// <para>
+    /// A file listed a moment ago may be unreadable now, and a host may know the paths without holding the text at
+    /// all. Neither is an error - the screen is then recovered from its file reference alone.
+    /// </para>
+    /// </remarks>
+    string? Contents(string path);
 }

--- a/Source/DotNET/Screenplay/Analysis/Screens/IUserInterfaceFiles.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/IUserInterfaceFiles.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Defines a system that tells which user interface files a directory holds.
+/// </summary>
+/// <remarks>
+/// Analysis works from a compilation and nothing else, which is what makes it hermetic and what lets every
+/// specification be source strings compiled in memory. A screen is the one thing a compilation cannot answer for -
+/// the file realizing it is TypeScript, so no syntax tree carries it - and this is the single seam where that
+/// question is asked. Substituting it keeps analysis as testable as the rest.
+/// </remarks>
+public interface IUserInterfaceFiles
+{
+    /// <summary>
+    /// Gets the user interface files a directory holds, without descending into it.
+    /// </summary>
+    /// <param name="directory">The directory to read, spelled the way the compilation spells its source paths.</param>
+    /// <returns>The paths of the files, in no particular order.</returns>
+    /// <remarks>
+    /// Descending is deliberately not done. A folder within a slice folder is a slice of its own under the vertical
+    /// slice convention, and its files belong to it rather than to the slice above.
+    /// </remarks>
+    IEnumerable<string> In(string directory);
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/ScreenDataReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/ScreenDataReader.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Reads which of a slice's queries a screen binds, and says plainly what it does not read.
+/// </summary>
+/// <param name="files">The <see cref="IUserInterfaceFiles"/> the text of a component is asked of.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything not inferred is reported to.</param>
+/// <remarks>
+/// Arc generates a proxy per query and a component imports it by name, so an import is a name the model can be held
+/// against rather than a reading of a user interface. A name matching a query the slice declares is a binding; a
+/// name matching nothing is dropped, whatever the component does with it. Nothing about the binding is taken from
+/// the component beyond the name - the type and the key come from the query, which is C#.
+/// <para>
+/// Every screen also reports what stays out. The rest of the declarative form is JSX structure, and the cost of
+/// guessing it wrong is a document that states something about the application that is not so - which is worse than
+/// a document that says less. Saying so per screen is what turns that limit from a silence into an answer.
+/// </para>
+/// </remarks>
+public class ScreenDataReader(IUserInterfaceFiles files, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Reads the bindings of one screen.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice the screen belongs to.</param>
+    /// <param name="name">The name of the screen.</param>
+    /// <param name="path">The path of the file realizing it, as the compilation spells it.</param>
+    /// <param name="queries">The queries the slice declares, under the names it declares them.</param>
+    /// <returns>The bindings, ordered by the query they read through.</returns>
+    public IEnumerable<ScreenDataModel> Read(
+        string @namespace,
+        string name,
+        string path,
+        IReadOnlyCollection<QueryModel> queries)
+    {
+        var imported = ScreenImports.In(files.Contents(path));
+
+        ReportUninferredStructure(@namespace, name);
+
+        return
+        [
+            .. queries
+                .Where(_ => imported.Contains(_.Name))
+                .OrderBy(_ => _.Name, StringComparer.Ordinal)
+                .Select(_ => new ScreenDataModel(_.Name, _.ReturnType, _.By?.Name))
+        ];
+    }
+
+    /// <summary>
+    /// Reports the part of a screen's body that is never inferred.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice the screen belongs to.</param>
+    /// <param name="name">The name of the screen.</param>
+    void ReportUninferredStructure(string @namespace, string name) =>
+        diagnostics.Information(
+            ScreenplayDiagnosticCodes.ScreenStructureNotInferred,
+            $"The screen '{name}' is written in TypeScript and JSX, so beyond the file realizing it and the queries it binds - its title, sections, tables, summaries, actions and navigation - nothing about it is inferred",
+            @namespace);
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/ScreenFiles.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/ScreenFiles.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Recognizes the files that realize a screen and reads the directory and the name of one.
+/// </summary>
+/// <remarks>
+/// Paths are compared and split on forward slashes only. A compilation carries whatever separator the machine it
+/// was built on uses, and a document is written once and read everywhere, so both are normalized before anything
+/// looks at them.
+/// </remarks>
+public static class ScreenFiles
+{
+    /// <summary>
+    /// The extension of a file realizing a screen.
+    /// </summary>
+    public const string Extension = ".tsx";
+
+    /// <summary>
+    /// Determines whether a path names a user interface file.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True when the path names one.</returns>
+    public static bool IsUserInterfaceFile(string path) =>
+        path.EndsWith(Extension, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets the name of the screen a file realizes.
+    /// </summary>
+    /// <param name="path">The path of the file.</param>
+    /// <returns>The name, or <see langword="null"/> when the file realizes no screen.</returns>
+    /// <remarks>
+    /// A component is named after what it is, so its file name is the name of the screen. A name carrying a second
+    /// extension - <c>.stories.tsx</c>, <c>.spec.tsx</c>, <c>.test.tsx</c> - names a companion of a component
+    /// rather than a component, and a companion is not something a slice ends in.
+    /// </remarks>
+    public static string? NameOf(string path)
+    {
+        if (!IsUserInterfaceFile(path))
+        {
+            return null;
+        }
+
+        var name = FileNameOf(path);
+        name = name[..^Extension.Length];
+
+        return name.Length == 0 || name.Contains('.', StringComparison.Ordinal) ? null : name;
+    }
+
+    /// <summary>
+    /// Gets the directory a file sits in.
+    /// </summary>
+    /// <param name="path">The path of the file.</param>
+    /// <returns>The directory, without a trailing separator, empty when the path names no directory.</returns>
+    public static string DirectoryOf(string path)
+    {
+        var normalized = Normalize(path);
+        var separator = normalized.LastIndexOf('/');
+
+        return separator < 0 ? string.Empty : normalized[..separator];
+    }
+
+    /// <summary>
+    /// Gets the name of the file a path ends in.
+    /// </summary>
+    /// <param name="path">The path to read.</param>
+    /// <returns>The file name.</returns>
+    static string FileNameOf(string path)
+    {
+        var normalized = Normalize(path);
+
+        return normalized[(normalized.LastIndexOf('/') + 1)..];
+    }
+
+    /// <summary>
+    /// Normalizes a path onto forward slashes.
+    /// </summary>
+    /// <param name="path">The path to normalize.</param>
+    /// <returns>The normalized path.</returns>
+    static string Normalize(string path) => path.Replace('\\', '/');
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/ScreenImports.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/ScreenImports.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Reads the names a user interface file imports from the files sitting alongside it.
+/// </summary>
+/// <remarks>
+/// This is the whole of what is read out of TypeScript, and it is read because an import statement is the one
+/// construct in the language whose meaning survives being looked at in isolation - a name, and where it came from.
+/// Nothing here interprets what the component does with the name; that is JSX, and a guess at it would be a
+/// falsehood stated confidently. The name is only ever handed to the model to be checked against what the slice
+/// really declares, so an import naming something the slice does not declare says nothing and is dropped.
+/// </remarks>
+public static partial class ScreenImports
+{
+    /// <summary>
+    /// Gets the names a file imports from a module sitting alongside it.
+    /// </summary>
+    /// <param name="text">The text of the file, or <see langword="null"/> when it could not be read.</param>
+    /// <returns>The imported names, as the module exports them rather than as the file renames them.</returns>
+    /// <remarks>
+    /// Only named imports of a relative module are read. A generated proxy is a named export written next to the
+    /// slice, so that is the shape every real binding has, and the shapes that are left out - a default import, a
+    /// namespace import, an import of a package - cannot be tied to an exported name with any certainty.
+    /// </remarks>
+    public static IReadOnlyCollection<string> In(string? text)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return names;
+        }
+
+        foreach (var statement in StatementRegex().Matches(text).Cast<Match>())
+        {
+            var clause = statement.Groups["clause"].Value;
+            if (!IsRelative(statement.Groups["module"].Value) || IsTypeOnly(clause))
+            {
+                continue;
+            }
+
+            foreach (var name in NamedIn(clause))
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Determines whether a module specifier names a file sitting alongside the one importing it.
+    /// </summary>
+    /// <param name="module">The module specifier.</param>
+    /// <returns>True when the specifier is relative.</returns>
+    static bool IsRelative(string module) =>
+        module.StartsWith("./", StringComparison.Ordinal) || module.StartsWith("../", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Determines whether an import clause brings in types rather than values.
+    /// </summary>
+    /// <param name="clause">The clause to check.</param>
+    /// <returns>True when the whole clause is type only.</returns>
+    /// <remarks>
+    /// A type only import is erased before anything runs, so it says the file mentions a shape rather than that it
+    /// reads through it. Binding a screen to a query it never calls would be a plain untruth.
+    /// </remarks>
+    static bool IsTypeOnly(string clause) => TypeOnlyRegex().IsMatch(clause);
+
+    /// <summary>
+    /// Gets the exported names an import clause brings in.
+    /// </summary>
+    /// <param name="clause">The clause to read.</param>
+    /// <returns>The names.</returns>
+    static IEnumerable<string> NamedIn(string clause)
+    {
+        var open = clause.IndexOf('{', StringComparison.Ordinal);
+        var close = clause.LastIndexOf('}');
+        if (open < 0 || close <= open)
+        {
+            yield break;
+        }
+
+        foreach (var specifier in clause[(open + 1)..close].Split(','))
+        {
+            if (ExportedNameIn(specifier) is { } name)
+            {
+                yield return name;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the name a module exports a specifier under, seeing past whatever the importing file renames it to.
+    /// </summary>
+    /// <param name="specifier">The specifier to read.</param>
+    /// <returns>The exported name, or <see langword="null"/> when the specifier is not one.</returns>
+    static string? ExportedNameIn(string specifier)
+    {
+        var words = specifier.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+
+        var exported = words switch
+        {
+            ["type", ..] => null,
+            [var only] => only,
+            [var name, "as", _] => name,
+            _ => null
+        };
+
+        return exported is not null && IdentifierRegex().IsMatch(exported) ? exported : null;
+    }
+
+    /// <summary>
+    /// Gets the pattern an import statement naming a module has to match.
+    /// </summary>
+    /// <returns>The compiled regular expression.</returns>
+    [GeneratedRegex(
+        """^[ \t]*import\b(?<clause>[^;'"]*?)\bfrom\s*(?<quote>['"])(?<module>[^'"]*)\k<quote>""",
+        RegexOptions.Multiline,
+        matchTimeoutMilliseconds: 1000)]
+    private static partial Regex StatementRegex();
+
+    /// <summary>
+    /// Gets the pattern a type only import clause has to match.
+    /// </summary>
+    /// <returns>The compiled regular expression.</returns>
+    [GeneratedRegex(@"^\s*type\b", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex TypeOnlyRegex();
+
+    /// <summary>
+    /// Gets the pattern an imported name has to match.
+    /// </summary>
+    /// <returns>The compiled regular expression.</returns>
+    [GeneratedRegex(@"^[A-Za-z_$][A-Za-z0-9_$]*$", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex IdentifierRegex();
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/ScreenReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/ScreenReader.cs
@@ -12,20 +12,30 @@ namespace Cratis.Arc.Screenplay.Analysis.Screens;
 /// <param name="files">The <see cref="IUserInterfaceFiles"/> telling what sits alongside the source.</param>
 /// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of each file.</param>
 /// <param name="ambiguity">The <see cref="AmbiguousScreens"/> anything uncertain is reported to.</param>
+/// <param name="data">The <see cref="ScreenDataReader"/> reading which of the slice's queries a screen binds.</param>
 /// <remarks>
-/// Only the file realizing a screen is recovered, never its structure. A screen's structure is TypeScript and JSX,
-/// and inferring <c>data</c>, <c>table</c> or <c>action</c> directives would mean reading a language this generator
-/// does not read - so it says the one thing it actually knows, which is which file a reader should open.
+/// Two things about a screen are recovered and no more: the file realizing it, which is what a reader opens, and the
+/// queries it binds, which are names the model already holds and can be held against what the slice really declares.
+/// The rest of a screen is JSX, and a guessed table or column would be a confident falsehood in a document whose
+/// entire value is that it is true.
 /// </remarks>
-public class ScreenReader(IUserInterfaceFiles files, SourcePaths paths, AmbiguousScreens ambiguity)
+public class ScreenReader(
+    IUserInterfaceFiles files,
+    SourcePaths paths,
+    AmbiguousScreens ambiguity,
+    ScreenDataReader data)
 {
     /// <summary>
     /// Reads the screens of a slice.
     /// </summary>
     /// <param name="namespace">The namespace of the slice.</param>
     /// <param name="types">The types the slice is declared by.</param>
+    /// <param name="queries">The queries the slice declares, under the names it declares them.</param>
     /// <returns>The screens, ordered by name.</returns>
-    public IEnumerable<ScreenModel> Read(string @namespace, IEnumerable<INamedTypeSymbol> types)
+    public IEnumerable<ScreenModel> Read(
+        string @namespace,
+        IEnumerable<INamedTypeSymbol> types,
+        IReadOnlyCollection<QueryModel> queries)
     {
         var directories = SliceDirectories.Of(types);
         if (directories.Count == 0)
@@ -35,7 +45,7 @@ public class ScreenReader(IUserInterfaceFiles files, SourcePaths paths, Ambiguou
 
         ambiguity.ReportDirectories(@namespace, directories);
 
-        return Named(@namespace, Found(directories));
+        return Named(@namespace, Found(directories), queries);
     }
 
     /// <summary>
@@ -55,12 +65,13 @@ public class ScreenReader(IUserInterfaceFiles files, SourcePaths paths, Ambiguou
     /// </summary>
     /// <param name="namespace">The namespace of the slice.</param>
     /// <param name="found">The paths found alongside the source.</param>
+    /// <param name="queries">The queries the slice declares.</param>
     /// <returns>The screens, ordered by name.</returns>
     /// <remarks>
     /// A name is what one screen is told apart from another by, so two files claiming the same one leave a document
     /// that says the same word twice and means it differently. The first is kept and the rest are reported.
     /// </remarks>
-    IEnumerable<ScreenModel> Named(string @namespace, IEnumerable<string> found)
+    IEnumerable<ScreenModel> Named(string @namespace, IEnumerable<string> found, IReadOnlyCollection<QueryModel> queries)
     {
         var screens = new Dictionary<string, ScreenModel>(StringComparer.Ordinal);
 
@@ -77,7 +88,10 @@ public class ScreenReader(IUserInterfaceFiles files, SourcePaths paths, Ambiguou
                 continue;
             }
 
-            screens.Add(name, new(name, paths.Relative(path) ?? path));
+            screens.Add(name, new(name, paths.Relative(path) ?? path)
+            {
+                Data = [.. data.Read(@namespace, name, path, queries)]
+            });
         }
 
         return [.. screens.Values.OrderBy(_ => _.Name, StringComparer.Ordinal)];

--- a/Source/DotNET/Screenplay/Analysis/Screens/ScreenReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/ScreenReader.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Reads the screens a slice ends in from the user interface files sitting alongside its source.
+/// </summary>
+/// <param name="files">The <see cref="IUserInterfaceFiles"/> telling what sits alongside the source.</param>
+/// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of each file.</param>
+/// <param name="ambiguity">The <see cref="AmbiguousScreens"/> anything uncertain is reported to.</param>
+/// <remarks>
+/// Only the file realizing a screen is recovered, never its structure. A screen's structure is TypeScript and JSX,
+/// and inferring <c>data</c>, <c>table</c> or <c>action</c> directives would mean reading a language this generator
+/// does not read - so it says the one thing it actually knows, which is which file a reader should open.
+/// </remarks>
+public class ScreenReader(IUserInterfaceFiles files, SourcePaths paths, AmbiguousScreens ambiguity)
+{
+    /// <summary>
+    /// Reads the screens of a slice.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="types">The types the slice is declared by.</param>
+    /// <returns>The screens, ordered by name.</returns>
+    public IEnumerable<ScreenModel> Read(string @namespace, IEnumerable<INamedTypeSymbol> types)
+    {
+        var directories = SliceDirectories.Of(types);
+        if (directories.Count == 0)
+        {
+            return [];
+        }
+
+        ambiguity.ReportDirectories(@namespace, directories);
+
+        return Named(@namespace, Found(directories));
+    }
+
+    /// <summary>
+    /// Finds every user interface file sitting in a set of directories.
+    /// </summary>
+    /// <param name="directories">The directories to look in.</param>
+    /// <returns>The paths, ordered so that the same source always reads the same way.</returns>
+    IEnumerable<string> Found(IReadOnlyList<string> directories) =>
+        directories
+            .SelectMany(files.In)
+            .Where(_ => !string.IsNullOrWhiteSpace(_))
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Names the screen every file realizes, leaving out the files that realize none.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="found">The paths found alongside the source.</param>
+    /// <returns>The screens, ordered by name.</returns>
+    /// <remarks>
+    /// A name is what one screen is told apart from another by, so two files claiming the same one leave a document
+    /// that says the same word twice and means it differently. The first is kept and the rest are reported.
+    /// </remarks>
+    IEnumerable<ScreenModel> Named(string @namespace, IEnumerable<string> found)
+    {
+        var screens = new Dictionary<string, ScreenModel>(StringComparer.Ordinal);
+
+        foreach (var path in found)
+        {
+            if (ScreenFiles.NameOf(path) is not { } name)
+            {
+                continue;
+            }
+
+            if (screens.TryGetValue(name, out var kept))
+            {
+                ambiguity.ReportRepeatedName(@namespace, paths.Relative(path) ?? path, kept.FilePath, name);
+                continue;
+            }
+
+            screens.Add(name, new(name, paths.Relative(path) ?? path));
+        }
+
+        return [.. screens.Values.OrderBy(_ => _.Name, StringComparer.Ordinal)];
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/SliceDirectories.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/SliceDirectories.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Resolves the directories the source of a slice lives in.
+/// </summary>
+/// <remarks>
+/// This is what a syntax tree buys that metadata never could - a real path - and it is the whole reason a screen can
+/// be recovered at all. The vertical slice convention puts the file realizing a screen next to the source of the
+/// slice it belongs to, so where the source lives is where to look.
+/// </remarks>
+public static class SliceDirectories
+{
+    /// <summary>
+    /// Gets the directories a set of types is declared across.
+    /// </summary>
+    /// <param name="types">The types to locate.</param>
+    /// <returns>The directories, distinct and ordered.</returns>
+    public static IReadOnlyList<string> Of(IEnumerable<INamedTypeSymbol> types) =>
+    [
+        .. types
+            .SelectMany(_ => _.DeclaringSyntaxReferences)
+            .Select(_ => _.SyntaxTree.FilePath)
+            .Where(_ => !string.IsNullOrWhiteSpace(_))
+            .Select(ScreenFiles.DirectoryOf)
+            .Where(_ => _.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+    ];
+}

--- a/Source/DotNET/Screenplay/Analysis/Screens/UserInterfaceFiles.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/UserInterfaceFiles.cs
@@ -26,4 +26,26 @@ public class UserInterfaceFiles : IUserInterfaceFiles
             .EnumerateFiles(directory, $"*{ScreenFiles.Extension}", SearchOption.TopDirectoryOnly)
             .Where(ScreenFiles.IsUserInterfaceFile);
     }
+
+    /// <inheritdoc/>
+    public string? Contents(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return File.ReadAllText(path);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
 }

--- a/Source/DotNET/Screenplay/Analysis/Screens/UserInterfaceFiles.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/UserInterfaceFiles.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis.Screens;
+
+/// <summary>
+/// Represents an implementation of <see cref="IUserInterfaceFiles"/> reading the file system the source was built from.
+/// </summary>
+/// <remarks>
+/// This is the only place in analysis that touches a disk, which is the point of it being behind an interface. A
+/// directory a compilation names may not exist by the time a document is generated from it - a path from another
+/// machine, a source generator, or a compilation built entirely in memory - and none of those is an error, so an
+/// unreadable directory simply holds nothing.
+/// </remarks>
+public class UserInterfaceFiles : IUserInterfaceFiles
+{
+    /// <inheritdoc/>
+    public IEnumerable<string> In(string directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+        {
+            return [];
+        }
+
+        return Directory
+            .EnumerateFiles(directory, $"*{ScreenFiles.Extension}", SearchOption.TopDirectoryOnly)
+            .Where(ScreenFiles.IsUserInterfaceFile);
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/SliceKindInference.cs
+++ b/Source/DotNET/Screenplay/Analysis/SliceKindInference.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Infers the Event Modeling kind of a slice from what it contains.
+/// </summary>
+/// <remarks>
+/// A reactor that turns an event into further events or commands is adapting one part of the model into another, so
+/// it yields <see cref="SliceKind.Translate"/> rather than <see cref="SliceKind.Automation"/>. A reactor that only
+/// causes an effect outside the system is an automation, and it decides the kind even when the slice also holds a
+/// command - the reaction is what the slice is about.
+/// </remarks>
+public static class SliceKindInference
+{
+    /// <summary>
+    /// Infers the kind of a slice, first match wins.
+    /// </summary>
+    /// <param name="commands">The commands the slice declares.</param>
+    /// <param name="reactors">The reactors the slice declares.</param>
+    /// <returns>The inferred <see cref="SliceKind"/>.</returns>
+    public static SliceKind Infer(IEnumerable<CommandModel> commands, IEnumerable<ReactorModel> reactors)
+    {
+        var declaredReactors = reactors as IReadOnlyCollection<ReactorModel> ?? [.. reactors];
+
+        if (declaredReactors.Any(_ => _.IsTranslating))
+        {
+            return SliceKind.Translate;
+        }
+
+        if (declaredReactors.Count > 0)
+        {
+            return SliceKind.Automation;
+        }
+
+        return commands.Any() ? SliceKind.StateChange : SliceKind.StateView;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/SliceKindInference.cs
+++ b/Source/DotNET/Screenplay/Analysis/SliceKindInference.cs
@@ -21,8 +21,17 @@ public static class SliceKindInference
     /// </summary>
     /// <param name="commands">The commands the slice declares.</param>
     /// <param name="reactors">The reactors the slice declares.</param>
+    /// <param name="hasAggregateRoot">Whether the slice declares an aggregate root.</param>
     /// <returns>The inferred <see cref="SliceKind"/>.</returns>
-    public static SliceKind Infer(IEnumerable<CommandModel> commands, IEnumerable<ReactorModel> reactors)
+    /// <remarks>
+    /// An aggregate root governs a change to the system just as a command does, so a slice holding one is a state
+    /// change whether or not a command sits beside it. Calling such a slice a state view would say the opposite of
+    /// what it is.
+    /// </remarks>
+    public static SliceKind Infer(
+        IEnumerable<CommandModel> commands,
+        IEnumerable<ReactorModel> reactors,
+        bool hasAggregateRoot = false)
     {
         var declaredReactors = reactors as IReadOnlyCollection<ReactorModel> ?? [.. reactors];
 
@@ -36,6 +45,6 @@ public static class SliceKindInference
             return SliceKind.Automation;
         }
 
-        return commands.Any() ? SliceKind.StateChange : SliceKind.StateView;
+        return commands.Any() || hasAggregateRoot ? SliceKind.StateChange : SliceKind.StateView;
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Slices/DeclaredQuery.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/DeclaredQuery.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Slices;
+
+/// <summary>
+/// Represents a query together with the type that declared it.
+/// </summary>
+/// <param name="DeclaringName">The name of the read model or controller declaring the query.</param>
+/// <param name="Query">The query itself.</param>
+/// <remarks>
+/// Two read models in one namespace can both declare a query called the same thing, and the model has nowhere to
+/// record which one a query came from. Keeping the declaring type alongside the query until names are resolved is
+/// what lets both survive under names that tell them apart.
+/// </remarks>
+public record DeclaredQuery(string DeclaringName, QueryModel Query);

--- a/Source/DotNET/Screenplay/Analysis/Slices/QueryNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/QueryNames.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Slices;
+
+/// <summary>
+/// Resolves the names the queries of a slice are declared under.
+/// </summary>
+/// <remarks>
+/// Two read models in one namespace declaring a query of the same name produce a document with two declarations
+/// that cannot be told apart. The grammar tolerates it, which is worse than rejecting it - the document reads as if
+/// one of them were a duplicate. Every colliding query is therefore qualified by the type that declared it, so both
+/// survive and both are traceable back to source, and the qualification is reported rather than done silently.
+/// <para>
+/// Every colliding name is qualified rather than only the later ones, because "first wins" would make the name a
+/// query is declared under depend on what else happens to be in the namespace.
+/// </para>
+/// </remarks>
+public static class QueryNames
+{
+    /// <summary>
+    /// Resolves the queries of a slice onto names that tell them apart.
+    /// </summary>
+    /// <param name="declared">The queries, together with the types that declared them.</param>
+    /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything ambiguous is reported to.</param>
+    /// <param name="location">Where the slice lives, for use in diagnostics.</param>
+    /// <returns>The queries, under names that are unique within the slice.</returns>
+    public static IEnumerable<QueryModel> Resolve(
+        IEnumerable<DeclaredQuery> declared,
+        ScreenplayDiagnostics diagnostics,
+        string location)
+    {
+        var all = declared as IReadOnlyCollection<DeclaredQuery> ?? [.. declared];
+        var colliding = all
+            .GroupBy(_ => _.Query.Name, StringComparer.Ordinal)
+            .Where(_ => _.Count() > 1)
+            .Select(_ => _.Key)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var taken = new HashSet<string>(StringComparer.Ordinal);
+        var resolved = new List<QueryModel>();
+
+        foreach (var entry in all)
+        {
+            var name = colliding.Contains(entry.Query.Name) ? $"{entry.DeclaringName}{entry.Query.Name}" : entry.Query.Name;
+
+            if (!taken.Add(name))
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.AmbiguousQueryName,
+                    $"'{entry.DeclaringName}' declares a second query that resolves to '{name}', which nothing can tell apart, so it was left out",
+                    location);
+
+                continue;
+            }
+
+            if (!string.Equals(name, entry.Query.Name, StringComparison.Ordinal))
+            {
+                diagnostics.Information(
+                    ScreenplayDiagnosticCodes.AmbiguousQueryName,
+                    $"More than one query in the slice is called '{entry.Query.Name}', so the one on '{entry.DeclaringName}' is declared as '{name}'",
+                    location);
+            }
+
+            resolved.Add(entry.Query with { Name = name });
+        }
+
+        return resolved;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
 using Cratis.Arc.Screenplay.Analysis.Commands;
 using Cratis.Arc.Screenplay.Analysis.Constraints;
 using Cratis.Arc.Screenplay.Analysis.Controllers;
@@ -69,8 +70,13 @@ public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics 
             content.Constraints.AddRange(readers.Constraints.Read(type, @namespace));
         }
 
+        if (AggregateRoots.IsDeclaredByApplication(type))
+        {
+            content.HasAggregateRoot = true;
+            readers.AggregateRoots.Declare(type, @namespace);
+        }
+
         ReadController(type, @namespace, content);
-        ReportAggregateRoot(type, @namespace);
     }
 
     /// <summary>
@@ -141,21 +147,5 @@ public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics 
         }
 
         content.Projection = projection;
-    }
-
-    /// <summary>
-    /// Reports an aggregate root, which produces events from code a document cannot describe.
-    /// </summary>
-    /// <param name="type">The type to check.</param>
-    /// <param name="namespace">The namespace the slice lives in.</param>
-    void ReportAggregateRoot(INamedTypeSymbol type, string @namespace)
-    {
-        if (type.FindBase(WellKnownTypeNames.AggregateRoot) is not null)
-        {
-            diagnostics.Warning(
-                ScreenplayDiagnosticCodes.AggregateRootWithoutCounterpart,
-                $"'{type.Name}' is an aggregate root, whose events are produced by code rather than declaratively, so what it produces is not stated",
-                @namespace);
-        }
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Analysis.Constraints;
+using Cratis.Arc.Screenplay.Analysis.Controllers;
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Cratis.Arc.Screenplay.Analysis.Projections;
+using Cratis.Arc.Screenplay.Analysis.Queries;
+using Cratis.Arc.Screenplay.Analysis.Reactors;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Slices;
+
+/// <summary>
+/// Reads everything one type contributes to the slice it lives in.
+/// </summary>
+/// <param name="readers">The <see cref="ArtifactReaders"/> reading each kind of artifact.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A type can be more than one thing at once - a read model with queries is also the declaration of a projection -
+/// so every recognizer is asked in turn rather than the first match winning.
+/// </remarks>
+public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Reads everything one type contributes.
+    /// </summary>
+    /// <param name="type">The type to read.</param>
+    /// <param name="namespace">The namespace the slice lives in.</param>
+    /// <param name="content">The content collected so far.</param>
+    public void Read(INamedTypeSymbol type, string @namespace, SliceContents content)
+    {
+        if (EventReader.IsEvent(type))
+        {
+            content.Events.Add(readers.Events.Read(type, @namespace));
+            content.Constraints.AddRange(ConstraintReader.FromEvent(type));
+        }
+
+        if (CommandReader.IsCommand(type))
+        {
+            content.Commands.Add(readers.Commands.Read(type, @namespace));
+        }
+
+        if (QueryReader.IsReadModel(type))
+        {
+            AddQueries(content, type, QueryReader.MethodsOf(type), @namespace);
+            Assign(content, readers.ModelBoundProjections.Read(type, @namespace), @namespace);
+        }
+
+        if (FluentProjectionReader.ReadModelOf(type) is { } projected)
+        {
+            Assign(content, readers.FluentProjections.Read(type, projected, @namespace), @namespace);
+        }
+
+        if (ReducerReader.ReadModelOf(type) is { } reduced)
+        {
+            Assign(content, readers.Reducers.Read(type, reduced, @namespace), @namespace);
+        }
+
+        if (ReactorReader.IsReactor(type))
+        {
+            content.Reactors.Add(readers.Reactors.Read(type));
+        }
+
+        if (ConstraintReader.IsConstraint(type))
+        {
+            content.Constraints.AddRange(readers.Constraints.Read(type, @namespace));
+        }
+
+        ReadController(type, @namespace, content);
+        ReportAggregateRoot(type, @namespace);
+    }
+
+    /// <summary>
+    /// Reads the commands and queries a controller exposes.
+    /// </summary>
+    /// <param name="type">The type to read.</param>
+    /// <param name="namespace">The namespace the slice lives in.</param>
+    /// <param name="content">The content collected so far.</param>
+    void ReadController(INamedTypeSymbol type, string @namespace, SliceContents content)
+    {
+        if (!ControllerRoutes.IsController(type))
+        {
+            return;
+        }
+
+        foreach (var method in ControllerRoutes.MethodsOf(type))
+        {
+            if (ControllerRoutes.IsCommand(method))
+            {
+                content.Commands.Add(readers.ControllerCommands.Read(type, method, @namespace));
+            }
+            else if (ControllerRoutes.IsQuery(method))
+            {
+                AddQueries(content, type, [method], @namespace);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the queries a type exposes, leaving out any whose read model cannot be named.
+    /// </summary>
+    /// <param name="content">The content collected so far.</param>
+    /// <param name="declaring">The type declaring the queries.</param>
+    /// <param name="methods">The methods exposing them.</param>
+    /// <param name="namespace">The namespace the slice lives in.</param>
+    void AddQueries(SliceContents content, INamedTypeSymbol declaring, IEnumerable<IMethodSymbol> methods, string @namespace)
+    {
+        foreach (var method in methods)
+        {
+            if (readers.Queries.Read(method, declaring, @namespace) is { } query)
+            {
+                content.Queries.Add(new(declaring.Name, query));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Assigns the single projection a slice may declare, reporting any beyond the first.
+    /// </summary>
+    /// <param name="content">The content collected so far.</param>
+    /// <param name="projection">The projection to assign.</param>
+    /// <param name="namespace">The namespace the slice lives in.</param>
+    void Assign(SliceContents content, ProjectionModel? projection, string @namespace)
+    {
+        if (projection is null)
+        {
+            return;
+        }
+
+        if (content.Projection is not null)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                $"'{projection.Identifier}' is a second projection in one slice, and a slice may declare at most one, so it was left out",
+                @namespace);
+
+            return;
+        }
+
+        content.Projection = projection;
+    }
+
+    /// <summary>
+    /// Reports an aggregate root, which produces events from code a document cannot describe.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="namespace">The namespace the slice lives in.</param>
+    void ReportAggregateRoot(INamedTypeSymbol type, string @namespace)
+    {
+        if (type.FindBase(WellKnownTypeNames.AggregateRoot) is not null)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.AggregateRootWithoutCounterpart,
+                $"'{type.Name}' is an aggregate root, whose events are produced by code rather than declaratively, so what it produces is not stated",
+                @namespace);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceContents.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceContents.cs
@@ -41,6 +41,15 @@ public class SliceContents
     public ProjectionModel? Projection { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the slice declares an aggregate root.
+    /// </summary>
+    /// <remarks>
+    /// An aggregate root governs a change to the system, which is what a state change slice is, so a slice holding
+    /// one is a state change even when no command sits beside it.
+    /// </remarks>
+    public bool HasAggregateRoot { get; set; }
+
+    /// <summary>
     /// Gets a value indicating whether the slice declares nothing at all.
     /// </summary>
     public bool IsEmpty =>

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceContents.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceContents.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Slices;
+
+/// <summary>
+/// Collects everything a slice declares, while its namespace is being read.
+/// </summary>
+public class SliceContents
+{
+    /// <summary>
+    /// Gets the commands the slice declares.
+    /// </summary>
+    public IList<CommandModel> Commands { get; } = [];
+
+    /// <summary>
+    /// Gets the events the slice declares.
+    /// </summary>
+    public IList<EventModel> Events { get; } = [];
+
+    /// <summary>
+    /// Gets the queries the slice declares, each with the type that declared it.
+    /// </summary>
+    public IList<DeclaredQuery> Queries { get; } = [];
+
+    /// <summary>
+    /// Gets the reactors the slice declares.
+    /// </summary>
+    public IList<ReactorModel> Reactors { get; } = [];
+
+    /// <summary>
+    /// Gets the constraints the slice declares.
+    /// </summary>
+    public IList<ConstraintModel> Constraints { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the single projection the slice declares.
+    /// </summary>
+    public ProjectionModel? Projection { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the slice declares nothing at all.
+    /// </summary>
+    public bool IsEmpty =>
+        Commands.Count == 0 &&
+        Events.Count == 0 &&
+        Queries.Count == 0 &&
+        Reactors.Count == 0 &&
+        Constraints.Count == 0 &&
+        Projection is null;
+}

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Slices;
+
+/// <summary>
+/// Turns everything declared within one namespace into a slice.
+/// </summary>
+/// <param name="readers">The <see cref="ArtifactReaders"/> reading each kind of artifact.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A namespace is the unit a slice is recovered from, because that is what the vertical slice convention makes it -
+/// everything belonging to one behavior lives together, and nothing else does.
+/// </remarks>
+public class SliceReader(ArtifactReaders readers, ScreenplayDiagnostics diagnostics)
+{
+    readonly SliceArtifactReader _artifacts = new(readers, diagnostics);
+
+    /// <summary>
+    /// Reads the slice a namespace declares.
+    /// </summary>
+    /// <param name="namespace">The namespace to read.</param>
+    /// <param name="types">The types the namespace declares, in a deterministic order.</param>
+    /// <returns>The <see cref="SliceModel"/>, or <see langword="null"/> when the namespace declares no artifact.</returns>
+    public SliceModel? Read(string @namespace, IEnumerable<INamedTypeSymbol> types)
+    {
+        var content = new SliceContents();
+
+        foreach (var type in types)
+        {
+            _artifacts.Read(type, @namespace, content);
+        }
+
+        if (content.IsEmpty)
+        {
+            return null;
+        }
+
+        var commands = content.Commands.OrderBy(_ => _.Name, StringComparer.Ordinal).ToList();
+        var reactors = content.Reactors.OrderBy(_ => _.Name, StringComparer.Ordinal).ToList();
+
+        return new(
+            @namespace,
+            NameOf(@namespace),
+            SliceKindInference.Infer(commands, reactors),
+            null,
+            commands,
+            [.. content.Events.OrderBy(_ => _.Name, StringComparer.Ordinal)],
+            [.. QueryNames.Resolve(content.Queries, diagnostics, @namespace).OrderBy(_ => _.Name, StringComparer.Ordinal)],
+            content.Projection,
+            reactors,
+            [.. content.Constraints.OrderBy(_ => _.Name, StringComparer.Ordinal)]);
+    }
+
+    /// <summary>
+    /// Gets the name of a slice from the namespace it lives in.
+    /// </summary>
+    /// <param name="namespace">The namespace to name.</param>
+    /// <returns>The name.</returns>
+    static string NameOf(string @namespace)
+    {
+        var segments = @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        return segments.Length == 0 ? string.Empty : segments[^1];
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis.Screens;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
 
@@ -11,11 +12,13 @@ namespace Cratis.Arc.Screenplay.Analysis.Slices;
 /// </summary>
 /// <param name="readers">The <see cref="ArtifactReaders"/> reading each kind of artifact.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <param name="screens">The <see cref="ScreenReader"/> reading what the slice ends in.</param>
 /// <remarks>
 /// A namespace is the unit a slice is recovered from, because that is what the vertical slice convention makes it -
-/// everything belonging to one behavior lives together, and nothing else does.
+/// everything belonging to one behavior lives together, and nothing else does. The same convention puts the file
+/// realizing a screen in that folder too, which is why screens are read here rather than discovered separately.
 /// </remarks>
-public class SliceReader(ArtifactReaders readers, ScreenplayDiagnostics diagnostics)
+public class SliceReader(ArtifactReaders readers, ScreenplayDiagnostics diagnostics, ScreenReader screens)
 {
     readonly SliceArtifactReader _artifacts = new(readers, diagnostics);
 
@@ -45,14 +48,17 @@ public class SliceReader(ArtifactReaders readers, ScreenplayDiagnostics diagnost
         return new(
             @namespace,
             NameOf(@namespace),
-            SliceKindInference.Infer(commands, reactors),
+            SliceKindInference.Infer(commands, reactors, content.HasAggregateRoot),
             null,
             commands,
             [.. content.Events.OrderBy(_ => _.Name, StringComparer.Ordinal)],
             [.. QueryNames.Resolve(content.Queries, diagnostics, @namespace).OrderBy(_ => _.Name, StringComparer.Ordinal)],
             content.Projection,
             reactors,
-            [.. content.Constraints.OrderBy(_ => _.Name, StringComparer.Ordinal)]);
+            [.. content.Constraints.OrderBy(_ => _.Name, StringComparer.Ordinal)])
+        {
+            Screens = [.. screens.Read(@namespace, types)]
+        };
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
@@ -44,6 +44,7 @@ public class SliceReader(ArtifactReaders readers, ScreenplayDiagnostics diagnost
 
         var commands = content.Commands.OrderBy(_ => _.Name, StringComparer.Ordinal).ToList();
         var reactors = content.Reactors.OrderBy(_ => _.Name, StringComparer.Ordinal).ToList();
+        var queries = QueryNames.Resolve(content.Queries, diagnostics, @namespace).OrderBy(_ => _.Name, StringComparer.Ordinal).ToList();
 
         return new(
             @namespace,
@@ -52,12 +53,12 @@ public class SliceReader(ArtifactReaders readers, ScreenplayDiagnostics diagnost
             null,
             commands,
             [.. content.Events.OrderBy(_ => _.Name, StringComparer.Ordinal)],
-            [.. QueryNames.Resolve(content.Queries, diagnostics, @namespace).OrderBy(_ => _.Name, StringComparer.Ordinal)],
+            queries,
             content.Projection,
             reactors,
             [.. content.Constraints.OrderBy(_ => _.Name, StringComparer.Ordinal)])
         {
-            Screens = [.. screens.Read(@namespace, types)]
+            Screens = [.. screens.Read(@namespace, types, queries)]
         };
     }
 

--- a/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
+++ b/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
@@ -17,22 +17,32 @@ namespace Cratis.Arc.Screenplay.Analysis;
 public class SourcePaths(string root)
 {
     /// <summary>
-    /// Resolves the shared root of every source file in a compilation.
+    /// Resolves the shared root of the source an application is really written in.
     /// </summary>
     /// <param name="compilation">The compilation to read.</param>
+    /// <param name="catalog">The catalogue of everything the compilation declares.</param>
     /// <returns>The <see cref="SourcePaths"/>.</returns>
-    public static SourcePaths For(Compilation compilation)
+    /// <remarks>
+    /// A compilation carries more than the project's own files. A referenced package can ship source of its own -
+    /// a file of global using directives is the common case - and it is compiled from wherever the package cache
+    /// happens to live. Taking the shared prefix of every syntax tree then yields the file system root, and every
+    /// path in the document comes out as the absolute layout of the machine that generated it, which is exactly what
+    /// stops a document from being committed and diffed.
+    /// <para>
+    /// The files declaring the artifacts say where the project is: the deepest directory most of them sit under is
+    /// certainly inside it. Every file on that same path - a folder beside them, a program entry point above them -
+    /// belongs to the project too and widens the root; a file sharing nothing with them but the file system root
+    /// belongs to somebody else and is left out of the question entirely.
+    /// </para>
+    /// </remarks>
+    public static SourcePaths For(Compilation compilation, ArtifactCatalog catalog)
     {
-        var directories = compilation.SyntaxTrees
-            .Select(_ => _.FilePath)
-            .Where(_ => !string.IsNullOrWhiteSpace(_))
-            .Select(Normalize)
-            .Select(_ => _[..(_.LastIndexOf('/') + 1)])
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-            .ToList();
+        var declared = DirectoriesOf(catalog.Types.Select(_ => _.SourceFilePath()));
+        var anchor = DeepestSharedBy(declared);
+        var project = Rooted(declared, anchor);
+        var root = Rooted(DirectoriesOf(compilation.SyntaxTrees.Select(_ => _.FilePath)), project);
 
-        return new(directories.Count == 0 ? string.Empty : CommonPrefix(directories));
+        return new(IsFileSystemRoot(root) ? string.Empty : root);
     }
 
     /// <summary>
@@ -53,6 +63,89 @@ public class SourcePaths(string root)
             ? normalized[root.Length..]
             : normalized;
     }
+
+    /// <summary>
+    /// Gets the deepest directory that most of a set of directories sit under.
+    /// </summary>
+    /// <param name="directories">The directories to weigh.</param>
+    /// <returns>The directory, empty when there is none.</returns>
+    /// <remarks>
+    /// This exists to be unmoved by a stray file. A directory holding most of what the application declares is
+    /// somewhere inside the project whatever else the compilation was handed, which is enough to tell the project
+    /// from everything sitting outside it.
+    /// </remarks>
+    static string DeepestSharedBy(List<string> directories) =>
+        directories
+            .SelectMany(Ancestors)
+            .Distinct(StringComparer.Ordinal)
+            .Where(candidate => directories.Count(_ => _.StartsWith(candidate, StringComparison.Ordinal)) * 2 > directories.Count)
+            .OrderByDescending(_ => _.Length)
+            .ThenBy(_ => _, StringComparer.Ordinal)
+            .FirstOrDefault() ?? string.Empty;
+
+    /// <summary>
+    /// Gets every directory a directory sits under, itself included.
+    /// </summary>
+    /// <param name="directory">The directory to walk up from.</param>
+    /// <returns>The directories, each ending in a separator.</returns>
+    static IEnumerable<string> Ancestors(string directory)
+    {
+        for (var separator = directory.IndexOf('/', StringComparison.Ordinal); separator >= 0; separator = directory.IndexOf('/', separator + 1))
+        {
+            yield return directory[..(separator + 1)];
+        }
+    }
+
+    /// <summary>
+    /// Gets the directory shared by everything on the same path as an anchor.
+    /// </summary>
+    /// <param name="directories">The directories to reduce.</param>
+    /// <param name="anchor">The directory known to be within the project.</param>
+    /// <returns>The shared directory, empty when there is none.</returns>
+    static string Rooted(List<string> directories, string anchor)
+    {
+        var onThePath = directories.Where(_ => OnTheSamePath(_, anchor)).ToList();
+
+        return onThePath.Count == 0 ? string.Empty : CommonPrefix(onThePath);
+    }
+
+    /// <summary>
+    /// Gets the distinct directories a set of paths live in, in a deterministic order.
+    /// </summary>
+    /// <param name="paths">The paths to read.</param>
+    /// <returns>The directories, each ending in a separator.</returns>
+    static List<string> DirectoriesOf(IEnumerable<string?> paths) =>
+    [
+        .. paths
+            .Where(_ => !string.IsNullOrWhiteSpace(_))
+            .Select(_ => Normalize(_!))
+            .Select(_ => _[..(_.LastIndexOf('/') + 1)])
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Determines whether a directory and the project's own are on the same path.
+    /// </summary>
+    /// <param name="directory">The directory to check.</param>
+    /// <param name="project">The directory the artifacts are declared under.</param>
+    /// <returns>True when one contains the other.</returns>
+    static bool OnTheSamePath(string directory, string project) =>
+        project.Length == 0 ||
+        directory.StartsWith(project, StringComparison.Ordinal) ||
+        project.StartsWith(directory, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Determines whether a directory is the root of a file system rather than a directory within one.
+    /// </summary>
+    /// <param name="directory">The directory to check.</param>
+    /// <returns>True when it is a file system root.</returns>
+    /// <remarks>
+    /// Writing a path relative to <c>/</c> is not writing it relative to anything - it removes one character and
+    /// leaves the machine's own layout behind, looking like a relative path while being nothing of the sort.
+    /// </remarks>
+    static bool IsFileSystemRoot(string directory) =>
+        string.Equals(directory, "/", StringComparison.Ordinal) || (directory.Length == 3 && directory[1] == ':' && directory[2] == '/');
 
     /// <summary>
     /// Normalizes a path onto forward slashes.

--- a/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
+++ b/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Turns the absolute paths a compilation carries into paths a generated document can reference.
+/// </summary>
+/// <param name="root">The directory every path is written relative to.</param>
+/// <remarks>
+/// Syntax trees carry whatever path the compiler was handed, which for a real build is absolute and specific to
+/// the machine it ran on. A document is meant to be committed and diffed, so paths are written relative to the
+/// deepest directory every source file shares.
+/// </remarks>
+public class SourcePaths(string root)
+{
+    /// <summary>
+    /// Resolves the shared root of every source file in a compilation.
+    /// </summary>
+    /// <param name="compilation">The compilation to read.</param>
+    /// <returns>The <see cref="SourcePaths"/>.</returns>
+    public static SourcePaths For(Compilation compilation)
+    {
+        var directories = compilation.SyntaxTrees
+            .Select(_ => _.FilePath)
+            .Where(_ => !string.IsNullOrWhiteSpace(_))
+            .Select(Normalize)
+            .Select(_ => _[..(_.LastIndexOf('/') + 1)])
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        return new(directories.Count == 0 ? string.Empty : CommonPrefix(directories));
+    }
+
+    /// <summary>
+    /// Rewrites a path so that it is relative to the shared root.
+    /// </summary>
+    /// <param name="path">The path to rewrite.</param>
+    /// <returns>The relative path, or <see langword="null"/> when there is none.</returns>
+    public string? Relative(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var normalized = Normalize(path);
+
+        return root.Length > 0 && normalized.StartsWith(root, StringComparison.Ordinal)
+            ? normalized[root.Length..]
+            : normalized;
+    }
+
+    /// <summary>
+    /// Normalizes a path onto forward slashes.
+    /// </summary>
+    /// <param name="path">The path to normalize.</param>
+    /// <returns>The normalized path.</returns>
+    static string Normalize(string path) => path.Replace('\\', '/');
+
+    /// <summary>
+    /// Finds the longest directory prefix every path shares.
+    /// </summary>
+    /// <param name="directories">The directories to compare.</param>
+    /// <returns>The shared prefix, ending in a separator.</returns>
+    static string CommonPrefix(List<string> directories)
+    {
+        var prefix = directories[0];
+
+        foreach (var directory in directories.Skip(1))
+        {
+            var length = 0;
+            while (length < prefix.Length && length < directory.Length && prefix[length] == directory[length])
+            {
+                length++;
+            }
+
+            prefix = prefix[..length];
+        }
+
+        var separator = prefix.LastIndexOf('/');
+
+        return separator < 0 ? string.Empty : prefix[..(separator + 1)];
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/SymbolExtensions.cs
+++ b/Source/DotNET/Screenplay/Analysis/SymbolExtensions.cs
@@ -111,6 +111,19 @@ public static class SymbolExtensions
         attribute.ConstructorArguments.Length > index ? attribute.ConstructorArguments[index].Value : null;
 
     /// <summary>
+    /// Gets a constructor argument of an attribute together with the type it was written as.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The argument, or <see langword="null"/> when it was not given.</returns>
+    /// <remarks>
+    /// The value alone is all most readers need. A constant of an enumeration is the exception - it arrives as the
+    /// number behind a member, and only the type it was written as says which enumeration that member belongs to.
+    /// </remarks>
+    public static TypedConstant? GetTypedArgument(this AttributeData attribute, int index) =>
+        attribute.ConstructorArguments.Length > index ? attribute.ConstructorArguments[index] : null;
+
+    /// <summary>
     /// Gets the public instance properties a type carries, including the ones it inherits.
     /// </summary>
     /// <param name="symbol">The type to read.</param>

--- a/Source/DotNET/Screenplay/Analysis/SymbolExtensions.cs
+++ b/Source/DotNET/Screenplay/Analysis/SymbolExtensions.cs
@@ -111,24 +111,51 @@ public static class SymbolExtensions
         attribute.ConstructorArguments.Length > index ? attribute.ConstructorArguments[index].Value : null;
 
     /// <summary>
-    /// Gets the public instance properties a type declares itself.
+    /// Gets the public instance properties a type carries, including the ones it inherits.
     /// </summary>
     /// <param name="symbol">The type to read.</param>
-    /// <returns>The properties, in declaration order.</returns>
-    public static IEnumerable<IPropertySymbol> DeclaredProperties(this ITypeSymbol symbol) =>
-        symbol.GetMembers()
-            .OfType<IPropertySymbol>()
-            .Where(_ => _.DeclaredAccessibility == Accessibility.Public && !_.IsStatic && !_.IsIndexer && _.Name != "EqualityContract");
+    /// <returns>The properties, base types first and in declaration order within each type.</returns>
+    /// <remarks>
+    /// A property declared on a base record is part of what the type carries just as much as one declared on the type
+    /// itself - it is serialized, it is sent, and a document leaving it out describes a shape that does not exist.
+    /// <para>
+    /// Within one type the order the source declares them in is kept, since that is what the developer wrote. Roslyn
+    /// returns the members of a type split across several partial declarations in the order the syntax trees were
+    /// handed to the compiler, which a build is free to vary, so the declarations are ordered by the file they live
+    /// in first. That is what makes the same source produce the same document however it was globbed.
+    /// </para>
+    /// </remarks>
+    public static IEnumerable<IPropertySymbol> DeclaredProperties(this ITypeSymbol symbol)
+    {
+        var declaring = new List<ITypeSymbol>();
+        for (var current = symbol; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+        {
+            declaring.Insert(0, current);
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        return declaring
+            .SelectMany(InDeclarationOrder)
+            .Where(_ => seen.Add(_.Name));
+    }
 
     /// <summary>
     /// Gets the path of the file a symbol is declared in.
     /// </summary>
     /// <param name="symbol">The symbol to locate.</param>
     /// <returns>The path, or <see langword="null"/> when the symbol has no source.</returns>
+    /// <remarks>
+    /// A type declared across several files has as many paths as it has declarations, and which one Roslyn hands over
+    /// first follows the order the syntax trees arrived in. The first in order is taken so that the document names
+    /// the same file every time.
+    /// </remarks>
     public static string? SourceFilePath(this ISymbol symbol) =>
         symbol.DeclaringSyntaxReferences
             .Select(_ => _.SyntaxTree.FilePath)
-            .FirstOrDefault(_ => !string.IsNullOrWhiteSpace(_));
+            .Where(_ => !string.IsNullOrWhiteSpace(_))
+            .Order(StringComparer.Ordinal)
+            .FirstOrDefault();
 
     /// <summary>
     /// Gets the namespace a symbol lives in.
@@ -137,4 +164,22 @@ public static class SymbolExtensions
     /// <returns>The namespace, empty for the global namespace.</returns>
     public static string Namespace(this ISymbol symbol) =>
         symbol.ContainingNamespace is { IsGlobalNamespace: false } @namespace ? @namespace.ToDisplayString() : string.Empty;
+
+    /// <summary>
+    /// Gets the public instance properties one type declares, in the order its source declares them.
+    /// </summary>
+    /// <param name="symbol">The type to read.</param>
+    /// <returns>The properties.</returns>
+    static IEnumerable<IPropertySymbol> InDeclarationOrder(ITypeSymbol symbol) =>
+        symbol.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(_ => _.DeclaredAccessibility == Accessibility.Public && !_.IsStatic && !_.IsIndexer && _.Name != "EqualityContract")
+            .OrderBy(DeclaredIn, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the file a property is declared in, for ordering the members of a type declared across several of them.
+    /// </summary>
+    /// <param name="property">The property to locate.</param>
+    /// <returns>The path, empty when the property has no source.</returns>
+    static string DeclaredIn(IPropertySymbol property) => property.SourceFilePath() ?? string.Empty;
 }

--- a/Source/DotNET/Screenplay/Analysis/SymbolExtensions.cs
+++ b/Source/DotNET/Screenplay/Analysis/SymbolExtensions.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Extends Roslyn symbols with the matching every recognizer needs.
+/// </summary>
+/// <remarks>
+/// Everything is matched on the fully qualified metadata name rather than on symbol identity, which is what lets
+/// the generator recognize Arc and Chronicle artifacts without referencing either.
+/// </remarks>
+public static class SymbolExtensions
+{
+    /// <summary>
+    /// Gets the fully qualified metadata name of a type, including the arity of a generic type.
+    /// </summary>
+    /// <param name="symbol">The type to name.</param>
+    /// <returns>The name, for example <c>Cratis.Concepts.ConceptAs`1</c>.</returns>
+    public static string FullMetadataName(this INamedTypeSymbol symbol)
+    {
+        var definition = symbol.OriginalDefinition;
+
+        return definition.ContainingNamespace is { IsGlobalNamespace: false } containing
+            ? $"{containing.ToDisplayString()}.{definition.MetadataName}"
+            : definition.MetadataName;
+    }
+
+    /// <summary>
+    /// Determines whether a type is the named one.
+    /// </summary>
+    /// <param name="symbol">The type to check.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name to match.</param>
+    /// <returns>True when the type matches.</returns>
+    public static bool Is(this ITypeSymbol? symbol, string fullMetadataName) =>
+        symbol is INamedTypeSymbol named && string.Equals(named.FullMetadataName(), fullMetadataName, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Gets the attribute of a given type applied to a symbol.
+    /// </summary>
+    /// <param name="symbol">The symbol to read.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
+    /// <returns>The attribute, or <see langword="null"/> when it is not applied.</returns>
+    public static AttributeData? GetAttribute(this ISymbol symbol, string fullMetadataName) =>
+        symbol.GetAttributes().FirstOrDefault(_ => _.AttributeClass.Is(fullMetadataName));
+
+    /// <summary>
+    /// Gets every attribute of a given type applied to a symbol.
+    /// </summary>
+    /// <param name="symbol">The symbol to read.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
+    /// <returns>The attributes.</returns>
+    public static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, string fullMetadataName) =>
+        symbol.GetAttributes().Where(_ => _.AttributeClass.Is(fullMetadataName));
+
+    /// <summary>
+    /// Determines whether an attribute of a given type is applied to a symbol.
+    /// </summary>
+    /// <param name="symbol">The symbol to check.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the attribute.</param>
+    /// <returns>True when the attribute is applied.</returns>
+    public static bool HasAttribute(this ISymbol symbol, string fullMetadataName) =>
+        symbol.GetAttribute(fullMetadataName) is not null;
+
+    /// <summary>
+    /// Finds a base type of a type, walking the whole chain.
+    /// </summary>
+    /// <param name="symbol">The type to walk from.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the base type.</param>
+    /// <returns>The base type, or <see langword="null"/> when the type does not derive from it.</returns>
+    public static INamedTypeSymbol? FindBase(this ITypeSymbol? symbol, string fullMetadataName)
+    {
+        for (var current = symbol?.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.Is(fullMetadataName))
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds an interface a type implements.
+    /// </summary>
+    /// <param name="symbol">The type to check.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the interface.</param>
+    /// <returns>The interface, or <see langword="null"/> when the type does not implement it.</returns>
+    public static INamedTypeSymbol? FindInterface(this ITypeSymbol? symbol, string fullMetadataName) =>
+        symbol?.AllInterfaces.FirstOrDefault(_ => _.Is(fullMetadataName));
+
+    /// <summary>
+    /// Gets the value of a named argument of an attribute.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="name">The name of the argument.</param>
+    /// <returns>The value, or <see langword="null"/> when the argument was not given.</returns>
+    public static object? GetNamedArgument(this AttributeData attribute, string name) =>
+        attribute.NamedArguments.FirstOrDefault(_ => string.Equals(_.Key, name, StringComparison.Ordinal)).Value.Value;
+
+    /// <summary>
+    /// Gets the value of a constructor argument of an attribute.
+    /// </summary>
+    /// <param name="attribute">The attribute to read.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The value, or <see langword="null"/> when the argument was not given.</returns>
+    public static object? GetArgument(this AttributeData attribute, int index) =>
+        attribute.ConstructorArguments.Length > index ? attribute.ConstructorArguments[index].Value : null;
+
+    /// <summary>
+    /// Gets the public instance properties a type declares itself.
+    /// </summary>
+    /// <param name="symbol">The type to read.</param>
+    /// <returns>The properties, in declaration order.</returns>
+    public static IEnumerable<IPropertySymbol> DeclaredProperties(this ITypeSymbol symbol) =>
+        symbol.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(_ => _.DeclaredAccessibility == Accessibility.Public && !_.IsStatic && !_.IsIndexer && _.Name != "EqualityContract");
+
+    /// <summary>
+    /// Gets the path of the file a symbol is declared in.
+    /// </summary>
+    /// <param name="symbol">The symbol to locate.</param>
+    /// <returns>The path, or <see langword="null"/> when the symbol has no source.</returns>
+    public static string? SourceFilePath(this ISymbol symbol) =>
+        symbol.DeclaringSyntaxReferences
+            .Select(_ => _.SyntaxTree.FilePath)
+            .FirstOrDefault(_ => !string.IsNullOrWhiteSpace(_));
+
+    /// <summary>
+    /// Gets the namespace a symbol lives in.
+    /// </summary>
+    /// <param name="symbol">The symbol to read.</param>
+    /// <returns>The namespace, empty for the global namespace.</returns>
+    public static string Namespace(this ISymbol symbol) =>
+        symbol.ContainingNamespace is { IsGlobalNamespace: false } @namespace ? @namespace.ToDisplayString() : string.Empty;
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/CollectionElements.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/CollectionElements.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Determines whether a type is a collection, and of what.
+/// </summary>
+/// <remarks>
+/// A string is a sequence of characters as far as the type system is concerned, which is exactly the trap this
+/// exists to avoid - it is a value, never a collection.
+/// </remarks>
+public static class CollectionElements
+{
+    /// <summary>
+    /// Gets the element type of a collection.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns>The element type, or <see langword="null"/> when the type is not a collection.</returns>
+    public static ITypeSymbol? ElementOf(ITypeSymbol type)
+    {
+        if (type.SpecialType == SpecialType.System_String)
+        {
+            return null;
+        }
+
+        if (type is IArrayTypeSymbol array)
+        {
+            return array.ElementType;
+        }
+
+        if (type is not INamedTypeSymbol named)
+        {
+            return null;
+        }
+
+        if (named.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
+        {
+            return named.TypeArguments[0];
+        }
+
+        var enumerable = named.AllInterfaces.FirstOrDefault(_ =>
+            _.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T);
+
+        return enumerable?.TypeArguments[0];
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/ScreenplayPrimitiveNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/ScreenplayPrimitiveNames.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Types;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Determines whether a symbol is one of the framework types a Screenplay primitive stands for.
+/// </summary>
+public static class ScreenplayPrimitiveNames
+{
+    /// <summary>
+    /// Determines whether a type is a Screenplay primitive.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type maps onto a primitive.</returns>
+    public static bool IsPrimitive(INamedTypeSymbol type) =>
+        ScreenplayPrimitiveTypes.TryResolve(type.FullMetadataName(), out _);
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
@@ -20,6 +20,18 @@ public class TypeRegistry
     readonly Dictionary<string, ConceptModel> _concepts = new(StringComparer.Ordinal);
     readonly Dictionary<string, List<ValidationRuleModel>> _validations = new(StringComparer.Ordinal);
     readonly HashSet<string> _pii = new(StringComparer.Ordinal);
+    readonly HashSet<string> _unmappable = new(StringComparer.Ordinal);
+    readonly HashSet<string> _ambiguous = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the full name of every type that had to be referred to by a name that does not say what it is.
+    /// </summary>
+    public IEnumerable<string> Unmappable => _unmappable.Order(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the full name of every type whose simple name a concept was already declared under.
+    /// </summary>
+    public IEnumerable<string> Ambiguous => _ambiguous.Order(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets every concept referenced by the application, ordered by name.
@@ -127,19 +139,39 @@ public class TypeRegistry
 
         if (type.TypeKind == TypeKind.Enum)
         {
-            Register(new(type.Name, ScreenplayPrimitive.Enum, false, ValuesOf(type), []));
+            Register(type, new(type.Name, ScreenplayPrimitive.Enum, false, ValuesOf(type), []));
 
             return type.Name;
         }
 
         if (type.FindBase(WellKnownTypeNames.ConceptAs) is { } concept)
         {
-            Register(ToConcept(type, concept.TypeArguments[0]));
+            Register(type, ToConcept(type, concept.TypeArguments[0]));
 
             return type.Name;
         }
 
+        ReportWhatTheNameLoses(type);
+
         return type.Name;
+    }
+
+    /// <summary>
+    /// Records a type whose simple name says less than the type does.
+    /// </summary>
+    /// <param name="type">The type being named.</param>
+    /// <remarks>
+    /// A read model or a nested object referred to by its own name is exactly right. A constructed generic is not -
+    /// writing <c>IDictionary&lt;string, string&gt;</c> as the single identifier the grammar allows leaves the word
+    /// <c>KeyValuePair</c> behind, which says nothing and which the document never declares. Same for a type
+    /// parameter, whose name is a placeholder rather than a type.
+    /// </remarks>
+    void ReportWhatTheNameLoses(ITypeSymbol type)
+    {
+        if (type is INamedTypeSymbol { TypeArguments.Length: > 0 } or { TypeKind: TypeKind.TypeParameter })
+        {
+            _unmappable.Add(type.ToDisplayString());
+        }
     }
 
     /// <summary>
@@ -167,12 +199,25 @@ public class TypeRegistry
     /// <summary>
     /// Registers a concept, keeping the first declaration of a given name.
     /// </summary>
+    /// <param name="type">The type the concept was read from.</param>
     /// <param name="concept">The concept to register.</param>
-    void Register(ConceptModel concept)
+    /// <remarks>
+    /// A concept is declared once at the top of the document and referenced by its simple name, so two types sharing
+    /// that name cannot both be described. Keeping the first is the only choice left, and saying so is what stops the
+    /// document from quietly claiming the second one is something it is not.
+    /// </remarks>
+    void Register(ITypeSymbol type, ConceptModel concept)
     {
-        if (!_concepts.ContainsKey(concept.Name))
+        if (!_concepts.TryGetValue(concept.Name, out var existing))
         {
             _concepts[concept.Name] = concept;
+
+            return;
+        }
+
+        if (existing.Primitive != concept.Primitive || !existing.EnumValues.SequenceEqual(concept.EnumValues, StringComparer.Ordinal))
+        {
+            _ambiguous.Add(type.ToDisplayString());
         }
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Resolves the type of a property, a parameter or a return value, collecting the concepts encountered along the way.
+/// </summary>
+/// <remarks>
+/// A concept is declared once at the top of the document and referenced by name from there on, so every concept an
+/// artifact refers to has to be registered while its type is resolved. Only concepts that are actually referenced
+/// are declared, which keeps the document to what the application uses.
+/// </remarks>
+public class TypeRegistry
+{
+    readonly Dictionary<string, ConceptModel> _concepts = new(StringComparer.Ordinal);
+    readonly Dictionary<string, List<ValidationRuleModel>> _validations = new(StringComparer.Ordinal);
+    readonly HashSet<string> _pii = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets every concept referenced by the application, ordered by name.
+    /// </summary>
+    public IEnumerable<ConceptModel> Concepts =>
+    [
+        .. _concepts.Values
+            .Select(_ => _ with
+            {
+                IsPii = _.IsPii || _pii.Contains(_.Name),
+                Validations = _validations.TryGetValue(_.Name, out var rules) ? rules : []
+            })
+            .OrderBy(_ => _.Name, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Resolves the Screenplay type reference a symbol corresponds to.
+    /// </summary>
+    /// <param name="type">The type to resolve.</param>
+    /// <returns>The <see cref="TypeReferenceModel"/>.</returns>
+    public TypeReferenceModel Resolve(ITypeSymbol type)
+    {
+        var optional = false;
+        var current = Unwrap(type, ref optional);
+        var collection = CollectionElements.ElementOf(current);
+        if (collection is not null)
+        {
+            current = Unwrap(collection, ref optional);
+        }
+
+        return new(NameOf(current), collection is not null, optional);
+    }
+
+    /// <summary>
+    /// Records that a value of a concept carries personally identifiable information.
+    /// </summary>
+    /// <param name="type">The type of the value.</param>
+    public void MarkAsPii(ITypeSymbol type)
+    {
+        var optional = false;
+        var current = Unwrap(type, ref optional);
+        var collection = CollectionElements.ElementOf(current);
+
+        _pii.Add((collection ?? current).Name);
+    }
+
+    /// <summary>
+    /// Records the validation rules a concept declares for itself.
+    /// </summary>
+    /// <param name="conceptName">The name of the concept.</param>
+    /// <param name="rules">The rules to record.</param>
+    public void AddValidations(string conceptName, IEnumerable<ValidationRuleModel> rules)
+    {
+        if (!_validations.TryGetValue(conceptName, out var declared))
+        {
+            declared = [];
+            _validations[conceptName] = declared;
+        }
+
+        declared.AddRange(rules);
+    }
+
+    /// <summary>
+    /// Strips the wrappers that only say whether a value may be absent.
+    /// </summary>
+    /// <param name="type">The type to strip.</param>
+    /// <param name="optional">Set when a wrapper said the value may be absent.</param>
+    /// <returns>The wrapped type.</returns>
+    static ITypeSymbol Unwrap(ITypeSymbol type, ref bool optional)
+    {
+        if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullable)
+        {
+            optional = true;
+
+            return nullable.TypeArguments[0];
+        }
+
+        if (type.NullableAnnotation == NullableAnnotation.Annotated && type.IsReferenceType)
+        {
+            optional = true;
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Gets the values of an enumeration, in declaration order.
+    /// </summary>
+    /// <param name="type">The enumeration to read.</param>
+    /// <returns>The value names.</returns>
+    static IEnumerable<string> ValuesOf(ITypeSymbol type) =>
+        [.. type.GetMembers().OfType<IFieldSymbol>().Where(_ => _.HasConstantValue).Select(_ => _.Name)];
+
+    /// <summary>
+    /// Resolves the name a type is referenced by, registering it as a concept when it is one.
+    /// </summary>
+    /// <param name="type">The type to name.</param>
+    /// <returns>The Screenplay type name.</returns>
+    string NameOf(ITypeSymbol type)
+    {
+        if (type is INamedTypeSymbol named && ScreenplayPrimitiveTypes.TryResolve(named.FullMetadataName(), out var primitive))
+        {
+            return ScreenplayPrimitiveTypes.GetName(primitive);
+        }
+
+        if (type.TypeKind == TypeKind.Enum)
+        {
+            Register(new(type.Name, ScreenplayPrimitive.Enum, false, ValuesOf(type), []));
+
+            return type.Name;
+        }
+
+        if (type.FindBase(WellKnownTypeNames.ConceptAs) is { } concept)
+        {
+            Register(ToConcept(type, concept.TypeArguments[0]));
+
+            return type.Name;
+        }
+
+        return type.Name;
+    }
+
+    /// <summary>
+    /// Builds the concept a type backed by <c>ConceptAs</c> declares.
+    /// </summary>
+    /// <param name="type">The concept type.</param>
+    /// <param name="backing">The type the concept is backed by.</param>
+    /// <returns>The <see cref="ConceptModel"/>.</returns>
+    ConceptModel ToConcept(ITypeSymbol type, ITypeSymbol backing)
+    {
+        var pii = type.HasAttribute(WellKnownTypeNames.PiiAttribute);
+
+        if (backing.TypeKind == TypeKind.Enum)
+        {
+            return new(type.Name, ScreenplayPrimitive.Enum, pii, ValuesOf(backing), []);
+        }
+
+        var resolved = backing is INamedTypeSymbol named && ScreenplayPrimitiveTypes.TryResolve(named.FullMetadataName(), out var primitive)
+            ? primitive
+            : ScreenplayPrimitive.String;
+
+        return new(type.Name, resolved, pii, [], []);
+    }
+
+    /// <summary>
+    /// Registers a concept, keeping the first declaration of a given name.
+    /// </summary>
+    /// <param name="concept">The concept to register.</param>
+    void Register(ConceptModel concept)
+    {
+        if (!_concepts.ContainsKey(concept.Name))
+        {
+            _concepts[concept.Name] = concept;
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Validation/InvocationChain.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/InvocationChain.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Validation;
+
+/// <summary>
+/// Represents a fluent call chain, unwound so that it reads in the order it was written.
+/// </summary>
+/// <param name="Root">The call the chain starts from.</param>
+/// <param name="RootName">The name of the call the chain starts from.</param>
+/// <param name="Calls">Everything called on the result, in source order.</param>
+public record InvocationChain(
+    InvocationExpressionSyntax Root,
+    string RootName,
+    IReadOnlyList<InvocationExpressionSyntax> Calls)
+{
+    /// <summary>
+    /// Unwinds a fluent call chain.
+    /// </summary>
+    /// <param name="expression">The outermost call of the chain.</param>
+    /// <returns>The chain, or <see langword="null"/> when the expression is not a chain of calls.</returns>
+    /// <remarks>
+    /// A chain is written outermost last but read innermost first, so unwinding it is what lets a reader of the
+    /// analysis follow the same order the developer wrote.
+    /// </remarks>
+    public static InvocationChain? Unwind(ExpressionSyntax? expression)
+    {
+        var calls = new List<InvocationExpressionSyntax>();
+        var current = expression;
+
+        while (current is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax member } invocation)
+        {
+            calls.Insert(0, invocation);
+            current = member.Expression;
+        }
+
+        return current is InvocationExpressionSyntax { Expression: SimpleNameSyntax name } root
+            ? new(root, name.Identifier.ValueText, calls)
+            : null;
+    }
+
+    /// <summary>
+    /// Unwinds a fluent call chain that may start from something other than a call.
+    /// </summary>
+    /// <param name="expression">The outermost call of the chain.</param>
+    /// <returns>Every call of the chain, in source order.</returns>
+    /// <remarks>
+    /// A builder chain starts from the builder itself rather than from a call, which is the difference between this
+    /// and <see cref="Unwind"/> - here there is no root call to name.
+    /// </remarks>
+    public static IReadOnlyList<InvocationExpressionSyntax> Sequence(ExpressionSyntax? expression)
+    {
+        var calls = new List<InvocationExpressionSyntax>();
+        var current = expression;
+
+        while (current is InvocationExpressionSyntax invocation)
+        {
+            calls.Insert(0, invocation);
+            current = invocation.Expression is MemberAccessExpressionSyntax member ? member.Expression : null;
+        }
+
+        return calls;
+    }
+
+    /// <summary>
+    /// Gets the name of a call within the chain.
+    /// </summary>
+    /// <param name="invocation">The call to name.</param>
+    /// <returns>The name.</returns>
+    public static string NameOf(InvocationExpressionSyntax invocation) =>
+        invocation.Expression is MemberAccessExpressionSyntax member ? member.Name.Identifier.ValueText : string.Empty;
+
+    /// <summary>
+    /// Gets the type argument a generic call was given.
+    /// </summary>
+    /// <param name="invocation">The call to read.</param>
+    /// <returns>The type argument, or <see langword="null"/> when the call has none.</returns>
+    public static TypeSyntax? TypeArgumentOf(InvocationExpressionSyntax invocation) =>
+        invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax { Name: GenericNameSyntax generic } => generic.TypeArgumentList.Arguments.FirstOrDefault(),
+            GenericNameSyntax generic => generic.TypeArgumentList.Arguments.FirstOrDefault(),
+            _ => null
+        };
+
+    /// <summary>
+    /// Gets the argument at a position of a call.
+    /// </summary>
+    /// <param name="invocation">The call to read.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The argument, or <see langword="null"/> when the call was not given one.</returns>
+    public static ExpressionSyntax? ArgumentOf(InvocationExpressionSyntax invocation, int index = 0) =>
+        invocation.ArgumentList.Arguments.Count > index ? invocation.ArgumentList.Arguments[index].Expression : null;
+}

--- a/Source/DotNET/Screenplay/Analysis/Validation/LambdaPaths.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/LambdaPaths.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Validation;
+
+/// <summary>
+/// Reads the property a lambda selects.
+/// </summary>
+/// <remarks>
+/// Validators, projections and constraints all name a property the same way - a lambda that walks into its
+/// argument. Reading it from the syntax is exact, where reading it from the compiled expression tree at runtime
+/// loses everything the lambda did not compile down to a member access.
+/// </remarks>
+public static class LambdaPaths
+{
+    /// <summary>
+    /// Reads the dotted path a lambda selects.
+    /// </summary>
+    /// <param name="expression">The lambda to read.</param>
+    /// <returns>The path, or <see langword="null"/> when the lambda does not simply select a property.</returns>
+    public static string? Read(ExpressionSyntax? expression)
+    {
+        var (parameter, body) = expression switch
+        {
+            SimpleLambdaExpressionSyntax simple => (simple.Parameter.Identifier.ValueText, simple.ExpressionBody),
+            ParenthesizedLambdaExpressionSyntax { ParameterList.Parameters.Count: 1 } parenthesized =>
+                (parenthesized.ParameterList.Parameters[0].Identifier.ValueText, parenthesized.ExpressionBody),
+            _ => (null, null)
+        };
+
+        return parameter is null || body is null ? null : ReadFrom(body, parameter);
+    }
+
+    /// <summary>
+    /// Reads the dotted path an expression walks from a named root.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="root">The name of the root the path starts at.</param>
+    /// <returns>The path, or <see langword="null"/> when the expression is not a walk from the root.</returns>
+    static string? ReadFrom(ExpressionSyntax expression, string root)
+    {
+        var segments = new List<string>();
+        var current = Unwrap(expression);
+
+        while (current is MemberAccessExpressionSyntax member)
+        {
+            segments.Insert(0, member.Name.Identifier.ValueText);
+            current = Unwrap(member.Expression);
+        }
+
+        return current is IdentifierNameSyntax identifier &&
+            string.Equals(identifier.Identifier.ValueText, root, StringComparison.Ordinal) &&
+            segments.Count > 0
+                ? string.Join('.', segments)
+                : null;
+    }
+
+    /// <summary>
+    /// Strips the wrappers that do not change what an expression selects.
+    /// </summary>
+    /// <param name="expression">The expression to strip.</param>
+    /// <returns>The wrapped expression.</returns>
+    static ExpressionSyntax Unwrap(ExpressionSyntax expression) => expression switch
+    {
+        ParenthesizedExpressionSyntax parenthesized => Unwrap(parenthesized.Expression),
+        CastExpressionSyntax cast => Unwrap(cast.Expression),
+        PostfixUnaryExpressionSyntax { RawKind: (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.SuppressNullableWarningExpression } suppress =>
+            Unwrap(suppress.Operand),
+        _ => expression
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
@@ -76,11 +76,12 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
     /// <param name="call">The call declaring the rule.</param>
     /// <param name="name">The name of the rule builder.</param>
     /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="location">Where the validator lives, for use in diagnostics.</param>
     /// <returns>The operand, or <see langword="null"/> when the rule takes none.</returns>
-    static object? OperandOf(InvocationExpressionSyntax call, string name, SemanticModel semanticModel) =>
+    object? OperandOf(InvocationExpressionSyntax call, string name, SemanticModel semanticModel, string location) =>
         string.Equals(name, EmailAddress, StringComparison.Ordinal)
             ? ValidationRuleKinds.EmailPattern
-            : Constant(call, 0, semanticModel);
+            : Constant(call, 0, semanticModel, location);
 
     /// <summary>
     /// Reads the constant value of an argument.
@@ -88,12 +89,38 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
     /// <param name="call">The call to read.</param>
     /// <param name="index">The position of the argument.</param>
     /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="location">Where the validator lives, for use in diagnostics.</param>
     /// <returns>The value, or <see langword="null"/> when the argument is not a constant.</returns>
-    static object? Constant(InvocationExpressionSyntax call, int index, SemanticModel semanticModel)
+    /// <remarks>
+    /// A rule comparing against a member of an enumeration is given the number behind the member, which would have
+    /// the document compare a concept declaring names against a number. Naming the member is what keeps the rule
+    /// readable against the concept it is written about.
+    /// </remarks>
+    object? Constant(InvocationExpressionSyntax call, int index, SemanticModel semanticModel, string location)
     {
         var argument = InvocationChain.ArgumentOf(call, index);
+        if (argument is null)
+        {
+            return null;
+        }
 
-        return argument is null ? null : semanticModel.GetConstantValue(argument).Value;
+        var value = semanticModel.GetConstantValue(argument).Value;
+        if (EnumConstants.EnumerationOf(argument, semanticModel) is not { } enumeration)
+        {
+            return value;
+        }
+
+        if (EnumConstants.TryResolve(enumeration, value, out var member))
+        {
+            return member;
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnnamedEnumerationValue,
+            $"'{enumeration.Name}' declares no member with the value '{value}', so it is written as that number rather than as a name the concept declares",
+            location);
+
+        return value;
     }
 
     /// <summary>
@@ -127,8 +154,8 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
 
         if (!forEach && string.Equals(name, Length, StringComparison.Ordinal) && call.ArgumentList.Arguments.Count == 2)
         {
-            rules.Add(new(property, ValidationRuleKind.Min, Constant(call, 0, semanticModel), null));
-            rules.Add(new(property, ValidationRuleKind.Max, Constant(call, 1, semanticModel), null));
+            rules.Add(new(property, ValidationRuleKind.Min, Constant(call, 0, semanticModel, location), null));
+            rules.Add(new(property, ValidationRuleKind.Max, Constant(call, 1, semanticModel, location), null));
 
             return 2;
         }
@@ -143,7 +170,7 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
             return 0;
         }
 
-        rules.Add(new(property, kind, OperandOf(call, name, semanticModel), null));
+        rules.Add(new(property, kind, OperandOf(call, name, semanticModel, location), null));
 
         return 1;
     }

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
@@ -58,11 +58,15 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
             return;
         }
 
-        var declared = 0;
+        var preceding = 0;
 
         foreach (var call in chain.Calls)
         {
-            declared += ReadCall(call, property, forEach, semanticModel, location, rules, declared);
+            var added = ReadCall(call, property, forEach, semanticModel, location, rules, preceding);
+            if (added > 0)
+            {
+                preceding = added;
+            }
         }
     }
 
@@ -101,7 +105,7 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
     /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
     /// <param name="location">Where the validator lives, for use in diagnostics.</param>
     /// <param name="rules">The rules collected so far.</param>
-    /// <param name="declared">The number of rules the chain has declared so far.</param>
+    /// <param name="preceding">The number of rules the call before this one declared.</param>
     /// <returns>The number of rules the call added.</returns>
     int ReadCall(
         InvocationExpressionSyntax call,
@@ -110,13 +114,13 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
         SemanticModel semanticModel,
         string location,
         IList<ValidationRuleModel> rules,
-        int declared)
+        int preceding)
     {
         var name = InvocationChain.NameOf(call);
 
         if (string.Equals(name, WithMessage, StringComparison.Ordinal))
         {
-            ApplyMessage(call, semanticModel, rules, declared, location);
+            ApplyMessage(call, semanticModel, rules, preceding, location);
 
             return 0;
         }
@@ -145,22 +149,27 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
     }
 
     /// <summary>
-    /// Applies a message to the rule it was written after.
+    /// Applies a message to every rule the call before it declared.
     /// </summary>
     /// <param name="call">The call carrying the message.</param>
     /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
     /// <param name="rules">The rules collected so far.</param>
-    /// <param name="declared">The number of rules the chain has declared so far.</param>
+    /// <param name="preceding">The number of rules the call before this one declared.</param>
     /// <param name="location">Where the validator lives, for use in diagnostics.</param>
+    /// <remarks>
+    /// One call can declare more than one rule - a length range is a lower bound and an upper bound - and a message
+    /// written after it was written about the range rather than about its upper half. Attaching it to the last rule
+    /// alone would leave the lower bound reporting a message the developer never wrote.
+    /// </remarks>
     void ApplyMessage(
         InvocationExpressionSyntax call,
         SemanticModel semanticModel,
         IList<ValidationRuleModel> rules,
-        int declared,
+        int preceding,
         string location)
     {
         var message = InvocationChain.ArgumentOf(call) is { } argument ? semanticModel.GetConstantValue(argument).Value as string : null;
-        if (message is null || declared == 0)
+        if (message is null || preceding == 0)
         {
             diagnostics.Warning(
                 ScreenplayDiagnosticCodes.UnmappableValidationRule,
@@ -170,6 +179,9 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
             return;
         }
 
-        rules[^1] = rules[^1] with { Message = message };
+        for (var index = rules.Count - preceding; index < rules.Count; index++)
+        {
+            rules[index] = rules[index] with { Message = message };
+        }
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Validation;
+
+/// <summary>
+/// Reads the rules one chain of a validator's constructor declares for one property.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A chain names a property once and then declares rule after rule on it, with messages attaching to whichever rule
+/// they were written after. Counting what each call declared is what lets a message find the right rule.
+/// </remarks>
+public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The call carrying the message shown when a rule is broken.
+    /// </summary>
+    public const string WithMessage = "WithMessage";
+
+    /// <summary>
+    /// The call constraining the length of a value, which in its two argument form is a range.
+    /// </summary>
+    public const string Length = "Length";
+
+    /// <summary>
+    /// The call constraining a value to look like an email address.
+    /// </summary>
+    public const string EmailAddress = "EmailAddress";
+
+    /// <summary>
+    /// Reads one rule chain.
+    /// </summary>
+    /// <param name="chain">The chain to read.</param>
+    /// <param name="forEach">Whether the rules were declared for each element of a collection.</param>
+    /// <param name="semanticModel">The semantic model of the tree the chain lives in.</param>
+    /// <param name="location">Where the validator lives, for use in diagnostics.</param>
+    /// <param name="rules">The rules collected so far.</param>
+    public void Read(
+        InvocationChain chain,
+        bool forEach,
+        SemanticModel semanticModel,
+        string location,
+        IList<ValidationRuleModel> rules)
+    {
+        var property = LambdaPaths.Read(InvocationChain.ArgumentOf(chain.Root));
+        if (property is null)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableValidationRule,
+                $"'{chain.Root}' does not name a property directly, so the rules declared on it were left out",
+                location);
+
+            return;
+        }
+
+        var declared = 0;
+
+        foreach (var call in chain.Calls)
+        {
+            declared += ReadCall(call, property, forEach, semanticModel, location, rules, declared);
+        }
+    }
+
+    /// <summary>
+    /// Reads the operand a rule compares against.
+    /// </summary>
+    /// <param name="call">The call declaring the rule.</param>
+    /// <param name="name">The name of the rule builder.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>The operand, or <see langword="null"/> when the rule takes none.</returns>
+    static object? OperandOf(InvocationExpressionSyntax call, string name, SemanticModel semanticModel) =>
+        string.Equals(name, EmailAddress, StringComparison.Ordinal)
+            ? ValidationRuleKinds.EmailPattern
+            : Constant(call, 0, semanticModel);
+
+    /// <summary>
+    /// Reads the constant value of an argument.
+    /// </summary>
+    /// <param name="call">The call to read.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <returns>The value, or <see langword="null"/> when the argument is not a constant.</returns>
+    static object? Constant(InvocationExpressionSyntax call, int index, SemanticModel semanticModel)
+    {
+        var argument = InvocationChain.ArgumentOf(call, index);
+
+        return argument is null ? null : semanticModel.GetConstantValue(argument).Value;
+    }
+
+    /// <summary>
+    /// Reads one call of a rule chain.
+    /// </summary>
+    /// <param name="call">The call to read.</param>
+    /// <param name="property">The property the chain declares rules for.</param>
+    /// <param name="forEach">Whether the rules were declared for each element of a collection.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="location">Where the validator lives, for use in diagnostics.</param>
+    /// <param name="rules">The rules collected so far.</param>
+    /// <param name="declared">The number of rules the chain has declared so far.</param>
+    /// <returns>The number of rules the call added.</returns>
+    int ReadCall(
+        InvocationExpressionSyntax call,
+        string property,
+        bool forEach,
+        SemanticModel semanticModel,
+        string location,
+        IList<ValidationRuleModel> rules,
+        int declared)
+    {
+        var name = InvocationChain.NameOf(call);
+
+        if (string.Equals(name, WithMessage, StringComparison.Ordinal))
+        {
+            ApplyMessage(call, semanticModel, rules, declared, location);
+
+            return 0;
+        }
+
+        if (!forEach && string.Equals(name, Length, StringComparison.Ordinal) && call.ArgumentList.Arguments.Count == 2)
+        {
+            rules.Add(new(property, ValidationRuleKind.Min, Constant(call, 0, semanticModel), null));
+            rules.Add(new(property, ValidationRuleKind.Max, Constant(call, 1, semanticModel), null));
+
+            return 2;
+        }
+
+        if (!ValidationRuleKinds.TryResolve(name, forEach, out var kind))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableValidationRule,
+                $"The '{name}' rule on '{property}' lives in code and has no declarative counterpart, so it was left out",
+                location);
+
+            return 0;
+        }
+
+        rules.Add(new(property, kind, OperandOf(call, name, semanticModel), null));
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Applies a message to the rule it was written after.
+    /// </summary>
+    /// <param name="call">The call carrying the message.</param>
+    /// <param name="semanticModel">The semantic model of the tree the call lives in.</param>
+    /// <param name="rules">The rules collected so far.</param>
+    /// <param name="declared">The number of rules the chain has declared so far.</param>
+    /// <param name="location">Where the validator lives, for use in diagnostics.</param>
+    void ApplyMessage(
+        InvocationExpressionSyntax call,
+        SemanticModel semanticModel,
+        IList<ValidationRuleModel> rules,
+        int declared,
+        string location)
+    {
+        var message = InvocationChain.ArgumentOf(call) is { } argument ? semanticModel.GetConstantValue(argument).Value as string : null;
+        if (message is null || declared == 0)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableValidationRule,
+                "A message was declared without a constant value or without a rule preceding it, and was left out",
+                location);
+
+            return;
+        }
+
+        rules[^1] = rules[^1] with { Message = message };
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationReader.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Validation;
+
+/// <summary>
+/// Finds the rule chains a validator's constructor declares.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Reading the constructor recovers what the runtime rule descriptor loses - which rules were declared for each
+/// element of a collection, and which comparisons were made against something other than a number.
+/// </remarks>
+public class ValidationReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The call declaring a rule for a property.
+    /// </summary>
+    public const string RuleFor = "RuleFor";
+
+    /// <summary>
+    /// The call declaring a rule for each element of a collection property.
+    /// </summary>
+    public const string RuleForEach = "RuleForEach";
+
+    readonly ValidationChainReader _chains = new(diagnostics);
+
+    /// <summary>
+    /// Determines whether a type is a validator, and of what.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>The validated type, or <see langword="null"/> when the type is not a validator.</returns>
+    public static ITypeSymbol? ValidatedTypeOf(ITypeSymbol type) =>
+        type.FindBase(WellKnownTypeNames.AbstractValidator)?.TypeArguments[0];
+
+    /// <summary>
+    /// Reads every rule a validator declares.
+    /// </summary>
+    /// <param name="validator">The type declaring the validator.</param>
+    /// <param name="location">Where the validator lives, for use in diagnostics.</param>
+    /// <returns>The rules, in the order the source declares them.</returns>
+    public IEnumerable<ValidationRuleModel> Read(INamedTypeSymbol validator, string location)
+    {
+        var rules = new List<ValidationRuleModel>();
+
+        foreach (var constructor in validator.InstanceConstructors.Where(_ => _.DeclaringSyntaxReferences.Length > 0))
+        {
+            foreach (var reference in constructor.DeclaringSyntaxReferences)
+            {
+                ReadDeclaration(reference.GetSyntax(), location, rules);
+            }
+        }
+
+        return rules;
+    }
+
+    /// <summary>
+    /// Reads every rule chain within one constructor declaration.
+    /// </summary>
+    /// <param name="declaration">The declaration to read.</param>
+    /// <param name="location">Where the validator lives, for use in diagnostics.</param>
+    /// <param name="rules">The rules collected so far.</param>
+    void ReadDeclaration(SyntaxNode declaration, string location, List<ValidationRuleModel> rules)
+    {
+        var semanticModel = compilation.GetSemanticModel(declaration.SyntaxTree);
+
+        foreach (var statement in declaration.DescendantNodes().OfType<ExpressionStatementSyntax>())
+        {
+            var chain = InvocationChain.Unwind(statement.Expression);
+            var forEach = chain is not null && string.Equals(chain.RootName, RuleForEach, StringComparison.Ordinal);
+
+            if (chain is null || (!forEach && !string.Equals(chain.RootName, RuleFor, StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            _chains.Read(chain, forEach, semanticModel, location, rules);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationRuleKinds.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationRuleKinds.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Validation;
+
+/// <summary>
+/// Maps the rule builders of a validator onto the declarative rules Screenplay has.
+/// </summary>
+/// <remarks>
+/// Only rules whose meaning survives without the code behind them are mapped. The collection forms exist because a
+/// rule declared for each element of a collection means something different from the same rule on the collection.
+/// </remarks>
+public static class ValidationRuleKinds
+{
+    /// <summary>
+    /// The pattern name the grammar knows for an email address.
+    /// </summary>
+    public const string EmailPattern = "email";
+
+    static readonly Dictionary<string, ValidationRuleKind> _single = new(StringComparer.Ordinal)
+    {
+        { "NotEmpty", ValidationRuleKind.NotEmpty },
+        { "NotNull", ValidationRuleKind.NotEmpty },
+        { "MaximumLength", ValidationRuleKind.Max },
+        { "MinimumLength", ValidationRuleKind.Min },
+        { "Length", ValidationRuleKind.Length },
+        { "GreaterThan", ValidationRuleKind.GreaterThan },
+        { "GreaterThanOrEqualTo", ValidationRuleKind.GreaterThanOrEqual },
+        { "LessThan", ValidationRuleKind.LessThan },
+        { "LessThanOrEqualTo", ValidationRuleKind.LessThanOrEqual },
+        { "Equal", ValidationRuleKind.Equal },
+        { "Matches", ValidationRuleKind.Matches },
+        { "EmailAddress", ValidationRuleKind.Matches }
+    };
+
+    static readonly Dictionary<string, ValidationRuleKind> _each = new(StringComparer.Ordinal)
+    {
+        { "GreaterThan", ValidationRuleKind.AllGreaterThan },
+        { "GreaterThanOrEqualTo", ValidationRuleKind.AllGreaterThanOrEqual }
+    };
+
+    /// <summary>
+    /// Tries to map a rule builder onto a declarative rule.
+    /// </summary>
+    /// <param name="method">The name of the rule builder.</param>
+    /// <param name="forEach">Whether the rule was declared for each element of a collection.</param>
+    /// <param name="kind">The declarative rule.</param>
+    /// <returns>True when the rule builder has a counterpart.</returns>
+    public static bool TryResolve(string method, bool forEach, out ValidationRuleKind kind) =>
+        forEach ? _each.TryGetValue(method, out kind) : _single.TryGetValue(method, out kind);
+
+    /// <summary>
+    /// Determines whether a rule builder carries meaning that only the code behind it has.
+    /// </summary>
+    /// <param name="method">The name of the rule builder.</param>
+    /// <returns>True when the rule builder is a rule rather than a modifier.</returns>
+    public static bool IsRule(string method) => _single.ContainsKey(method) || _each.ContainsKey(method);
+}

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidatorCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidatorCatalog.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Validation;
+
+/// <summary>
+/// Holds the rules every validator in the compilation declares, keyed by what it validates.
+/// </summary>
+/// <remarks>
+/// A validator does not have to live next to what it validates, so they are collected once for the whole
+/// compilation and looked up by type rather than discovered per slice.
+/// </remarks>
+public class ValidatorCatalog
+{
+    readonly Dictionary<string, List<ValidationRuleModel>> _rules = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Collects every validator a catalogue of types declares.
+    /// </summary>
+    /// <param name="catalog">The catalogue to read.</param>
+    /// <param name="reader">The <see cref="ValidationReader"/> reading each validator.</param>
+    /// <returns>The <see cref="ValidatorCatalog"/>.</returns>
+    public static ValidatorCatalog From(ArtifactCatalog catalog, ValidationReader reader)
+    {
+        var validators = new ValidatorCatalog();
+
+        foreach (var type in catalog.Types.Where(_ => _ is { IsAbstract: false, TypeKind: TypeKind.Class }))
+        {
+            if (ValidationReader.ValidatedTypeOf(type) is not { } validated)
+            {
+                continue;
+            }
+
+            validators.Add(validated, reader.Read(type, type.Namespace()));
+        }
+
+        return validators;
+    }
+
+    /// <summary>
+    /// Gets the rules declared for a type.
+    /// </summary>
+    /// <param name="type">The type to look up.</param>
+    /// <returns>The rules, empty when nothing validates the type.</returns>
+    public IEnumerable<ValidationRuleModel> For(ITypeSymbol type) =>
+        _rules.TryGetValue(KeyFor(type), out var rules) ? rules : [];
+
+    /// <summary>
+    /// Gets the key a type is looked up by.
+    /// </summary>
+    /// <param name="type">The type to key.</param>
+    /// <returns>The key.</returns>
+    static string KeyFor(ITypeSymbol type) => type.ToDisplayString();
+
+    /// <summary>
+    /// Adds the rules a validator declares.
+    /// </summary>
+    /// <param name="validated">The type being validated.</param>
+    /// <param name="rules">The rules to add.</param>
+    void Add(ITypeSymbol validated, IEnumerable<ValidationRuleModel> rules)
+    {
+        var key = KeyFor(validated);
+        if (!_rules.TryGetValue(key, out var declared))
+        {
+            declared = [];
+            _rules[key] = declared;
+        }
+
+        declared.AddRange(rules);
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
@@ -27,6 +27,15 @@ public static class WellKnownTypeNames
     /// <summary>The attribute allowing anonymous callers.</summary>
     public const string AllowAnonymousAttribute = "Cratis.Arc.Authorization.AllowAnonymousAttribute";
 
+    /// <summary>The options every named authorization policy is registered on.</summary>
+    public const string AuthorizationOptions = "Microsoft.AspNetCore.Authorization.AuthorizationOptions";
+
+    /// <summary>The builder every named authorization policy can also be registered on.</summary>
+    public const string AuthorizationBuilder = "Microsoft.AspNetCore.Authorization.AuthorizationBuilder";
+
+    /// <summary>The builder the requirements of a named authorization policy are declared against.</summary>
+    public const string AuthorizationPolicyBuilder = "Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder";
+
     /// <summary>The interface a command pipeline is executed through.</summary>
     public const string CommandPipeline = "Cratis.Arc.Commands.ICommandPipeline";
 
@@ -86,6 +95,9 @@ public static class WellKnownTypeNames
 
     /// <summary>The base type an aggregate root derives from.</summary>
     public const string AggregateRoot = "Cratis.Arc.Chronicle.Aggregates.AggregateRoot";
+
+    /// <summary>The interface every aggregate root implements.</summary>
+    public const string AggregateRootInterface = "Cratis.Arc.Chronicle.Aggregates.IAggregateRoot";
 
     /// <summary>The base type every FluentValidation validator derives from.</summary>
     public const string AbstractValidator = "FluentValidation.AbstractValidator`1";

--- a/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Holds the fully qualified metadata names of every framework type source analysis recognizes.
+/// </summary>
+/// <remarks>
+/// Matching is by name rather than by symbol identity so that the generator never has to reference Arc, Chronicle
+/// or ASP.NET Core itself. Generic types carry their arity, which is what <c>MetadataName</c> yields.
+/// </remarks>
+public static class WellKnownTypeNames
+{
+    /// <summary>The attribute marking a model-bound command.</summary>
+    public const string CommandAttribute = "Cratis.Arc.Commands.ModelBound.CommandAttribute";
+
+    /// <summary>The attribute marking a model-bound read model.</summary>
+    public const string ReadModelAttribute = "Cratis.Arc.Queries.ModelBound.ReadModelAttribute";
+
+    /// <summary>The attribute requiring an authenticated caller.</summary>
+    public const string AuthorizeAttribute = "Cratis.Arc.Authorization.AuthorizeAttribute";
+
+    /// <summary>The attribute naming the roles a caller may hold.</summary>
+    public const string RolesAttribute = "Cratis.Arc.Authorization.RolesAttribute";
+
+    /// <summary>The attribute allowing anonymous callers.</summary>
+    public const string AllowAnonymousAttribute = "Cratis.Arc.Authorization.AllowAnonymousAttribute";
+
+    /// <summary>The interface a command pipeline is executed through.</summary>
+    public const string CommandPipeline = "Cratis.Arc.Commands.ICommandPipeline";
+
+    /// <summary>The base type every strongly typed domain value derives from.</summary>
+    public const string ConceptAs = "Cratis.Concepts.ConceptAs`1";
+
+    /// <summary>The attribute marking an event type.</summary>
+    public const string EventTypeAttribute = "Cratis.Chronicle.Events.EventTypeAttribute";
+
+    /// <summary>The attribute classifying an event with tags.</summary>
+    public const string TagAttribute = "Cratis.Chronicle.TagAttribute";
+
+    /// <summary>The attribute classifying an event with tags, plural form.</summary>
+    public const string TagsAttribute = "Cratis.Chronicle.TagsAttribute";
+
+    /// <summary>The attribute marking an event as a tombstone.</summary>
+    public const string TombstoneAttribute = "Cratis.Chronicle.Events.TombstoneAttribute";
+
+    /// <summary>The attribute marking an event as compensating another.</summary>
+    public const string CompensationForAttribute = "Cratis.Chronicle.Events.CompensationForAttribute";
+
+    /// <summary>The generic attribute marking an event as compensating another.</summary>
+    public const string CompensationForAttributeOfT = "Cratis.Chronicle.Events.CompensationForAttribute`1";
+
+    /// <summary>The attribute marking a value as personally identifiable information.</summary>
+    public const string PiiAttribute = "Cratis.Chronicle.Compliance.GDPR.PIIAttribute";
+
+    /// <summary>The attribute narrowing a command to an event source type.</summary>
+    public const string EventSourceTypeAttribute = "Cratis.Chronicle.Events.EventSourceTypeAttribute";
+
+    /// <summary>The attribute narrowing a command to an event stream type.</summary>
+    public const string EventStreamTypeAttribute = "Cratis.Chronicle.Events.EventStreamTypeAttribute";
+
+    /// <summary>The attribute narrowing a command to an event stream identifier.</summary>
+    public const string EventStreamIdAttribute = "Cratis.Chronicle.Events.EventStreamIdAttribute";
+
+    /// <summary>The attribute requiring a property of an event to be unique.</summary>
+    public const string UniqueAttribute = "Cratis.Chronicle.Events.Constraints.UniqueAttribute";
+
+    /// <summary>The interface a constraint declared in code implements.</summary>
+    public const string Constraint = "Cratis.Chronicle.Events.Constraints.IConstraint";
+
+    /// <summary>The interface a fluent projection implements.</summary>
+    public const string ProjectionFor = "Cratis.Chronicle.Projections.IProjectionFor`1";
+
+    /// <summary>The attribute configuring a projection.</summary>
+    public const string ProjectionAttribute = "Cratis.Chronicle.Projections.ProjectionAttribute";
+
+    /// <summary>The interface a reducer implements.</summary>
+    public const string ReducerFor = "Cratis.Chronicle.Reducers.IReducerFor`1";
+
+    /// <summary>The marker interface a reactor implements.</summary>
+    public const string Reactor = "Cratis.Chronicle.Reactors.IReactor";
+
+    /// <summary>The attribute configuring a reactor.</summary>
+    public const string ReactorAttribute = "Cratis.Chronicle.Reactors.ReactorAttribute";
+
+    /// <summary>The base type an aggregate root derives from.</summary>
+    public const string AggregateRoot = "Cratis.Arc.Chronicle.Aggregates.AggregateRoot";
+
+    /// <summary>The base type every FluentValidation validator derives from.</summary>
+    public const string AbstractValidator = "FluentValidation.AbstractValidator`1";
+
+    /// <summary>The base type of an ASP.NET Core controller.</summary>
+    public const string ControllerBase = "Microsoft.AspNetCore.Mvc.ControllerBase";
+
+    /// <summary>The attribute marking a controller method as taking its argument from the request body.</summary>
+    public const string FromBodyAttribute = "Microsoft.AspNetCore.Mvc.FromBodyAttribute";
+
+    /// <summary>The interface every transport level result of a controller method implements.</summary>
+    public const string ActionResultInterface = "Microsoft.AspNetCore.Mvc.IActionResult";
+
+    /// <summary>The base type the transport level results of a controller method derive from.</summary>
+    public const string ActionResult = "Microsoft.AspNetCore.Mvc.ActionResult";
+
+    /// <summary>The transport level result carrying the value a controller method really returns.</summary>
+    public const string ActionResultOfT = "Microsoft.AspNetCore.Mvc.ActionResult`1";
+}

--- a/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
@@ -112,7 +112,7 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
             new ConstraintSyntaxBuilder(naming),
             new ReactorSyntaxBuilder(naming, diagnostics),
             new ProjectionSyntaxBuilder(naming, diagnostics),
-            new ScreenSyntaxBuilder(naming));
+            new ScreenSyntaxBuilder(naming, _types));
 
     /// <summary>
     /// Sanitizes a document level name, falling back when it yields nothing usable.

--- a/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
@@ -35,6 +35,7 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
     readonly AuthorizeSyntaxBuilder _authorize = new();
     readonly ValidationSyntaxBuilder _validations = new(naming, diagnostics);
     readonly TypeReferenceConverter _types = new(naming);
+    readonly NameAvailability _names = new(naming, diagnostics);
 
     /// <summary>
     /// Builds the document.
@@ -49,7 +50,7 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
         var module = ToName(model.Module, resolved.Module);
 
         var modules = BuildModules(model, module, resolved.SegmentsToSkip ?? 0);
-        var concepts = new ConceptSyntaxBuilder(naming, _validations, diagnostics).Build(model.Concepts);
+        var concepts = new ConceptSyntaxBuilder(naming, _validations, diagnostics, _names).Build(model.Concepts);
         var policies = new PolicySyntaxBuilder(naming).Build(model.Policies, _authorize.Referenced);
 
         return new(
@@ -105,13 +106,14 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
                 _types,
                 _authorize,
                 _validations,
-                new ProducesSyntaxBuilder(naming),
-                new ConcurrencySyntaxBuilder(naming, diagnostics)),
-            new EventSyntaxBuilder(naming, _types),
+                new ProducesSyntaxBuilder(naming, _names),
+                new ConcurrencySyntaxBuilder(naming, diagnostics),
+                _names),
+            new EventSyntaxBuilder(naming, _types, _names),
             new QuerySyntaxBuilder(naming, _types, _authorize),
             new ConstraintSyntaxBuilder(naming),
             new ReactorSyntaxBuilder(naming, diagnostics),
-            new ProjectionSyntaxBuilder(naming, diagnostics),
+            new ProjectionSyntaxBuilder(naming, diagnostics, _names),
             new ScreenSyntaxBuilder(naming, _types));
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
@@ -10,6 +10,7 @@ using Cratis.Arc.Screenplay.Emission.Policies;
 using Cratis.Arc.Screenplay.Emission.Projections;
 using Cratis.Arc.Screenplay.Emission.Queries;
 using Cratis.Arc.Screenplay.Emission.Reactors;
+using Cratis.Arc.Screenplay.Emission.Screens;
 using Cratis.Arc.Screenplay.Emission.Slices;
 using Cratis.Arc.Screenplay.Emission.Types;
 using Cratis.Arc.Screenplay.Emission.Validation;
@@ -31,7 +32,7 @@ namespace Cratis.Arc.Screenplay.Emission;
 /// </remarks>
 public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
 {
-    readonly AuthorizeSyntaxBuilder _authorize = new(naming);
+    readonly AuthorizeSyntaxBuilder _authorize = new();
     readonly ValidationSyntaxBuilder _validations = new(naming, diagnostics);
     readonly TypeReferenceConverter _types = new(naming);
 
@@ -110,7 +111,8 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
             new QuerySyntaxBuilder(naming, _types, _authorize),
             new ConstraintSyntaxBuilder(naming),
             new ReactorSyntaxBuilder(naming, diagnostics),
-            new ProjectionSyntaxBuilder(naming, diagnostics));
+            new ProjectionSyntaxBuilder(naming, diagnostics),
+            new ScreenSyntaxBuilder(naming));
 
     /// <summary>
     /// Sanitizes a document level name, falling back when it yields nothing usable.

--- a/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Commands;
+using Cratis.Arc.Screenplay.Emission.Concepts;
+using Cratis.Arc.Screenplay.Emission.Constraints;
+using Cratis.Arc.Screenplay.Emission.Events;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Policies;
+using Cratis.Arc.Screenplay.Emission.Projections;
+using Cratis.Arc.Screenplay.Emission.Queries;
+using Cratis.Arc.Screenplay.Emission.Reactors;
+using Cratis.Arc.Screenplay.Emission.Slices;
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Emission.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission;
+
+/// <summary>
+/// Builds the Screenplay document describing an application model.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// Everything the document contains is ordered explicitly, never by the order the model happened to arrive in. That
+/// is what makes the same model produce byte identical output every time, which in turn is what makes a generated
+/// document something you can commit, diff and review.
+/// </remarks>
+public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
+{
+    readonly AuthorizeSyntaxBuilder _authorize = new(naming);
+    readonly ValidationSyntaxBuilder _validations = new(naming, diagnostics);
+    readonly TypeReferenceConverter _types = new(naming);
+
+    /// <summary>
+    /// Builds the document.
+    /// </summary>
+    /// <param name="model">The model to build from.</param>
+    /// <param name="options">The options to build with.</param>
+    /// <returns>The <see cref="ApplicationSyntax"/>.</returns>
+    public ApplicationSyntax Build(ApplicationModel model, ScreenplayOptions options)
+    {
+        var resolved = options.WithDefaults(model.Domain);
+        var domain = ToName(model.Domain, resolved.Domain);
+        var module = ToName(model.Module, resolved.Module);
+
+        var modules = BuildModules(model, module, resolved.SegmentsToSkip ?? 0);
+        var concepts = new ConceptSyntaxBuilder(naming, _validations, diagnostics).Build(model.Concepts);
+        var policies = new PolicySyntaxBuilder(naming).Build(model.Policies, _authorize.Referenced);
+
+        return new(
+            [],
+            [.. concepts],
+            [.. policies],
+            [.. modules],
+            SourceLocation.Start,
+            new DomainSyntax(domain, SourceLocation.Start));
+    }
+
+    /// <summary>
+    /// Builds the modules holding every slice that declares something.
+    /// </summary>
+    /// <param name="model">The model to build from.</param>
+    /// <param name="module">The name of the module.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments to skip.</param>
+    /// <returns>The modules.</returns>
+    IEnumerable<ModuleSyntax> BuildModules(ApplicationModel model, string module, int segmentsToSkip)
+    {
+        var sliceBuilder = CreateSliceBuilder();
+        var placed = new List<PlacedSlice>();
+
+        foreach (var slice in model.Slices
+            .OrderBy(_ => _.Namespace, StringComparer.Ordinal)
+            .ThenBy(_ => _.Name, StringComparer.Ordinal))
+        {
+            var built = sliceBuilder.Build(slice);
+            if (SliceContent.IsEmpty(built))
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.EmptySlice,
+                    $"The slice '{slice.Name}' declares nothing that can be expressed and was left out",
+                    slice.Namespace);
+                continue;
+            }
+
+            placed.Add(new(slice.Namespace, built));
+        }
+
+        return new SliceTreeBuilder(naming).Build(placed, module, segmentsToSkip);
+    }
+
+    /// <summary>
+    /// Composes the builder that turns one slice into its declaration.
+    /// </summary>
+    /// <returns>The <see cref="SliceSyntaxBuilder"/>.</returns>
+    SliceSyntaxBuilder CreateSliceBuilder() =>
+        new(
+            naming,
+            new CommandSyntaxBuilder(
+                naming,
+                _types,
+                _authorize,
+                _validations,
+                new ProducesSyntaxBuilder(naming),
+                new ConcurrencySyntaxBuilder(naming, diagnostics)),
+            new EventSyntaxBuilder(naming, _types),
+            new QuerySyntaxBuilder(naming, _types, _authorize),
+            new ConstraintSyntaxBuilder(naming),
+            new ReactorSyntaxBuilder(naming, diagnostics),
+            new ProjectionSyntaxBuilder(naming, diagnostics));
+
+    /// <summary>
+    /// Sanitizes a document level name, falling back when it yields nothing usable.
+    /// </summary>
+    /// <param name="value">The name to sanitize.</param>
+    /// <param name="fallback">The name to fall back to.</param>
+    /// <returns>The sanitized name.</returns>
+    string ToName(string? value, string? fallback)
+    {
+        var name = naming.ToDeclarationName(value ?? string.Empty);
+
+        return name.Length > 1 ? name : naming.ToDeclarationName(fallback ?? ScreenplayOptions.DefaultName);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Commands/CommandSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Commands/CommandSyntaxBuilder.cs
@@ -20,13 +20,15 @@ namespace Cratis.Arc.Screenplay.Emission.Commands;
 /// <param name="validations">The <see cref="ValidationSyntaxBuilder"/> used for the validate blocks.</param>
 /// <param name="produces">The <see cref="ProducesSyntaxBuilder"/> used for the produces blocks.</param>
 /// <param name="concurrency">The <see cref="ConcurrencySyntaxBuilder"/> used for the concurrency block.</param>
+/// <param name="names">The <see cref="NameAvailability"/> deciding which property names the body can carry.</param>
 public class CommandSyntaxBuilder(
     IScreenplayNaming naming,
     TypeReferenceConverter types,
     AuthorizeSyntaxBuilder authorize,
     ValidationSyntaxBuilder validations,
     ProducesSyntaxBuilder produces,
-    ConcurrencySyntaxBuilder concurrency)
+    ConcurrencySyntaxBuilder concurrency,
+    NameAvailability names)
 {
     /// <summary>
     /// Builds the command declaration.
@@ -36,11 +38,11 @@ public class CommandSyntaxBuilder(
     /// <returns>The <see cref="CommandSyntax"/>.</returns>
     public CommandSyntax Build(CommandModel command, string location)
     {
-        var produced = produces.Build(command.Produces).ToList();
+        var produced = produces.Build(command.Produces, location).ToList();
 
         return new(
             naming.ToDeclarationName(command.Name),
-            [.. command.Properties.Select(ToProperty)],
+            [.. ToProperties(command, location)],
             authorize.Build(command.Authorization),
             [.. validations.Build(command.Validations, location)],
             produced,
@@ -49,6 +51,17 @@ public class CommandSyntaxBuilder(
             concurrency.Build(command.Concurrency, location),
             naming.ToStringLiteral(command.Description));
     }
+
+    /// <summary>
+    /// Converts the properties of the command, leaving out every name the command body reads as a directive.
+    /// </summary>
+    /// <param name="command">The command to convert the properties of.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The properties the body can carry.</returns>
+    IEnumerable<PropertySyntax> ToProperties(CommandModel command, string location) =>
+        command.Properties
+            .Where(_ => names.Allows(_.Name, ReservedWords.InCommand, command.Name, location))
+            .Select(ToProperty);
 
     /// <summary>
     /// Converts a property of the command.

--- a/Source/DotNET/Screenplay/Emission/Commands/CommandSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Commands/CommandSyntaxBuilder.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Policies;
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Emission.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Commands;
+
+/// <summary>
+/// Builds the Screenplay <c>command</c> declaration for a command.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="types">The <see cref="TypeReferenceConverter"/> used for property types.</param>
+/// <param name="authorize">The <see cref="AuthorizeSyntaxBuilder"/> used for the authorize block.</param>
+/// <param name="validations">The <see cref="ValidationSyntaxBuilder"/> used for the validate blocks.</param>
+/// <param name="produces">The <see cref="ProducesSyntaxBuilder"/> used for the produces blocks.</param>
+/// <param name="concurrency">The <see cref="ConcurrencySyntaxBuilder"/> used for the concurrency block.</param>
+public class CommandSyntaxBuilder(
+    IScreenplayNaming naming,
+    TypeReferenceConverter types,
+    AuthorizeSyntaxBuilder authorize,
+    ValidationSyntaxBuilder validations,
+    ProducesSyntaxBuilder produces,
+    ConcurrencySyntaxBuilder concurrency)
+{
+    /// <summary>
+    /// Builds the command declaration.
+    /// </summary>
+    /// <param name="command">The command to build for.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="CommandSyntax"/>.</returns>
+    public CommandSyntax Build(CommandModel command, string location)
+    {
+        var produced = produces.Build(command.Produces).ToList();
+
+        return new(
+            naming.ToDeclarationName(command.Name),
+            [.. command.Properties.Select(ToProperty)],
+            authorize.Build(command.Authorization),
+            [.. validations.Build(command.Validations, location)],
+            produced,
+            ToHandler(command, produced.Count),
+            SourceLocation.Start,
+            concurrency.Build(command.Concurrency, location),
+            naming.ToStringLiteral(command.Description));
+    }
+
+    /// <summary>
+    /// Converts a property of the command.
+    /// </summary>
+    /// <param name="property">The property to convert.</param>
+    /// <returns>The <see cref="PropertySyntax"/>.</returns>
+    PropertySyntax ToProperty(PropertyModel property) =>
+        new(naming.ToPropertyName(property.Name), types.Convert(property.Type), SourceLocation.Start);
+
+    /// <summary>
+    /// Builds the handler reference for a command whose behavior is not expressed declaratively.
+    /// </summary>
+    /// <param name="command">The command to build for.</param>
+    /// <param name="producedCount">The number of produces blocks that were emitted.</param>
+    /// <returns>The <see cref="HandlerSyntax"/>, or <see langword="null"/> when there is nothing to point at.</returns>
+    /// <remarks>
+    /// A command declaring both a handler and a produces block does not compile, so the file is only pointed at when
+    /// nothing was produced declaratively.
+    /// </remarks>
+    HandlerSyntax? ToHandler(CommandModel command, int producedCount)
+    {
+        if (producedCount > 0 || naming.ToFilePath(command.SourceFilePath) is not { } path)
+        {
+            return null;
+        }
+
+        return new(new FileReferenceSyntax(path, SourceLocation.Start), null, SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Commands/ConcurrencySyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Commands/ConcurrencySyntaxBuilder.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Commands;
+
+/// <summary>
+/// Builds the Screenplay <c>concurrency</c> block for a command.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A concurrency block that narrows nothing at all does not compile, so a scope carrying no dimension is reported
+/// and left out rather than emitted empty.
+/// </remarks>
+public class ConcurrencySyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Builds the concurrency block a command declares.
+    /// </summary>
+    /// <param name="concurrency">The scope to build for, if the command declares one.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="ConcurrencySyntax"/>, or <see langword="null"/> when there is nothing to declare.</returns>
+    public ConcurrencySyntax? Build(ConcurrencyModel? concurrency, string location)
+    {
+        if (concurrency is null)
+        {
+            return null;
+        }
+
+        var sourceType = ToIdentifier(concurrency.SourceType);
+        var streamType = ToIdentifier(concurrency.StreamType);
+        var streamId = ToIdentifier(concurrency.StreamId);
+        var eventTypes = concurrency.EventTypes
+            .Select(naming.ToDeclarationName)
+            .Where(_ => _.Length > 1)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (!concurrency.EventSource && sourceType is null && streamType is null && streamId is null && eventTypes.Count == 0)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.EmptyConcurrencyScope,
+                "The concurrency scope narrows nothing at all and was left out",
+                location);
+
+            return null;
+        }
+
+        return new(concurrency.EventSource, sourceType, streamType, streamId, eventTypes, SourceLocation.Start);
+    }
+
+    /// <summary>
+    /// Converts a dimension of the scope into the identifier it is written as.
+    /// </summary>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>The identifier, or <see langword="null"/> when nothing should be emitted.</returns>
+    string? ToIdentifier(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var identifier = naming.ToDeclarationName(value);
+
+        return identifier.Length <= 1 ? null : identifier;
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Commands/ProducesSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Commands/ProducesSyntaxBuilder.cs
@@ -13,7 +13,8 @@ namespace Cratis.Arc.Screenplay.Emission.Commands;
 /// Builds the Screenplay <c>produces</c> blocks of a command.
 /// </summary>
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
-public class ProducesSyntaxBuilder(IScreenplayNaming naming)
+/// <param name="names">The <see cref="NameAvailability"/> deciding which properties the block can map onto.</param>
+public class ProducesSyntaxBuilder(IScreenplayNaming naming, NameAvailability names)
 {
     readonly MappingSourceConverter _sources = new(naming);
     readonly ConditionConverter _conditions = new(naming);
@@ -22,19 +23,30 @@ public class ProducesSyntaxBuilder(IScreenplayNaming naming)
     /// Builds the produces blocks of a command.
     /// </summary>
     /// <param name="produces">The events the command produces.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <returns>The produces blocks, in the order the command declares them.</returns>
-    public IEnumerable<ProducesSyntax> Build(IEnumerable<ProducesModel> produces) => [.. produces.Select(Build)];
+    public IEnumerable<ProducesSyntax> Build(IEnumerable<ProducesModel> produces, string location) =>
+        [.. produces.Select(_ => Build(_, location))];
 
     /// <summary>
     /// Builds a single produces block.
     /// </summary>
     /// <param name="produces">The event production to build for.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <returns>The <see cref="ProducesSyntax"/>.</returns>
-    ProducesSyntax Build(ProducesModel produces) =>
+    /// <remarks>
+    /// A mapping is written onto the property of the event it fills in, so a mapping onto a property the block reads
+    /// as a directive of its own is left out for the same reason the property itself is.
+    /// </remarks>
+    ProducesSyntax Build(ProducesModel produces, string location) =>
         new(
             naming.ToDeclarationName(produces.EventName),
             _conditions.Convert(produces.When),
-            [.. produces.Mappings.Select(ToMapping)],
+            [
+                .. produces.Mappings
+                    .Where(_ => names.Allows(_.Property, ReservedWords.InProduces, produces.EventName, location))
+                    .Select(ToMapping)
+            ],
             SourceLocation.Start);
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/Commands/ProducesSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Commands/ProducesSyntaxBuilder.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Expressions;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Commands;
+
+/// <summary>
+/// Builds the Screenplay <c>produces</c> blocks of a command.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+public class ProducesSyntaxBuilder(IScreenplayNaming naming)
+{
+    readonly MappingSourceConverter _sources = new(naming);
+    readonly ConditionConverter _conditions = new(naming);
+
+    /// <summary>
+    /// Builds the produces blocks of a command.
+    /// </summary>
+    /// <param name="produces">The events the command produces.</param>
+    /// <returns>The produces blocks, in the order the command declares them.</returns>
+    public IEnumerable<ProducesSyntax> Build(IEnumerable<ProducesModel> produces) => [.. produces.Select(Build)];
+
+    /// <summary>
+    /// Builds a single produces block.
+    /// </summary>
+    /// <param name="produces">The event production to build for.</param>
+    /// <returns>The <see cref="ProducesSyntax"/>.</returns>
+    ProducesSyntax Build(ProducesModel produces) =>
+        new(
+            naming.ToDeclarationName(produces.EventName),
+            _conditions.Convert(produces.When),
+            [.. produces.Mappings.Select(ToMapping)],
+            SourceLocation.Start);
+
+    /// <summary>
+    /// Converts a single mapping onto an event property.
+    /// </summary>
+    /// <param name="mapping">The mapping to convert.</param>
+    /// <returns>The <see cref="PropertyMappingSyntax"/>.</returns>
+    PropertyMappingSyntax ToMapping(PropertyMappingModel mapping) =>
+        new(naming.ToPropertyName(mapping.Property), _sources.Convert(mapping.Source), SourceLocation.Start);
+}

--- a/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
@@ -16,10 +16,12 @@ namespace Cratis.Arc.Screenplay.Emission.Concepts;
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
 /// <param name="validations">The <see cref="ValidationSyntaxBuilder"/> used for the validate blocks.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <param name="names">The <see cref="NameAvailability"/> deciding which value names the body can carry.</param>
 public class ConceptSyntaxBuilder(
     IScreenplayNaming naming,
     ValidationSyntaxBuilder validations,
-    ScreenplayDiagnostics diagnostics)
+    ScreenplayDiagnostics diagnostics,
+    NameAvailability names)
 {
     /// <summary>
     /// The Screenplay attribute marking a concept as personally identifiable information.
@@ -71,8 +73,18 @@ public class ConceptSyntaxBuilder(
     /// </summary>
     /// <param name="concept">The concept to read the values of.</param>
     /// <returns>The values, empty when the concept is not an enumeration.</returns>
+    /// <remarks>
+    /// A value is written on a line of its own, so a value named after a word the concept body reads as a directive
+    /// is swallowed by that directive rather than declared, and is left out instead.
+    /// </remarks>
     List<string> ToValues(ConceptModel concept) =>
         concept.Primitive == ScreenplayPrimitive.Enum
-            ? [.. concept.EnumValues.Select(naming.ToPropertyName).Distinct(StringComparer.Ordinal)]
+            ?
+            [
+                .. concept.EnumValues
+                    .Where(_ => names.Allows(_, ReservedWords.InConcept, concept.Name, concept.Name))
+                    .Select(naming.ToPropertyName)
+                    .Distinct(StringComparer.Ordinal)
+            ]
             : [];
 }

--- a/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Emission.Validation;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Concepts;
+
+/// <summary>
+/// Builds the document level <c>concept</c> declarations.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="validations">The <see cref="ValidationSyntaxBuilder"/> used for the validate blocks.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+public class ConceptSyntaxBuilder(
+    IScreenplayNaming naming,
+    ValidationSyntaxBuilder validations,
+    ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The Screenplay attribute marking a concept as personally identifiable information.
+    /// </summary>
+    public const string PersonallyIdentifiableInformation = "pii";
+
+    /// <summary>
+    /// Builds every concept the document declares.
+    /// </summary>
+    /// <param name="concepts">The concepts to build.</param>
+    /// <returns>The concept declarations, ordered by name.</returns>
+    public IEnumerable<ConceptSyntax> Build(IEnumerable<ConceptModel> concepts)
+    {
+        var declared = new Dictionary<string, ConceptSyntax>(StringComparer.Ordinal);
+
+        foreach (var concept in concepts)
+        {
+            var name = naming.ToDeclarationName(concept.Name);
+            if (name.Length <= 1 || declared.ContainsKey(name))
+            {
+                continue;
+            }
+
+            var values = ToValues(concept);
+            if (concept.Primitive == ScreenplayPrimitive.Enum && values.Count == 0)
+            {
+                // An enumeration with no values has an empty body, which does not compile.
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.EnumWithoutValues,
+                    $"The concept '{concept.Name}' is an enumeration with no values and was left out",
+                    concept.Name);
+                continue;
+            }
+
+            declared[name] = new(
+                name,
+                ScreenplayPrimitiveTypes.GetName(concept.Primitive),
+                concept.IsPii ? [PersonallyIdentifiableInformation] : [],
+                values,
+                SourceLocation.Start,
+                [.. validations.Build(concept.Validations, concept.Name, impliedSubject: true)]);
+        }
+
+        return [.. declared.Values.OrderBy(_ => _.Name, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Gets the values of an enumeration in the lower camel case form the grammar requires.
+    /// </summary>
+    /// <param name="concept">The concept to read the values of.</param>
+    /// <returns>The values, empty when the concept is not an enumeration.</returns>
+    List<string> ToValues(ConceptModel concept) =>
+        concept.Primitive == ScreenplayPrimitive.Enum
+            ? [.. concept.EnumValues.Select(naming.ToPropertyName).Distinct(StringComparer.Ordinal)]
+            : [];
+}

--- a/Source/DotNET/Screenplay/Emission/Constraints/ConstraintSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Constraints/ConstraintSyntaxBuilder.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Files;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Constraints;
+
+/// <summary>
+/// Builds the Screenplay <c>constraint</c> declaration for a constraint.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <remarks>
+/// Screenplay knows exactly three constraint shapes - unique on a property of an event, unique on an event type, and
+/// a reference to the file holding the rule. Anything else is rendered as a file reference rather than as something
+/// it is not.
+/// </remarks>
+public class ConstraintSyntaxBuilder(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// Builds the constraint declaration.
+    /// </summary>
+    /// <param name="constraint">The constraint to build for.</param>
+    /// <param name="namespace">The namespace of the slice the constraint lives in.</param>
+    /// <returns>The <see cref="ConstraintSyntax"/>.</returns>
+    public ConstraintSyntax Build(ConstraintModel constraint, string @namespace)
+    {
+        var name = naming.ToDeclarationName(constraint.Name);
+
+        return constraint switch
+        {
+            UniquePropertyConstraintModel unique => new UniquePropertyConstraintSyntax(
+                name,
+                naming.ToPropertyPath(unique.Property),
+                naming.ToDeclarationName(unique.EventName),
+                SourceLocation.Start),
+            UniqueEventConstraintModel unique => new UniqueEventConstraintSyntax(
+                name,
+                naming.ToDeclarationName(unique.EventName),
+                SourceLocation.Start),
+            CustomConstraintModel custom => ToFileConstraint(name, custom, @namespace),
+            _ => ToFileConstraint(name, new CustomConstraintModel(constraint.Name, null), @namespace)
+        };
+    }
+
+    /// <summary>
+    /// Builds the declaration pointing at the file holding a constraint's rule.
+    /// </summary>
+    /// <param name="name">The sanitized name of the constraint.</param>
+    /// <param name="constraint">The constraint to build for.</param>
+    /// <param name="namespace">The namespace of the slice the constraint lives in.</param>
+    /// <returns>The <see cref="FileConstraintSyntax"/>.</returns>
+    FileConstraintSyntax ToFileConstraint(string name, CustomConstraintModel constraint, string @namespace)
+    {
+        var path = naming.ToFilePath(constraint.SourceFilePath) ?? SourceFilePaths.Conventional(@namespace, name);
+
+        return new(name, new FileReferenceSyntax(path, SourceLocation.Start), SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Events/EventSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Events/EventSyntaxBuilder.cs
@@ -14,19 +14,32 @@ namespace Cratis.Arc.Screenplay.Emission.Events;
 /// </summary>
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
 /// <param name="types">The <see cref="TypeReferenceConverter"/> used for property types.</param>
-public class EventSyntaxBuilder(IScreenplayNaming naming, TypeReferenceConverter types)
+/// <param name="names">The <see cref="NameAvailability"/> deciding which property names the body can carry.</param>
+public class EventSyntaxBuilder(IScreenplayNaming naming, TypeReferenceConverter types, NameAvailability names)
 {
     /// <summary>
     /// Builds the event declaration.
     /// </summary>
     /// <param name="event">The event to build for.</param>
+    /// <param name="location">Where the event lives, for use in diagnostics.</param>
     /// <returns>The <see cref="EventSyntax"/>.</returns>
-    public EventSyntax Build(EventModel @event) =>
+    public EventSyntax Build(EventModel @event, string location) =>
         new(
             naming.ToDeclarationName(@event.Name),
-            [.. @event.Properties.Select(ToProperty)],
+            [.. ToProperties(@event, location)],
             SourceLocation.Start,
             BuildTags(@event));
+
+    /// <summary>
+    /// Converts the properties of the event, leaving out every name the event body reads as a directive.
+    /// </summary>
+    /// <param name="event">The event to convert the properties of.</param>
+    /// <param name="location">Where the event lives, for use in diagnostics.</param>
+    /// <returns>The properties the body can carry.</returns>
+    IEnumerable<PropertySyntax> ToProperties(EventModel @event, string location) =>
+        @event.Properties
+            .Where(_ => names.Allows(_.Name, ReservedWords.InEvent, @event.Name, location))
+            .Select(ToProperty);
 
     /// <summary>
     /// Converts a property of the event.

--- a/Source/DotNET/Screenplay/Emission/Events/EventSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Events/EventSyntaxBuilder.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Events;
+
+/// <summary>
+/// Builds the Screenplay declaration for an event.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="types">The <see cref="TypeReferenceConverter"/> used for property types.</param>
+public class EventSyntaxBuilder(IScreenplayNaming naming, TypeReferenceConverter types)
+{
+    /// <summary>
+    /// Builds the event declaration.
+    /// </summary>
+    /// <param name="event">The event to build for.</param>
+    /// <returns>The <see cref="EventSyntax"/>.</returns>
+    public EventSyntax Build(EventModel @event) =>
+        new(
+            naming.ToDeclarationName(@event.Name),
+            [.. @event.Properties.Select(ToProperty)],
+            SourceLocation.Start,
+            BuildTags(@event));
+
+    /// <summary>
+    /// Converts a property of the event.
+    /// </summary>
+    /// <param name="property">The property to convert.</param>
+    /// <returns>The <see cref="PropertySyntax"/>.</returns>
+    PropertySyntax ToProperty(PropertyModel property) =>
+        new(naming.ToPropertyName(property.Name), types.Convert(property.Type), SourceLocation.Start);
+
+    /// <summary>
+    /// Builds the tags an event is classified by.
+    /// </summary>
+    /// <param name="event">The event to read.</param>
+    /// <returns>The tags, or <see langword="null"/> when the event declares none.</returns>
+    /// <remarks>
+    /// A tag whose value is an identifier is printed bare, everything else through the expression renderer, so the
+    /// value only has to survive as a string literal.
+    /// </remarks>
+    List<TagSyntax>? BuildTags(EventModel @event)
+    {
+        var tags = @event.Tags
+            .Select(naming.ToStringLiteral)
+            .OfType<string>()
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .Select(_ => new TagSyntax(new LiteralExpressionSyntax(_, SourceLocation.Start), SourceLocation.Start))
+            .ToList();
+
+        return tags.Count == 0 ? null : tags;
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Expressions/ConditionConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Expressions/ConditionConverter.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Expressions;
+
+/// <summary>
+/// Converts a <see cref="ConditionModel"/> into the Screenplay condition it corresponds to.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <remarks>
+/// Screenplay has no parentheses in conditions, so a nested tree flattens when printed. Only a left associative
+/// tree survives a round trip with its meaning intact.
+/// </remarks>
+public class ConditionConverter(IScreenplayNaming naming)
+{
+    readonly MappingSourceConverter _sources = new(naming);
+
+    /// <summary>
+    /// Converts a condition.
+    /// </summary>
+    /// <param name="condition">The condition to convert.</param>
+    /// <returns>The <see cref="ConditionSyntax"/>, or <see langword="null"/> when there is none.</returns>
+    public ConditionSyntax? Convert(ConditionModel? condition) => condition switch
+    {
+        ComparisonCondition comparison => new ComparisonConditionSyntax(
+            naming.ToPropertyPath(comparison.Left),
+            ToOperator(comparison.Operator),
+            _sources.Convert(comparison.Right),
+            SourceLocation.Start),
+        LogicalCondition logical when Convert(logical.Left) is { } left && Convert(logical.Right) is { } right =>
+            new LogicalConditionSyntax(
+                left,
+                logical.IsOr ? LogicalOperator.Or : LogicalOperator.And,
+                right,
+                SourceLocation.Start),
+        _ => null
+    };
+
+    /// <summary>
+    /// Converts the comparison a condition makes.
+    /// </summary>
+    /// <param name="kind">The comparison to convert.</param>
+    /// <returns>The <see cref="ComparisonOperator"/>.</returns>
+    static ComparisonOperator ToOperator(ComparisonKind kind) => kind switch
+    {
+        ComparisonKind.NotEqual => ComparisonOperator.NotEqual,
+        ComparisonKind.GreaterThan => ComparisonOperator.GreaterThan,
+        ComparisonKind.GreaterThanOrEqual => ComparisonOperator.GreaterThanOrEqual,
+        ComparisonKind.LessThan => ComparisonOperator.LessThan,
+        ComparisonKind.LessThanOrEqual => ComparisonOperator.LessThanOrEqual,
+        _ => ComparisonOperator.Equal
+    };
+}

--- a/Source/DotNET/Screenplay/Emission/Expressions/LiteralConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Expressions/LiteralConverter.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Expressions;
+
+/// <summary>
+/// Converts a constant value into a Screenplay literal.
+/// </summary>
+/// <remarks>
+/// Every number is converted to a <see cref="double"/> first. The printer formats anything else with the current
+/// culture, which emits a comma as the decimal separator on most of the world's machines and produces a document
+/// that no longer parses.
+/// </remarks>
+public static class LiteralConverter
+{
+    /// <summary>
+    /// Converts a constant value.
+    /// </summary>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="naming">The <see cref="IScreenplayNaming"/> used for sanitizing string content.</param>
+    /// <returns>The <see cref="LiteralExpressionSyntax"/>.</returns>
+    public static LiteralExpressionSyntax Convert(object? value, IScreenplayNaming naming) =>
+        new(ToPrintableValue(value, naming), SourceLocation.Start);
+
+    /// <summary>
+    /// Determines whether a value is numeric and therefore expressible as a Screenplay number.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <returns>True when the value is numeric.</returns>
+    public static bool IsNumeric(object? value) =>
+        value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal;
+
+    /// <summary>
+    /// Reduces a value to something the printer can render without losing it.
+    /// </summary>
+    /// <param name="value">The value to reduce.</param>
+    /// <param name="naming">The <see cref="IScreenplayNaming"/> used for sanitizing string content.</param>
+    /// <returns>The value to hand to the printer.</returns>
+    static object? ToPrintableValue(object? value, IScreenplayNaming naming) => value switch
+    {
+        null => null,
+        bool boolean => boolean,
+        string text => naming.ToStringLiteral(text) ?? string.Empty,
+        _ when IsNumeric(value) => System.Convert.ToDouble(value, CultureInfo.InvariantCulture),
+        _ => naming.ToStringLiteral(value.ToString()) ?? string.Empty
+    };
+}

--- a/Source/DotNET/Screenplay/Emission/Expressions/LiteralConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Expressions/LiteralConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Diagnostics;
 using Cratis.Screenplay.Syntax;
 
@@ -45,6 +46,10 @@ public static class LiteralConverter
     {
         null => null,
         bool boolean => boolean,
+
+        // A concept declares its members in lower camel case and a value referring to one is a string matching that
+        // form exactly, so the member goes through the same conversion the declaration was written with.
+        EnumValue member => naming.ToStringLiteral(naming.ToPropertyName(member.Member)) ?? string.Empty,
         string text => naming.ToStringLiteral(text) ?? string.Empty,
         _ when IsNumeric(value) => System.Convert.ToDouble(value, CultureInfo.InvariantCulture),
         _ => naming.ToStringLiteral(value.ToString()) ?? string.Empty

--- a/Source/DotNET/Screenplay/Emission/Expressions/MappingSourceConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Expressions/MappingSourceConverter.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Expressions;
+
+/// <summary>
+/// Converts a <see cref="MappingSourceModel"/> into the host language expression it corresponds to.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <remarks>
+/// This is the host expression grammar, which is what <c>produces</c> mappings, conditions and validation operands
+/// are parsed with. It is not the same grammar as the one inside a projection body - crossing the two produces
+/// output that does not compile.
+/// </remarks>
+public class MappingSourceConverter(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// Converts a mapping source.
+    /// </summary>
+    /// <param name="source">The source to convert.</param>
+    /// <returns>The <see cref="ExpressionSyntax"/>.</returns>
+    public ExpressionSyntax Convert(MappingSourceModel source) => source switch
+    {
+        PropertyPathSource path => new PathExpressionSyntax(naming.ToPropertyPath(path.Path), SourceLocation.Start),
+        ContextSource context => new ContextExpressionSyntax(naming.ToPropertyPath(context.Path), SourceLocation.Start),
+        LiteralSource literal => LiteralConverter.Convert(literal.Value, naming),
+        _ => LiteralConverter.Convert(null, naming)
+    };
+}

--- a/Source/DotNET/Screenplay/Emission/Files/SourceFilePaths.cs
+++ b/Source/DotNET/Screenplay/Emission/Files/SourceFilePaths.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Emission.Files;
+
+/// <summary>
+/// Resolves the path a <c>file</c> reference points at.
+/// </summary>
+/// <remarks>
+/// Analysis carries the real path from the syntax tree whenever it has one. When it does not - an artifact living
+/// in a referenced package has metadata but no source - the vertical slice convention, where the namespace mirrors
+/// the folder structure, is the closest thing to an answer.
+/// </remarks>
+public static class SourceFilePaths
+{
+    /// <summary>
+    /// The extension of a source file.
+    /// </summary>
+    public const string Extension = ".cs";
+
+    /// <summary>
+    /// Gets the conventional path of an artifact from the namespace it lives in.
+    /// </summary>
+    /// <param name="namespace">The namespace of the artifact.</param>
+    /// <param name="name">The name of the artifact.</param>
+    /// <returns>The relative path.</returns>
+    public static string Conventional(string @namespace, string name)
+    {
+        var folders = @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries).Skip(1);
+
+        return string.Join('/', folders.Append($"{name}{Extension}"));
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/IScreenplayEmitter.cs
+++ b/Source/DotNET/Screenplay/Emission/IScreenplayEmitter.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Emission;
+
+/// <summary>
+/// Defines a system that turns an application model into a Screenplay document.
+/// </summary>
+/// <remarks>
+/// This is the half of the generator that knows the Screenplay language. It sees only the model, never a
+/// compilation, which is what makes it exercisable by handing it records and reading back the document.
+/// </remarks>
+public interface IScreenplayEmitter
+{
+    /// <summary>
+    /// Emits the Screenplay document describing a model.
+    /// </summary>
+    /// <param name="model">The model to emit.</param>
+    /// <param name="options">The options to emit with.</param>
+    /// <returns>The <see cref="ScreenplayEmission"/>.</returns>
+    ScreenplayEmission Emit(ApplicationModel model, ScreenplayOptions options);
+}

--- a/Source/DotNET/Screenplay/Emission/Naming/IScreenplayNaming.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/IScreenplayNaming.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Emission.Naming;
+
+/// <summary>
+/// Defines a system that converts model names and free text into forms the Screenplay language accepts.
+/// </summary>
+/// <remarks>
+/// The Screenplay printer performs no escaping and no case conversion. Every name and every string that ends up in
+/// the output must therefore be normalized before a syntax node is constructed.
+/// </remarks>
+public interface IScreenplayNaming
+{
+    /// <summary>
+    /// Converts a member name to the lower camel case form required for property, parameter and mapping names.
+    /// </summary>
+    /// <param name="name">The name to convert.</param>
+    /// <returns>The camel cased name.</returns>
+    string ToPropertyName(string name);
+
+    /// <summary>
+    /// Converts a dotted member path to the lower camel case form, one segment at a time.
+    /// </summary>
+    /// <param name="path">The path to convert.</param>
+    /// <returns>The camel cased path.</returns>
+    string ToPropertyPath(string path);
+
+    /// <summary>
+    /// Converts a type name to the identifier form required for declaration names.
+    /// </summary>
+    /// <param name="name">The name to convert.</param>
+    /// <returns>The sanitized identifier.</returns>
+    string ToDeclarationName(string name);
+
+    /// <summary>
+    /// Removes every character that would make a Screenplay string literal fail to parse.
+    /// </summary>
+    /// <param name="value">The value to sanitize.</param>
+    /// <returns>The sanitized value, or <see langword="null"/> when nothing is left.</returns>
+    string? ToStringLiteral(string? value);
+
+    /// <summary>
+    /// Converts a source file path into the form a <c>file</c> reference accepts.
+    /// </summary>
+    /// <param name="path">The path to convert.</param>
+    /// <returns>The sanitized path, or <see langword="null"/> when nothing is left.</returns>
+    string? ToFilePath(string? path);
+}

--- a/Source/DotNET/Screenplay/Emission/Naming/NameAvailability.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/NameAvailability.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Emission.Naming;
+
+/// <summary>
+/// Decides whether a name can be written where it is going, and reports every one that cannot.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> the name is written through.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything left out is reported to.</param>
+/// <remarks>
+/// A line whose first word is a word the enclosing block reserves is read as that directive, so writing it produces
+/// a document that does not compile - or worse, one that compiles as something else entirely. The name cannot be
+/// escaped and cannot be changed without describing a member the application does not have, which leaves saying so
+/// and moving on as the only honest answer.
+/// </remarks>
+public class NameAvailability(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Gets whether a name can be written in a block, reporting it when it cannot.
+    /// </summary>
+    /// <param name="name">The name as the application declares it.</param>
+    /// <param name="reserved">The <see cref="ReservedWords"/> of the block the name is written in.</param>
+    /// <param name="declaringType">The type declaring the name, for use in diagnostics.</param>
+    /// <param name="location">Where the declaring type lives, for use in diagnostics.</param>
+    /// <returns>True when the name can be written, false when it was left out.</returns>
+    public bool Allows(string name, ReservedWords reserved, string declaringType, string? location)
+    {
+        var written = naming.ToPropertyName(name);
+        if (!reserved.Reserve(written))
+        {
+            return true;
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.NameReservedByGrammar,
+            $"'{name}' on '{declaringType}' is written as '{written}', which a {reserved.Block} block reads as its own '{written}' directive rather than as a name, so it was left out",
+            location);
+
+        return false;
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Naming/ReservedWords.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/ReservedWords.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Emission.Naming;
+
+/// <summary>
+/// Represents the words a Screenplay block reads as a directive of its own rather than as a name.
+/// </summary>
+/// <param name="Block">The block the words belong to, named as the language names it.</param>
+/// <param name="Words">The words the block reserves, in the lower camel case form names are written in.</param>
+/// <remarks>
+/// Screenplay is line based and every block decides what a line is from its first word. A generated name that
+/// happens to be one of those words is therefore read as the directive it names, never as a name, and the language
+/// offers nothing to escape it with. The sets below are read from the parsers of the language and are the only
+/// reason a generated name is ever left out of a block it would otherwise belong in.
+/// </remarks>
+public record ReservedWords(string Block, IReadOnlySet<string> Words)
+{
+    /// <summary>
+    /// The words the body of a <c>command</c> reads as a directive.
+    /// </summary>
+    public static readonly ReservedWords InCommand = new(
+        "command",
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "authorize",
+            "concurrency",
+            "description",
+            "handler",
+            "produces",
+            "validate"
+        });
+
+    /// <summary>
+    /// The words the body of an <c>event</c> reads as a directive.
+    /// </summary>
+    public static readonly ReservedWords InEvent = new("event", new HashSet<string>(StringComparer.Ordinal) { "tag" });
+
+    /// <summary>
+    /// The words the body of a <c>produces</c> block reads as a directive.
+    /// </summary>
+    public static readonly ReservedWords InProduces = new("produces", new HashSet<string>(StringComparer.Ordinal) { "tag" });
+
+    /// <summary>
+    /// The words the body of a projection <c>from</c> block reads as a directive.
+    /// </summary>
+    public static readonly ReservedWords InFrom = new(
+        "from",
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "key",
+            "parent"
+        });
+
+    /// <summary>
+    /// The words the body of a <c>concept</c> reads as a directive.
+    /// </summary>
+    public static readonly ReservedWords InConcept = new("concept", new HashSet<string>(StringComparer.Ordinal) { "validate" });
+
+    /// <summary>
+    /// The words no block reserves, used where a name is written somewhere nothing is dispatched on it.
+    /// </summary>
+    public static readonly ReservedWords None = new(string.Empty, new HashSet<string>(StringComparer.Ordinal));
+
+    /// <summary>
+    /// Gets whether the block reads a name as a directive rather than as a name.
+    /// </summary>
+    /// <param name="name">The name as it would be written.</param>
+    /// <returns>True when the block reserves the name, false otherwise.</returns>
+    public bool Reserve(string name) => Words.Contains(name);
+}

--- a/Source/DotNET/Screenplay/Emission/Naming/ScreenplayIdentifier.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/ScreenplayIdentifier.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+
+namespace Cratis.Arc.Screenplay.Emission.Naming;
+
+/// <summary>
+/// Answers whether a value can be written to the document as a bare word rather than as a quoted string.
+/// </summary>
+public static partial class ScreenplayIdentifier
+{
+    /// <summary>
+    /// The prefix marking a value as a key into the companion strings file rather than as literal text.
+    /// </summary>
+    public const string LocalizationPrefix = "$strings.";
+
+    /// <summary>
+    /// Determines whether a value is a bare identifier.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <returns>True when the value can be written without quotes.</returns>
+    public static bool IsBareIdentifier(string? value) => !string.IsNullOrEmpty(value) && BareIdentifier().IsMatch(value);
+
+    /// <summary>
+    /// Determines whether a message is a localization key rather than literal text.
+    /// </summary>
+    /// <param name="message">The message to check.</param>
+    /// <returns>True when the message is a localization key.</returns>
+    public static bool IsLocalizationKey(string? message) =>
+        message?.StartsWith(LocalizationPrefix, StringComparison.Ordinal) == true;
+
+    /// <summary>
+    /// Gets the pattern a bare identifier has to match.
+    /// </summary>
+    /// <returns>The compiled regular expression.</returns>
+    [GeneratedRegex(@"^[A-Za-z_]\w*$", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex BareIdentifier();
+}

--- a/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
@@ -73,7 +73,7 @@ public class ScreenplayNaming : IScreenplayNaming
             return null;
         }
 
-        var sanitized = value.Replace(Quote, '\'').Trim();
+        var sanitized = OnOneLine(value.Replace(Quote, '\''));
 
         return sanitized.Length == 0 ? null : sanitized;
     }
@@ -86,9 +86,44 @@ public class ScreenplayNaming : IScreenplayNaming
             return null;
         }
 
-        var sanitized = path.Replace('\\', '/').Replace(Quote, '\'').Trim();
+        var sanitized = OnOneLine(path.Replace('\\', '/').Replace(Quote, '\''));
 
         return sanitized.Length == 0 ? null : sanitized;
+    }
+
+    /// <summary>
+    /// Reduces a value to the single line every Screenplay construct is written on.
+    /// </summary>
+    /// <param name="value">The value to reduce.</param>
+    /// <returns>The value on one line.</returns>
+    /// <remarks>
+    /// The language is line based and the printer never escapes, so a line break inside a string literal ends the
+    /// construct halfway through and everything after it is read as a new declaration - a document that does not
+    /// compile. Every run of whitespace, control character included, therefore becomes a single space.
+    /// </remarks>
+    static string OnOneLine(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        var separated = false;
+
+        foreach (var character in value)
+        {
+            if (char.IsWhiteSpace(character) || char.IsControl(character))
+            {
+                separated = builder.Length > 0;
+                continue;
+            }
+
+            if (separated)
+            {
+                builder.Append(' ');
+                separated = false;
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Cratis.Arc.Screenplay.Emission.Naming;
+
+/// <summary>
+/// Represents an implementation of <see cref="IScreenplayNaming"/>.
+/// </summary>
+public class ScreenplayNaming : IScreenplayNaming
+{
+    /// <summary>
+    /// The character the Screenplay printer cannot escape inside a string literal.
+    /// </summary>
+    public const char Quote = '"';
+
+    /// <summary>
+    /// The name used for a property whose own name yields nothing usable.
+    /// </summary>
+    public const string DefaultPropertyName = "value";
+
+    /// <inheritdoc/>
+    public string ToPropertyName(string name)
+    {
+        var identifier = Sanitize(name);
+        if (identifier.Length == 0)
+        {
+            return DefaultPropertyName;
+        }
+
+        var builder = new StringBuilder(identifier);
+        for (var index = 0; index < builder.Length; index++)
+        {
+            if (!char.IsUpper(builder[index]))
+            {
+                break;
+            }
+
+            // Preserve the casing of an acronym's final character when it starts a new word - "ISBNValue" becomes "isbnValue".
+            if (index > 0 && index + 1 < builder.Length && !char.IsUpper(builder[index + 1]))
+            {
+                break;
+            }
+
+            builder[index] = char.ToLowerInvariant(builder[index]);
+        }
+
+        var result = builder.ToString();
+
+        return char.IsDigit(result[0]) ? $"_{result}" : result;
+    }
+
+    /// <inheritdoc/>
+    public string ToPropertyPath(string path) =>
+        string.IsNullOrWhiteSpace(path)
+            ? DefaultPropertyName
+            : string.Join('.', path.Split('.', StringSplitOptions.RemoveEmptyEntries).Select(ToPropertyName));
+
+    /// <inheritdoc/>
+    public string ToDeclarationName(string name)
+    {
+        var identifier = Sanitize(name);
+
+        return identifier.Length == 0 || char.IsDigit(identifier[0]) ? $"_{identifier}" : identifier;
+    }
+
+    /// <inheritdoc/>
+    public string? ToStringLiteral(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var sanitized = value.Replace(Quote, '\'').Trim();
+
+        return sanitized.Length == 0 ? null : sanitized;
+    }
+
+    /// <inheritdoc/>
+    public string? ToFilePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var sanitized = path.Replace('\\', '/').Replace(Quote, '\'').Trim();
+
+        return sanitized.Length == 0 ? null : sanitized;
+    }
+
+    /// <summary>
+    /// Strips everything that is not a valid identifier character, including generic type arity suffixes.
+    /// </summary>
+    /// <param name="name">The name to sanitize.</param>
+    /// <returns>The sanitized name.</returns>
+    static string Sanitize(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return string.Empty;
+        }
+
+        var backTick = name.IndexOf('`', StringComparison.Ordinal);
+        var candidate = backTick > 0 ? name[..backTick] : name;
+        var builder = new StringBuilder(candidate.Length);
+
+        foreach (var character in candidate)
+        {
+            if (char.IsLetterOrDigit(character) || character == '_')
+            {
+                builder.Append(character);
+            }
+        }
+
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Policies/AuthorizeSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/AuthorizeSyntaxBuilder.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Policies;
+
+/// <summary>
+/// Builds the Screenplay <c>authorize</c> block for a command or a query, recording every policy it references.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <remarks>
+/// The references are recorded so that the document can declare every policy it uses. A document referencing a
+/// policy it never declares still compiles, but it compiles with a warning, and a generated document that warns is
+/// a generated document nobody trusts.
+/// </remarks>
+public class AuthorizeSyntaxBuilder(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// The name of the policy requiring nothing but an authenticated caller.
+    /// </summary>
+    public const string AuthenticatedPolicy = "Authenticated";
+
+    readonly HashSet<string> _referenced = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets every policy referenced so far.
+    /// </summary>
+    public IEnumerable<string> Referenced => _referenced;
+
+    /// <summary>
+    /// Builds the authorize block for what an artifact requires of the caller.
+    /// </summary>
+    /// <param name="authorization">What the artifact requires, if anything.</param>
+    /// <returns>The <see cref="AuthorizeSyntax"/>, or <see langword="null"/> when nothing is required.</returns>
+    public AuthorizeSyntax? Build(AuthorizationModel? authorization)
+    {
+        if (authorization?.RequiresAuthentication != true)
+        {
+            return null;
+        }
+
+        var policies = authorization.Roles
+            .Select(naming.ToDeclarationName)
+            .Where(_ => _.Length > 1)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        if (policies.Count == 0)
+        {
+            policies.Add(AuthenticatedPolicy);
+        }
+
+        foreach (var policy in policies)
+        {
+            _referenced.Add(policy);
+        }
+
+        return new(
+            [.. policies.Select((policy, index) => new PolicyReferenceSyntax(policy, index > 0, SourceLocation.Start))],
+            SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Policies/AuthorizeSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/AuthorizeSyntaxBuilder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Arc.Screenplay.Emission.Naming;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Diagnostics;
 using Cratis.Screenplay.Syntax;
@@ -11,13 +10,16 @@ namespace Cratis.Arc.Screenplay.Emission.Policies;
 /// <summary>
 /// Builds the Screenplay <c>authorize</c> block for a command or a query, recording every policy it references.
 /// </summary>
-/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
 /// <remarks>
 /// The references are recorded so that the document can declare every policy it uses. A document referencing a
 /// policy it never declares still compiles, but it compiles with a warning, and a generated document that warns is
 /// a generated document nobody trusts.
+/// <para>
+/// Roles are alternatives to each other - holding any one of them is enough - while a named policy is an additional
+/// demand, so roles are combined with <c>or</c> and policies follow them without one.
+/// </para>
 /// </remarks>
-public class AuthorizeSyntaxBuilder(IScreenplayNaming naming)
+public class AuthorizeSyntaxBuilder
 {
     /// <summary>
     /// The name of the policy requiring nothing but an authenticated caller.
@@ -43,25 +45,38 @@ public class AuthorizeSyntaxBuilder(IScreenplayNaming naming)
             return null;
         }
 
-        var policies = authorization.Roles
-            .Select(naming.ToDeclarationName)
-            .Where(_ => _.Length > 1)
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-            .ToList();
+        var roles = Named(authorization.Roles);
+        var named = Named(authorization.Policies).Where(_ => !roles.Contains(_)).ToList();
 
-        if (policies.Count == 0)
+        if (roles.Count == 0 && named.Count == 0)
         {
-            policies.Add(AuthenticatedPolicy);
+            named.Add(AuthenticatedPolicy);
         }
 
-        foreach (var policy in policies)
+        foreach (var policy in roles.Concat(named))
         {
             _referenced.Add(policy);
         }
 
         return new(
-            [.. policies.Select((policy, index) => new PolicyReferenceSyntax(policy, index > 0, SourceLocation.Start))],
+            [
+                .. roles.Select((role, index) => new PolicyReferenceSyntax(role, index > 0, SourceLocation.Start)),
+                .. named.Select(policy => new PolicyReferenceSyntax(policy, false, SourceLocation.Start))
+            ],
             SourceLocation.Start);
     }
+
+    /// <summary>
+    /// Converts names into the form a policy reference takes, leaving out anything nothing is left of.
+    /// </summary>
+    /// <param name="names">The names to convert.</param>
+    /// <returns>The names, distinct and ordered.</returns>
+    static List<string> Named(IEnumerable<string> names) =>
+    [
+        .. names
+            .Select(PolicyNames.For)
+            .Where(_ => _.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+    ];
 }

--- a/Source/DotNET/Screenplay/Emission/Policies/PolicyConditionConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/PolicyConditionConverter.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Policies;
+
+/// <summary>
+/// Converts what a policy requires into the condition expressing it.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+public class PolicyConditionConverter(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// Converts a requirement into the condition expressing it.
+    /// </summary>
+    /// <param name="requirement">The requirement to convert, if any.</param>
+    /// <returns>The condition, never <see langword="null"/>.</returns>
+    /// <remarks>
+    /// A policy has to require something - the grammar has no empty policy - so a requirement that was never
+    /// recovered becomes the least the reference itself implies, which is that somebody is there at all. The
+    /// analysis reports it rather than letting the document present the fallback as what the application says.
+    /// </remarks>
+    public PolicyConditionSyntax Convert(PolicyRequirementModel? requirement) =>
+        Read(requirement) ?? new AuthenticatedConditionSyntax(SourceLocation.Start);
+
+    /// <summary>
+    /// Converts a requirement, yielding nothing when nothing of it survives.
+    /// </summary>
+    /// <param name="requirement">The requirement to convert.</param>
+    /// <returns>The condition, or <see langword="null"/>.</returns>
+    PolicyConditionSyntax? Read(PolicyRequirementModel? requirement) => requirement switch
+    {
+        AuthenticatedRequirement => new AuthenticatedConditionSyntax(SourceLocation.Start),
+        RoleRequirement role => Role(role.Role),
+        ClaimRequirement claim => Claim(claim),
+        CombinedRequirement combined => Combine(combined),
+        _ => null
+    };
+
+    /// <summary>
+    /// Converts a role requirement.
+    /// </summary>
+    /// <param name="role">The name of the role.</param>
+    /// <returns>The condition, or <see langword="null"/> when the name cannot be written.</returns>
+    RoleConditionSyntax? Role(string role) =>
+        naming.ToStringLiteral(role) is { } name ? new RoleConditionSyntax(name, SourceLocation.Start) : null;
+
+    /// <summary>
+    /// Converts a claim requirement.
+    /// </summary>
+    /// <param name="claim">The requirement to convert.</param>
+    /// <returns>The condition, or <see langword="null"/> when either part cannot be written.</returns>
+    ClaimConditionSyntax? Claim(ClaimRequirement claim) =>
+        naming.ToStringLiteral(claim.Claim) is { } name && naming.ToStringLiteral(claim.Value) is { } value
+            ? new ClaimConditionSyntax(name, false, value, SourceLocation.Start)
+            : null;
+
+    /// <summary>
+    /// Converts two combined requirements, keeping whichever side survives on its own.
+    /// </summary>
+    /// <param name="combined">The requirement to convert.</param>
+    /// <returns>The condition, or <see langword="null"/> when neither side survives.</returns>
+    PolicyConditionSyntax? Combine(CombinedRequirement combined)
+    {
+        var left = Read(combined.Left);
+        var right = Read(combined.Right);
+
+        if (left is null || right is null)
+        {
+            return left ?? right;
+        }
+
+        return new LogicalPolicyConditionSyntax(
+            left,
+            combined.IsOr ? LogicalOperator.Or : LogicalOperator.And,
+            right,
+            SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Policies/PolicyNames.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/PolicyNames.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Cratis.Arc.Screenplay.Emission.Policies;
+
+/// <summary>
+/// Converts what an application calls a policy into what the document can refer to it as.
+/// </summary>
+/// <remarks>
+/// The grammar accepts a policy reference only as a Pascal cased identifier, while an application is free to name a
+/// role or a policy anything at all - <c>can-reserve</c>, <c>reader</c>, <c>Reservations.Approve</c>. Everything an
+/// identifier cannot hold is therefore treated as the boundary between two words, so the name reads the way it was
+/// written rather than running together. Every reference and every declaration goes through here, so the two always
+/// agree and the document never refers to a policy it does not declare.
+/// </remarks>
+public static class PolicyNames
+{
+    /// <summary>
+    /// The shortest name the grammar accepts as a policy reference.
+    /// </summary>
+    public const int MinimumLength = 2;
+
+    /// <summary>
+    /// Converts a name into the form a policy reference takes.
+    /// </summary>
+    /// <param name="name">The name to convert.</param>
+    /// <returns>The converted name, empty when nothing the grammar accepts is left.</returns>
+    public static string For(string? name)
+    {
+        var identifier = new StringBuilder();
+        var startsWord = true;
+
+        foreach (var character in name ?? string.Empty)
+        {
+            if (!char.IsLetterOrDigit(character))
+            {
+                startsWord = true;
+                continue;
+            }
+
+            identifier.Append(startsWord ? char.ToUpperInvariant(character) : character);
+            startsWord = false;
+        }
+
+        var converted = identifier.ToString().Normalize(NormalizationForm.FormC);
+
+        return converted.Length < MinimumLength || !char.IsAsciiLetterUpper(converted[0]) ? string.Empty : converted;
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Policies/PolicySyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/PolicySyntaxBuilder.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Policies;
+
+/// <summary>
+/// Builds the document level <c>policy</c> declarations.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+public class PolicySyntaxBuilder(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// Builds every policy the document declares.
+    /// </summary>
+    /// <param name="declared">The policies the model declares.</param>
+    /// <param name="referenced">The policies the emitted authorize blocks reference.</param>
+    /// <returns>The policy declarations, ordered by name.</returns>
+    /// <remarks>
+    /// A policy referenced by an artifact but not declared by the model is synthesized as a role policy, so that the
+    /// document is always self consistent. The one exception is the well known authenticated policy, which requires
+    /// nothing but a caller.
+    /// </remarks>
+    public IEnumerable<PolicySyntax> Build(IEnumerable<PolicyModel> declared, IEnumerable<string> referenced)
+    {
+        var policies = new Dictionary<string, PolicySyntax>(StringComparer.Ordinal);
+
+        foreach (var policy in declared)
+        {
+            var name = naming.ToDeclarationName(policy.Name);
+            if (name.Length <= 1 || policies.ContainsKey(name))
+            {
+                continue;
+            }
+
+            policies[name] = new(name, ToCondition(policy), null, SourceLocation.Start);
+        }
+
+        foreach (var name in referenced.Where(_ => !policies.ContainsKey(_)))
+        {
+            policies[name] = new(name, Synthesize(name), null, SourceLocation.Start);
+        }
+
+        return [.. policies.Values.OrderBy(_ => _.Name, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Synthesizes the condition of a policy that is referenced but never declared.
+    /// </summary>
+    /// <param name="name">The name of the policy.</param>
+    /// <returns>The condition.</returns>
+    static PolicyConditionSyntax Synthesize(string name) =>
+        string.Equals(name, AuthorizeSyntaxBuilder.AuthenticatedPolicy, StringComparison.Ordinal)
+            ? new AuthenticatedConditionSyntax(SourceLocation.Start)
+            : new RoleConditionSyntax(name, SourceLocation.Start);
+
+    /// <summary>
+    /// Converts what a declared policy requires into the condition expressing it.
+    /// </summary>
+    /// <param name="policy">The policy to convert.</param>
+    /// <returns>The condition.</returns>
+    /// <remarks>
+    /// A policy declaring a role implies an authenticated caller, so the role alone is emitted rather than the two
+    /// combined - the flattened form would read as if the two were independent.
+    /// </remarks>
+    PolicyConditionSyntax ToCondition(PolicyModel policy)
+    {
+        var role = policy.Role is null ? string.Empty : naming.ToDeclarationName(policy.Role);
+
+        return role.Length > 1
+            ? new RoleConditionSyntax(role, SourceLocation.Start)
+            : new AuthenticatedConditionSyntax(SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Policies/PolicySyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/PolicySyntaxBuilder.cs
@@ -14,6 +14,8 @@ namespace Cratis.Arc.Screenplay.Emission.Policies;
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
 public class PolicySyntaxBuilder(IScreenplayNaming naming)
 {
+    readonly PolicyConditionConverter _conditions = new(naming);
+
     /// <summary>
     /// Builds every policy the document declares.
     /// </summary>
@@ -31,13 +33,13 @@ public class PolicySyntaxBuilder(IScreenplayNaming naming)
 
         foreach (var policy in declared)
         {
-            var name = naming.ToDeclarationName(policy.Name);
-            if (name.Length <= 1 || policies.ContainsKey(name))
+            var name = PolicyNames.For(policy.Name);
+            if (name.Length == 0 || policies.ContainsKey(name))
             {
                 continue;
             }
 
-            policies[name] = new(name, ToCondition(policy), null, SourceLocation.Start);
+            policies[name] = new(name, _conditions.Convert(policy.Requirement), null, SourceLocation.Start);
         }
 
         foreach (var name in referenced.Where(_ => !policies.ContainsKey(_)))
@@ -57,22 +59,4 @@ public class PolicySyntaxBuilder(IScreenplayNaming naming)
         string.Equals(name, AuthorizeSyntaxBuilder.AuthenticatedPolicy, StringComparison.Ordinal)
             ? new AuthenticatedConditionSyntax(SourceLocation.Start)
             : new RoleConditionSyntax(name, SourceLocation.Start);
-
-    /// <summary>
-    /// Converts what a declared policy requires into the condition expressing it.
-    /// </summary>
-    /// <param name="policy">The policy to convert.</param>
-    /// <returns>The condition.</returns>
-    /// <remarks>
-    /// A policy declaring a role implies an authenticated caller, so the role alone is emitted rather than the two
-    /// combined - the flattened form would read as if the two were independent.
-    /// </remarks>
-    PolicyConditionSyntax ToCondition(PolicyModel policy)
-    {
-        var role = policy.Role is null ? string.Empty : naming.ToDeclarationName(policy.Role);
-
-        return role.Length > 1
-            ? new RoleConditionSyntax(role, SourceLocation.Start)
-            : new AuthenticatedConditionSyntax(SourceLocation.Start);
-    }
 }

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionBlockConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionBlockConverter.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.Emission.Projections;
+
+/// <summary>
+/// Converts the scopes of a projection into Screenplay projection blocks.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="readModelName">The name of the read model, used when a composite key carries no type name.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <param name="location">Where the projection lives, for use in diagnostics.</param>
+public class ProjectionBlockConverter(
+    IScreenplayNaming naming,
+    string readModelName,
+    ScreenplayDiagnostics diagnostics,
+    string location)
+{
+    readonly ProjectionMappingConverter _mappings = new(naming, diagnostics, location);
+    readonly ProjectionJoinConverter _joins = new(naming, new(naming, diagnostics, location), diagnostics, location);
+
+    /// <summary>
+    /// Converts the model's auto map setting into the Screenplay one.
+    /// </summary>
+    /// <param name="autoMap">The model setting.</param>
+    /// <returns>The Screenplay setting.</returns>
+    public static AutoMapMode ToAutoMapMode(ProjectionAutoMapMode autoMap) => autoMap switch
+    {
+        ProjectionAutoMapMode.Disabled => AutoMapMode.Disabled,
+        ProjectionAutoMapMode.Enabled => AutoMapMode.Enabled,
+        _ => AutoMapMode.Inherit
+    };
+
+    /// <summary>
+    /// Converts a scope into the blocks it declares.
+    /// </summary>
+    /// <param name="scope">The scope to convert.</param>
+    /// <param name="subscribesToAllEvents">Whether the projection observes every event type in the system.</param>
+    /// <returns>The blocks, in a deterministic order.</returns>
+    public IEnumerable<ProjectionBlockSyntax> Convert(ProjectionScopeModel scope, bool subscribesToAllEvents = false)
+    {
+        var blocks = new List<ProjectionBlockSyntax>();
+
+        AddEveryOrAll(blocks, scope.Every, subscribesToAllEvents);
+        blocks.AddRange(scope.From.Select(ToFrom));
+        blocks.AddRange(_joins.Convert(scope.Joins));
+        blocks.AddRange(ToChildren(scope.Children));
+        blocks.AddRange(ToNested(scope.Nested));
+        blocks.AddRange(scope.RemovedWith.Select(ToRemoveWith));
+        blocks.AddRange(scope.RemovedWithJoin.Select(ToRemoveViaJoin));
+
+        return blocks;
+    }
+
+    /// <summary>
+    /// Reduces a key back to a plain expression, which is all the removal blocks accept.
+    /// </summary>
+    /// <param name="key">The key to reduce.</param>
+    /// <returns>The expression, or <see langword="null"/>.</returns>
+    static ExpressionSyntax? ToExpression(KeySyntax? key) =>
+        key is ExpressionKeySyntax expressionKey ? expressionKey.Expression : null;
+
+    /// <summary>
+    /// Adds the <c>every</c> or <c>all</c> block when the scope declares one.
+    /// </summary>
+    /// <param name="blocks">The blocks collected so far.</param>
+    /// <param name="every">The block to add.</param>
+    /// <param name="subscribesToAllEvents">Whether the projection observes every event type in the system.</param>
+    void AddEveryOrAll(List<ProjectionBlockSyntax> blocks, ProjectionEveryModel? every, bool subscribesToAllEvents)
+    {
+        if (every is null)
+        {
+            return;
+        }
+
+        var mappings = _mappings.Convert(every.Properties);
+        var autoMap = ToAutoMapMode(every.AutoMap);
+
+        blocks.Add(subscribesToAllEvents
+            ? new AllSyntax(mappings, autoMap, SourceLocation.Start)
+            : new EverySyntax(mappings, every.IncludeChildren, autoMap, SourceLocation.Start));
+    }
+
+    /// <summary>
+    /// Converts a block observing specific event types.
+    /// </summary>
+    /// <param name="from">The block to convert.</param>
+    /// <returns>The <see cref="FromSyntax"/>.</returns>
+    FromSyntax ToFrom(ProjectionFromModel from) =>
+        new(
+            [.. from.EventTypes.Select(_ => new EventSpecSyntax(naming.ToDeclarationName(_), null, SourceLocation.Start))],
+            ConvertKey(from.Key),
+            ProjectionKeyConverter.ConvertParent(from.ParentKey),
+            _mappings.Convert(from.Properties),
+            SourceLocation.Start);
+
+    /// <summary>
+    /// Converts a key, reporting one that could not be expressed rather than silently falling back to the default.
+    /// </summary>
+    /// <param name="key">The key expression to convert.</param>
+    /// <returns>The <see cref="KeySyntax"/>, or <see langword="null"/> when the default key applies.</returns>
+    KeySyntax? ConvertKey(string? key)
+    {
+        var converted = ProjectionKeyConverter.Convert(key, readModelName);
+        if (converted is null && !ProjectionKeyConverter.IsDefault(key))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionKey,
+                $"The key '{key}' has no counterpart in the projection definition language, so the event source id is used instead",
+                location);
+        }
+
+        return converted;
+    }
+
+    /// <summary>
+    /// Converts the child collections of a scope, leaving out any that would produce an empty body.
+    /// </summary>
+    /// <param name="children">The child scopes to convert.</param>
+    /// <returns>The <see cref="ChildrenSyntax"/> blocks.</returns>
+    IEnumerable<ProjectionBlockSyntax> ToChildren(IEnumerable<ProjectionChildScopeModel> children)
+    {
+        foreach (var child in children)
+        {
+            var blocks = Convert(child.Scope).ToList();
+            if (blocks.Count == 0 || !ProjectionExpressionConverter.TryConvert(child.IdentifiedBy, out var identifiedBy))
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableProjectionScope,
+                    $"The children of '{child.Property}' declare nothing expressible, or are identified by '{child.IdentifiedBy}' which has no counterpart in the projection definition language",
+                    location);
+                continue;
+            }
+
+            yield return new ChildrenSyntax(
+                naming.ToPropertyName(child.Property),
+                identifiedBy,
+                ToAutoMapMode(child.AutoMap),
+                blocks,
+                SourceLocation.Start);
+        }
+    }
+
+    /// <summary>
+    /// Converts the nested objects of a scope, leaving out any without a from block since those do not compile.
+    /// </summary>
+    /// <param name="nested">The nested scopes to convert.</param>
+    /// <returns>The <see cref="NestedSyntax"/> blocks.</returns>
+    IEnumerable<ProjectionBlockSyntax> ToNested(IEnumerable<ProjectionChildScopeModel> nested)
+    {
+        foreach (var child in nested)
+        {
+            var blocks = Convert(child.Scope).ToList();
+            if (!blocks.OfType<FromSyntax>().Any())
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableProjectionScope,
+                    $"The nested object '{child.Property}' observes no event type and was left out",
+                    location);
+                continue;
+            }
+
+            yield return new NestedSyntax(
+                naming.ToPropertyName(child.Property),
+                ToAutoMapMode(child.AutoMap),
+                blocks,
+                SourceLocation.Start);
+        }
+    }
+
+    /// <summary>
+    /// Converts a removal block.
+    /// </summary>
+    /// <param name="remove">The block to convert.</param>
+    /// <returns>The <see cref="RemoveWithSyntax"/>.</returns>
+    RemoveWithSyntax ToRemoveWith(ProjectionRemoveModel remove) =>
+        new(
+            naming.ToDeclarationName(remove.EventType),
+            ToExpression(ConvertKey(remove.Key)),
+            ProjectionKeyConverter.ConvertParent(remove.ParentKey),
+            SourceLocation.Start);
+
+    /// <summary>
+    /// Converts a removal block that goes through a join.
+    /// </summary>
+    /// <param name="remove">The block to convert.</param>
+    /// <returns>The <see cref="RemoveViaJoinSyntax"/>.</returns>
+    RemoveViaJoinSyntax ToRemoveViaJoin(ProjectionRemoveModel remove) =>
+        new(
+            naming.ToDeclarationName(remove.EventType),
+            ToExpression(ConvertKey(remove.Key)),
+            SourceLocation.Start);
+}

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionBlockConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionBlockConverter.cs
@@ -16,14 +16,16 @@ namespace Cratis.Arc.Screenplay.Emission.Projections;
 /// <param name="readModelName">The name of the read model, used when a composite key carries no type name.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+/// <param name="names">The <see cref="NameAvailability"/> deciding which properties a block can map onto.</param>
 public class ProjectionBlockConverter(
     IScreenplayNaming naming,
     string readModelName,
     ScreenplayDiagnostics diagnostics,
-    string location)
+    string location,
+    NameAvailability names)
 {
-    readonly ProjectionMappingConverter _mappings = new(naming, diagnostics, location);
-    readonly ProjectionJoinConverter _joins = new(naming, new(naming, diagnostics, location), diagnostics, location);
+    readonly ProjectionMappingConverter _mappings = new(naming, diagnostics, location, readModelName, names);
+    readonly ProjectionJoinConverter _joins = new(naming, new(naming, diagnostics, location, readModelName, names), diagnostics, location);
 
     /// <summary>
     /// Converts the model's auto map setting into the Screenplay one.
@@ -79,7 +81,7 @@ public class ProjectionBlockConverter(
             return;
         }
 
-        var mappings = _mappings.Convert(every.Properties);
+        var mappings = _mappings.Convert(every.Properties, ReservedWords.None);
         var autoMap = ToAutoMapMode(every.AutoMap);
 
         blocks.Add(subscribesToAllEvents
@@ -97,7 +99,7 @@ public class ProjectionBlockConverter(
             [.. from.EventTypes.Select(_ => new EventSpecSyntax(naming.ToDeclarationName(_), null, SourceLocation.Start))],
             ConvertKey(from.Key),
             ProjectionKeyConverter.ConvertParent(from.ParentKey),
-            _mappings.Convert(from.Properties),
+            _mappings.Convert(from.Properties, ReservedWords.InFrom),
             SourceLocation.Start);
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionExpressionConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionExpressionConverter.cs
@@ -39,6 +39,11 @@ public static partial class ProjectionExpressionConverter
     /// </summary>
     public const string ValuePrefix = "$value(";
 
+    /// <summary>
+    /// The prefix of the expression yielding a member of an enumeration.
+    /// </summary>
+    public const string EnumerationPrefix = "$enum(";
+
     static readonly string[] _eventContextPaths = ["occurred", "sequenceNumber", "correlationId", "eventSourceId"];
     static readonly string[] _causedByProperties = ["subject", "name", "userName"];
 
@@ -95,6 +100,14 @@ public static partial class ProjectionExpressionConverter
         if (expression.StartsWith(ValuePrefix, StringComparison.Ordinal) && expression.EndsWith(')'))
         {
             converted = ToLiteral(expression[ValuePrefix.Length..^1]);
+            return true;
+        }
+
+        // A member of an enumeration is a string naming it and nothing else, so it never goes through the guessing
+        // that turns a captured constant back into whichever kind it looks like.
+        if (expression.StartsWith(EnumerationPrefix, StringComparison.Ordinal) && expression.EndsWith(')'))
+        {
+            converted = new LiteralExpressionSyntax(expression[EnumerationPrefix.Length..^1], SourceLocation.Start);
             return true;
         }
 

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionExpressionConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionExpressionConverter.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.Emission.Projections;
+
+/// <summary>
+/// Converts the projection property expression mini language into Screenplay projection expressions.
+/// </summary>
+/// <remarks>
+/// Only the forms the projection definition language accepts are produced. Host expressions such as
+/// <c>$context.</c> or <c>$env.</c> are errors inside a projection body, so anything that cannot be expressed is
+/// reported as unconvertible and left out of the document.
+/// </remarks>
+public static partial class ProjectionExpressionConverter
+{
+    /// <summary>
+    /// The expression yielding the identifier of the event source an event belongs to.
+    /// </summary>
+    public const string EventSourceId = "$eventSourceId";
+
+    /// <summary>
+    /// The prefix of the expression yielding a value from the event context.
+    /// </summary>
+    public const string EventContextPrefix = "$eventContext(";
+
+    /// <summary>
+    /// The expression yielding the identity that caused an event.
+    /// </summary>
+    public const string CausedBy = "$causedBy";
+
+    /// <summary>
+    /// The prefix of the expression yielding a constant value.
+    /// </summary>
+    public const string ValuePrefix = "$value(";
+
+    static readonly string[] _eventContextPaths = ["occurred", "sequenceNumber", "correlationId", "eventSourceId"];
+    static readonly string[] _causedByProperties = ["subject", "name", "userName"];
+
+    /// <summary>
+    /// Converts a property expression into a Screenplay projection expression.
+    /// </summary>
+    /// <param name="expression">The expression to convert.</param>
+    /// <param name="converted">The converted expression.</param>
+    /// <returns>True when the expression has a projection definition language counterpart.</returns>
+    public static bool TryConvert(string expression, out ExpressionSyntax converted)
+    {
+        converted = null!;
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return false;
+        }
+
+        if (expression == EventSourceId)
+        {
+            converted = new EventSourceIdExpressionSyntax(SourceLocation.Start);
+            return true;
+        }
+
+        if (expression.StartsWith(EventContextPrefix, StringComparison.Ordinal) && expression.EndsWith(')'))
+        {
+            var path = expression[EventContextPrefix.Length..^1];
+            if (!_eventContextPaths.Contains(path, StringComparer.Ordinal))
+            {
+                return false;
+            }
+
+            converted = new EventContextExpressionSyntax(path, SourceLocation.Start);
+            return true;
+        }
+
+        if (expression == CausedBy)
+        {
+            converted = new CausedByExpressionSyntax(null, SourceLocation.Start);
+            return true;
+        }
+
+        if (expression.StartsWith($"{CausedBy}.", StringComparison.Ordinal))
+        {
+            var property = expression[(CausedBy.Length + 1)..];
+            if (!_causedByProperties.Contains(property, StringComparer.Ordinal))
+            {
+                return false;
+            }
+
+            converted = new CausedByExpressionSyntax(property, SourceLocation.Start);
+            return true;
+        }
+
+        if (expression.StartsWith(ValuePrefix, StringComparison.Ordinal) && expression.EndsWith(')'))
+        {
+            converted = ToLiteral(expression[ValuePrefix.Length..^1]);
+            return true;
+        }
+
+        if (expression.StartsWith('$') || !PathExpression().IsMatch(expression))
+        {
+            return false;
+        }
+
+        converted = new PathExpressionSyntax(expression, SourceLocation.Start);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Converts a captured constant into a Screenplay literal.
+    /// </summary>
+    /// <param name="value">The invariant string representation of the constant.</param>
+    /// <returns>The literal expression.</returns>
+    static LiteralExpressionSyntax ToLiteral(string value)
+    {
+        if (string.Equals(value, "null", StringComparison.Ordinal))
+        {
+            return new(null, SourceLocation.Start);
+        }
+
+        if (bool.TryParse(value, out var boolean))
+        {
+            return new(boolean, SourceLocation.Start);
+        }
+
+        // Every number has to be a double - the printer formats anything else with the current culture.
+        return double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var number)
+            ? new(number, SourceLocation.Start)
+            : new(value.Replace('"', '\''), SourceLocation.Start);
+    }
+
+    /// <summary>
+    /// Gets the pattern the projection definition language accepts for a property path.
+    /// </summary>
+    /// <returns>The compiled regular expression.</returns>
+    [GeneratedRegex(@"^@?[A-Za-z_]\w*(\.@?[A-Za-z_$]\w*)*$", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex PathExpression();
+}

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionJoinConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionJoinConverter.cs
@@ -64,6 +64,6 @@ public class ProjectionJoinConverter(
         new(
             naming.ToDeclarationName(join.EventType),
             AutoMapMode.Inherit,
-            mappings.Convert(join.Properties),
+            mappings.Convert(join.Properties, ReservedWords.None),
             SourceLocation.Start);
 }

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionJoinConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionJoinConverter.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.Emission.Projections;
+
+/// <summary>
+/// Converts the join blocks of a projection scope.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="mappings">The <see cref="ProjectionMappingConverter"/> used for the mapping lines.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <param name="location">Where the projection lives, for use in diagnostics.</param>
+/// <remarks>
+/// The grammar names the property a whole join fills in and the property it keys on, and lists the events joined
+/// from underneath, so every event sharing both properties has to be regrouped under a single block.
+/// </remarks>
+public class ProjectionJoinConverter(
+    IScreenplayNaming naming,
+    ProjectionMappingConverter mappings,
+    ScreenplayDiagnostics diagnostics,
+    string location)
+{
+    /// <summary>
+    /// Converts the join blocks of a scope.
+    /// </summary>
+    /// <param name="joins">The blocks to convert.</param>
+    /// <returns>The <see cref="JoinSyntax"/> blocks.</returns>
+    public IEnumerable<JoinSyntax> Convert(IEnumerable<ProjectionJoinModel> joins)
+    {
+        var declared = joins as IReadOnlyCollection<ProjectionJoinModel> ?? [.. joins];
+
+        foreach (var join in declared.Where(_ => _.On.Length == 0 || _.Property.Length == 0))
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionJoin,
+                $"The join from '{join.EventType}' declares no property to hold the joined data, or no property to key on, and was left out",
+                location);
+        }
+
+        return
+        [
+            .. declared
+                .Where(_ => _.On.Length > 0 && _.Property.Length > 0)
+                .GroupBy(_ => (_.Property, _.On))
+                .Select(group => new JoinSyntax(
+                    naming.ToPropertyName(group.Key.Property),
+                    naming.ToPropertyName(group.Key.On),
+                    [.. group.Select(ToJoinEvent)],
+                    SourceLocation.Start))
+        ];
+    }
+
+    /// <summary>
+    /// Converts a single event joined from.
+    /// </summary>
+    /// <param name="join">The block to convert.</param>
+    /// <returns>The <see cref="JoinEventSyntax"/>.</returns>
+    JoinEventSyntax ToJoinEvent(ProjectionJoinModel join) =>
+        new(
+            naming.ToDeclarationName(join.EventType),
+            AutoMapMode.Inherit,
+            mappings.Convert(join.Properties),
+            SourceLocation.Start);
+}

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionKeyConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionKeyConverter.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.Emission.Projections;
+
+/// <summary>
+/// Converts the key expressions of a projection into Screenplay keys.
+/// </summary>
+/// <remarks>
+/// The event source id is the implicit key of every block, so it is never written out.
+/// <para>
+/// Composite keys appear in two shapes. One carries only parts - <c>$composite(Prop=expr,Prop2=expr2)</c> - while
+/// the other leads with a type name - <c>$composite(TypeName, Prop=expr)</c>. Both are accepted; when no type name
+/// is carried, the read model's own name is used, since that is what the key identifies.
+/// </para>
+/// </remarks>
+public static class ProjectionKeyConverter
+{
+    /// <summary>
+    /// The prefix of a composite key expression.
+    /// </summary>
+    public const string CompositePrefix = "$composite(";
+
+    /// <summary>
+    /// Converts a key expression into a Screenplay key.
+    /// </summary>
+    /// <param name="key">The key expression to convert.</param>
+    /// <param name="readModelName">The name of the read model, used when a composite key carries no type name.</param>
+    /// <returns>The <see cref="KeySyntax"/>, or <see langword="null"/> when the default key applies.</returns>
+    public static KeySyntax? Convert(string? key, string readModelName)
+    {
+        if (string.IsNullOrWhiteSpace(key) || string.Equals(key, ProjectionExpressionConverter.EventSourceId, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (key.StartsWith(CompositePrefix, StringComparison.Ordinal))
+        {
+            return ConvertComposite(key, readModelName);
+        }
+
+        return ProjectionExpressionConverter.TryConvert(key, out var expression)
+            ? new ExpressionKeySyntax(expression, SourceLocation.Start)
+            : null;
+    }
+
+    /// <summary>
+    /// Determines whether a key expression is one the default key applies to rather than one that was lost.
+    /// </summary>
+    /// <param name="key">The key expression to check.</param>
+    /// <returns>True when nothing is lost by emitting no key at all.</returns>
+    public static bool IsDefault(string? key) =>
+        string.IsNullOrWhiteSpace(key) || string.Equals(key, ProjectionExpressionConverter.EventSourceId, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Converts a parent key expression, which the grammar takes as a plain expression.
+    /// </summary>
+    /// <param name="parentKey">The parent key expression to convert.</param>
+    /// <returns>The expression, or <see langword="null"/> when there is none.</returns>
+    public static ExpressionSyntax? ConvertParent(string? parentKey)
+    {
+        if (string.IsNullOrWhiteSpace(parentKey) || parentKey.StartsWith(CompositePrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return ProjectionExpressionConverter.TryConvert(parentKey, out var expression) ? expression : null;
+    }
+
+    /// <summary>
+    /// Converts a composite key expression.
+    /// </summary>
+    /// <param name="key">The composite key expression.</param>
+    /// <param name="readModelName">The name used when the expression carries no type name.</param>
+    /// <returns>The key, or <see langword="null"/> when no part could be converted.</returns>
+    /// <remarks>
+    /// An empty composite key is a compile error, so a composite whose every part is unconvertible is dropped whole
+    /// rather than emitted with a missing part - a key that identifies a read model by fewer properties than it
+    /// really does would be worse than no key at all.
+    /// </remarks>
+    static CompositeKeySyntax? ConvertComposite(string key, string readModelName)
+    {
+        if (!key.EndsWith(')'))
+        {
+            return null;
+        }
+
+        var segments = key[CompositePrefix.Length..^1]
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        var type = readModelName;
+        var parts = new List<KeyPartSyntax>();
+
+        foreach (var segment in segments)
+        {
+            var separator = segment.IndexOf('=', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                type = segment;
+                continue;
+            }
+
+            var property = segment[..separator].Trim();
+            if (property.Length == 0 || !ProjectionExpressionConverter.TryConvert(segment[(separator + 1)..].Trim(), out var expression))
+            {
+                return null;
+            }
+
+            parts.Add(new(property, expression, SourceLocation.Start));
+        }
+
+        return parts.Count == 0 || type.Length == 0 ? null : new CompositeKeySyntax(type, parts, SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionMappingConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionMappingConverter.cs
@@ -13,7 +13,14 @@ namespace Cratis.Arc.Screenplay.Emission.Projections;
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <param name="location">Where the projection lives, for use in diagnostics.</param>
-public class ProjectionMappingConverter(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics, string location)
+/// <param name="readModelName">The name of the read model the mappings fill in, for use in diagnostics.</param>
+/// <param name="names">The <see cref="NameAvailability"/> deciding which properties a block can map onto.</param>
+public class ProjectionMappingConverter(
+    IScreenplayNaming naming,
+    ScreenplayDiagnostics diagnostics,
+    string location,
+    string readModelName,
+    NameAvailability names)
 {
     /// <summary>
     /// The expression incrementing a read model property.
@@ -44,8 +51,13 @@ public class ProjectionMappingConverter(IScreenplayNaming naming, ScreenplayDiag
     /// Converts a property map into mapping lines, reporting everything Screenplay cannot express.
     /// </summary>
     /// <param name="properties">The property map of the projection.</param>
+    /// <param name="reserved">The <see cref="ReservedWords"/> of the block the mappings are written in.</param>
     /// <returns>The mapping lines, ordered by property.</returns>
-    public IEnumerable<MappingSyntax> Convert(IReadOnlyDictionary<string, string> properties)
+    /// <remarks>
+    /// Only a plain assignment leads with the property it fills in - <c>increment</c>, <c>count</c>, <c>add</c> and
+    /// their kind lead with the operation - so a name the block reserves is only a problem for the former.
+    /// </remarks>
+    public IEnumerable<MappingSyntax> Convert(IReadOnlyDictionary<string, string> properties, ReservedWords reserved)
     {
         var mappings = new List<MappingSyntax>();
 
@@ -59,6 +71,11 @@ public class ProjectionMappingConverter(IScreenplayNaming naming, ScreenplayDiag
                     ScreenplayDiagnosticCodes.UnmappableProjectionExpression,
                     $"The expression '{expression}' mapped onto '{rawProperty}' has no counterpart in the projection definition language",
                     location);
+                continue;
+            }
+
+            if (mapping is SetMappingSyntax && !names.Allows(rawProperty, reserved, readModelName, location))
+            {
                 continue;
             }
 

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionMappingConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionMappingConverter.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.Emission.Projections;
+
+/// <summary>
+/// Converts the property map of a projection into Screenplay mapping lines.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <param name="location">Where the projection lives, for use in diagnostics.</param>
+public class ProjectionMappingConverter(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics, string location)
+{
+    /// <summary>
+    /// The expression incrementing a read model property.
+    /// </summary>
+    public const string Increment = "$increment";
+
+    /// <summary>
+    /// The expression decrementing a read model property.
+    /// </summary>
+    public const string Decrement = "$decrement";
+
+    /// <summary>
+    /// The expression counting occurrences into a read model property.
+    /// </summary>
+    public const string Count = "$count";
+
+    /// <summary>
+    /// The prefix of the expression adding an event property to a read model property.
+    /// </summary>
+    public const string AddPrefix = "$add(";
+
+    /// <summary>
+    /// The prefix of the expression subtracting an event property from a read model property.
+    /// </summary>
+    public const string SubtractPrefix = "$subtract(";
+
+    /// <summary>
+    /// Converts a property map into mapping lines, reporting everything Screenplay cannot express.
+    /// </summary>
+    /// <param name="properties">The property map of the projection.</param>
+    /// <returns>The mapping lines, ordered by property.</returns>
+    public IEnumerable<MappingSyntax> Convert(IReadOnlyDictionary<string, string> properties)
+    {
+        var mappings = new List<MappingSyntax>();
+
+        foreach (var (rawProperty, expression) in properties.OrderBy(_ => _.Key, StringComparer.Ordinal))
+        {
+            var property = naming.ToPropertyName(rawProperty);
+            var mapping = Convert(property, expression);
+            if (mapping is null)
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnmappableProjectionExpression,
+                    $"The expression '{expression}' mapped onto '{rawProperty}' has no counterpart in the projection definition language",
+                    location);
+                continue;
+            }
+
+            mappings.Add(mapping);
+        }
+
+        return mappings;
+    }
+
+    /// <summary>
+    /// Converts a single property expression into a mapping line.
+    /// </summary>
+    /// <param name="property">The camel cased read model property.</param>
+    /// <param name="expression">The property expression.</param>
+    /// <returns>The mapping line, or <see langword="null"/> when it cannot be expressed.</returns>
+    static MappingSyntax? Convert(string property, string expression)
+    {
+        if (expression == Increment)
+        {
+            return new IncrementMappingSyntax(property, SourceLocation.Start);
+        }
+
+        if (expression == Decrement)
+        {
+            return new DecrementMappingSyntax(property, SourceLocation.Start);
+        }
+
+        if (expression == Count)
+        {
+            return new CountMappingSyntax(property, SourceLocation.Start);
+        }
+
+        if (expression.StartsWith(AddPrefix, StringComparison.Ordinal) && expression.EndsWith(')'))
+        {
+            return ProjectionExpressionConverter.TryConvert(expression[AddPrefix.Length..^1], out var added)
+                ? new AddMappingSyntax(property, added, SourceLocation.Start)
+                : null;
+        }
+
+        if (expression.StartsWith(SubtractPrefix, StringComparison.Ordinal) && expression.EndsWith(')'))
+        {
+            return ProjectionExpressionConverter.TryConvert(expression[SubtractPrefix.Length..^1], out var subtracted)
+                ? new SubtractMappingSyntax(property, subtracted, SourceLocation.Start)
+                : null;
+        }
+
+        return ProjectionExpressionConverter.TryConvert(expression, out var source)
+            ? new SetMappingSyntax(property, source, SourceLocation.Start)
+            : null;
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionSyntaxBuilder.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.Emission.Projections;
+
+/// <summary>
+/// Builds the Screenplay <c>projection</c> declaration for a projection.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+public partial class ProjectionSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// The identifier of the default event sequence, which is never written out.
+    /// </summary>
+    public const string EventLogSequence = "event-log";
+
+    /// <summary>
+    /// Builds the projection declaration.
+    /// </summary>
+    /// <param name="projection">The projection to build for.</param>
+    /// <param name="location">Where the projection lives, for use in diagnostics.</param>
+    /// <returns>The <see cref="ProjectionSyntax"/>, or <see langword="null"/> when there is nothing to declare.</returns>
+    public ProjectionSyntax? Build(ProjectionModel projection, string location)
+    {
+        var readModel = naming.ToDeclarationName(projection.ReadModel);
+        var blocks = new ProjectionBlockConverter(naming, readModel, diagnostics, location)
+            .Convert(projection.Scope, projection.SubscribesToAllEvents)
+            .ToList();
+
+        if (blocks.Count == 0)
+        {
+            // A projection with no directives at all does not compile - leaving it out keeps the document valid.
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.EmptyProjection,
+                $"The projection '{projection.Identifier}' declares nothing that can be expressed and was left out",
+                location);
+
+            return null;
+        }
+
+        return new(
+            GetName(projection, readModel),
+            readModel.Length <= 1 ? null : readModel,
+            GetSequence(projection),
+            ProjectionBlockConverter.ToAutoMapMode(projection.AutoMap),
+            null,
+            blocks,
+            SourceLocation.Start);
+    }
+
+    /// <summary>
+    /// Gets the sequence to write out, if it is both non default and expressible as an identifier.
+    /// </summary>
+    /// <param name="projection">The projection to read from.</param>
+    /// <returns>The sequence identifier, or <see langword="null"/>.</returns>
+    static string? GetSequence(ProjectionModel projection)
+    {
+        var sequence = projection.EventSequenceId;
+
+        return string.IsNullOrEmpty(sequence) ||
+            string.Equals(sequence, EventLogSequence, StringComparison.Ordinal) ||
+            !Identifier().IsMatch(sequence)
+                ? null
+                : sequence;
+    }
+
+    /// <summary>
+    /// Gets the pattern an identifier has to match.
+    /// </summary>
+    /// <returns>The compiled regular expression.</returns>
+    [GeneratedRegex(@"^[A-Za-z_]\w*$", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex Identifier();
+
+    /// <summary>
+    /// Gets the name of the projection from its identifier, falling back to the read model.
+    /// </summary>
+    /// <param name="projection">The projection to name.</param>
+    /// <param name="readModel">The sanitized name of the read model the projection builds.</param>
+    /// <returns>The projection name.</returns>
+    string GetName(ProjectionModel projection, string readModel)
+    {
+        var identifier = projection.Identifier ?? string.Empty;
+        var lastSegment = identifier[(identifier.LastIndexOf('.') + 1)..];
+        var name = naming.ToDeclarationName(lastSegment);
+
+        return name.Length <= 1 ? readModel : name;
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Projections/ProjectionSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Projections/ProjectionSyntaxBuilder.cs
@@ -14,7 +14,8 @@ namespace Cratis.Arc.Screenplay.Emission.Projections;
 /// </summary>
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
-public partial class ProjectionSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
+/// <param name="names">The <see cref="NameAvailability"/> deciding which properties a block can map onto.</param>
+public partial class ProjectionSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics, NameAvailability names)
 {
     /// <summary>
     /// The identifier of the default event sequence, which is never written out.
@@ -30,7 +31,7 @@ public partial class ProjectionSyntaxBuilder(IScreenplayNaming naming, Screenpla
     public ProjectionSyntax? Build(ProjectionModel projection, string location)
     {
         var readModel = naming.ToDeclarationName(projection.ReadModel);
-        var blocks = new ProjectionBlockConverter(naming, readModel, diagnostics, location)
+        var blocks = new ProjectionBlockConverter(naming, readModel, diagnostics, location, names)
             .Convert(projection.Scope, projection.SubscribesToAllEvents)
             .ToList();
 

--- a/Source/DotNET/Screenplay/Emission/Queries/QuerySyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Queries/QuerySyntaxBuilder.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Policies;
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Queries;
+
+/// <summary>
+/// Builds the Screenplay <c>query</c> declaration for a query.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="types">The <see cref="TypeReferenceConverter"/> used for the return and parameter types.</param>
+/// <param name="authorize">The <see cref="AuthorizeSyntaxBuilder"/> used for the authorize block.</param>
+public class QuerySyntaxBuilder(
+    IScreenplayNaming naming,
+    TypeReferenceConverter types,
+    AuthorizeSyntaxBuilder authorize)
+{
+    /// <summary>
+    /// Builds the query declaration.
+    /// </summary>
+    /// <param name="query">The query to build for.</param>
+    /// <returns>The <see cref="QuerySyntax"/>.</returns>
+    public QuerySyntax Build(QueryModel query) =>
+        new(
+            naming.ToDeclarationName(query.Name),
+            types.Convert(query.ReturnType),
+            query.By is null ? null : ToParameter(query.By),
+            [.. query.Filters.Select(ToParameter)],
+            authorize.Build(query.Authorization),
+            SourceLocation.Start);
+
+    /// <summary>
+    /// Converts a parameter of the query.
+    /// </summary>
+    /// <param name="parameter">The parameter to convert.</param>
+    /// <returns>The <see cref="QueryParameterSyntax"/>.</returns>
+    QueryParameterSyntax ToParameter(PropertyModel parameter) =>
+        new(naming.ToPropertyName(parameter.Name), types.Convert(parameter.Type), SourceLocation.Start);
+}

--- a/Source/DotNET/Screenplay/Emission/Reactors/ReactorSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Reactors/ReactorSyntaxBuilder.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Files;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Reactors;
+
+/// <summary>
+/// Builds the Screenplay <c>reactor</c> declaration for a reactor.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+/// <remarks>
+/// A reactor body is code, so the only faithful rendering is a file reference. A trigger with neither a file nor an
+/// inline body has an empty body and does not compile, which is why a path is always resolved.
+/// </remarks>
+public class ReactorSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Builds the reactor declaration.
+    /// </summary>
+    /// <param name="reactor">The reactor to build for.</param>
+    /// <param name="namespace">The namespace of the slice the reactor lives in.</param>
+    /// <returns>The <see cref="ReactorSyntax"/>, or <see langword="null"/> when it observes no events.</returns>
+    public ReactorSyntax? Build(ReactorModel reactor, string @namespace)
+    {
+        var name = naming.ToDeclarationName(reactor.Name);
+        var path = naming.ToFilePath(reactor.SourceFilePath) ?? SourceFilePaths.Conventional(@namespace, name);
+        var file = new FileReferenceSyntax(path, SourceLocation.Start);
+
+        var triggers = reactor.ObservedEvents
+            .Select(naming.ToDeclarationName)
+            .Where(_ => _.Length > 1)
+            .Distinct(StringComparer.Ordinal)
+            .Select(_ => new ReactorTriggerSyntax(_, file, null, SourceLocation.Start))
+            .ToList();
+
+        if (triggers.Count == 0)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.ReactorWithoutEvents,
+                $"The reactor '{reactor.Name}' observes no events and was left out",
+                @namespace);
+
+            return null;
+        }
+
+        return new(name, triggers, SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/ScreenplayEmission.cs
+++ b/Source/DotNET/Screenplay/Emission/ScreenplayEmission.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission;
+
+/// <summary>
+/// Represents everything emitting a Screenplay document produced.
+/// </summary>
+/// <param name="Source">The printed <c>.play</c> text.</param>
+/// <param name="Application">The document that was printed.</param>
+/// <param name="Diagnostics">Everything that could not be expressed, reported rather than dropped.</param>
+public record ScreenplayEmission(
+    string Source,
+    ApplicationSyntax Application,
+    IReadOnlyList<ScreenplayDiagnostic> Diagnostics);

--- a/Source/DotNET/Screenplay/Emission/ScreenplayEmitter.cs
+++ b/Source/DotNET/Screenplay/Emission/ScreenplayEmitter.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Printing;
+
+namespace Cratis.Arc.Screenplay.Emission;
+
+/// <summary>
+/// Represents an implementation of <see cref="IScreenplayEmitter"/>.
+/// </summary>
+/// <param name="printer">The <see cref="IScreenplayPrinter"/> that prints the document.</param>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+public class ScreenplayEmitter(IScreenplayPrinter printer, IScreenplayNaming naming) : IScreenplayEmitter
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScreenplayEmitter"/> class using the standard printer and naming.
+    /// </summary>
+    public ScreenplayEmitter()
+        : this(new ScreenplayPrinter(), new ScreenplayNaming())
+    {
+    }
+
+    /// <inheritdoc/>
+    public ScreenplayEmission Emit(ApplicationModel model, ScreenplayOptions options)
+    {
+        var diagnostics = new ScreenplayDiagnostics();
+        var application = new ApplicationSyntaxBuilder(naming, diagnostics).Build(model, options);
+
+        return new(printer.Print(application), application, diagnostics.All);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Screens/ScreenSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Screens/ScreenSyntaxBuilder.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Screens;
+
+/// <summary>
+/// Builds the Screenplay <c>screen</c> declaration for a screen.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <remarks>
+/// A screen is written in its <c>file</c> form and never in its declarative one. The declarative form describes what
+/// a screen shows and does, and nothing in a compilation says either - so the file reference is the whole of what is
+/// honestly known, and it is the part a reader most wants anyway.
+/// </remarks>
+public class ScreenSyntaxBuilder(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// The extension of the file realizing a screen.
+    /// </summary>
+    public const string Extension = ".tsx";
+
+    /// <summary>
+    /// Builds the screen declaration.
+    /// </summary>
+    /// <param name="screen">The screen to build for.</param>
+    /// <param name="namespace">The namespace of the slice the screen belongs to.</param>
+    /// <returns>The <see cref="ScreenSyntax"/>.</returns>
+    /// <remarks>
+    /// A screen with neither a file nor a directive has an empty body, so a path is always resolved - falling back
+    /// to where the vertical slice convention would put the file when the model carries none.
+    /// </remarks>
+    public ScreenSyntax Build(ScreenModel screen, string @namespace)
+    {
+        var name = naming.ToDeclarationName(screen.Name);
+        var path = naming.ToFilePath(screen.FilePath) ?? Conventional(@namespace, name);
+
+        return new(name, new FileReferenceSyntax(path, SourceLocation.Start), [], SourceLocation.Start);
+    }
+
+    /// <summary>
+    /// Gets the path the vertical slice convention would put the file realizing a screen at.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="name">The name of the screen.</param>
+    /// <returns>The relative path.</returns>
+    static string Conventional(string @namespace, string name) =>
+        string.Join('/', @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries).Skip(1).Append($"{name}{Extension}"));
+}

--- a/Source/DotNET/Screenplay/Emission/Screens/ScreenSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Screens/ScreenSyntaxBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Types;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Diagnostics;
 using Cratis.Screenplay.Syntax;
@@ -12,12 +13,14 @@ namespace Cratis.Arc.Screenplay.Emission.Screens;
 /// Builds the Screenplay <c>screen</c> declaration for a screen.
 /// </summary>
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="types">The <see cref="TypeReferenceConverter"/> used for the type each binding reads.</param>
 /// <remarks>
-/// A screen is written in its <c>file</c> form and never in its declarative one. The declarative form describes what
-/// a screen shows and does, and nothing in a compilation says either - so the file reference is the whole of what is
-/// honestly known, and it is the part a reader most wants anyway.
+/// A screen is written with its <c>file</c> reference and its <c>data</c> directives together. The grammar allows a
+/// screen to carry both, and both are worth saying - the bindings state what the screen reads, and the file stays
+/// the honest pointer to the implementation that no directive replaces. Nothing else is written, because nothing
+/// else is known: the widgets of a screen live in JSX, which this generator does not read.
 /// </remarks>
-public class ScreenSyntaxBuilder(IScreenplayNaming naming)
+public class ScreenSyntaxBuilder(IScreenplayNaming naming, TypeReferenceConverter types)
 {
     /// <summary>
     /// The extension of the file realizing a screen.
@@ -39,7 +42,7 @@ public class ScreenSyntaxBuilder(IScreenplayNaming naming)
         var name = naming.ToDeclarationName(screen.Name);
         var path = naming.ToFilePath(screen.FilePath) ?? Conventional(@namespace, name);
 
-        return new(name, new FileReferenceSyntax(path, SourceLocation.Start), [], SourceLocation.Start);
+        return new(name, new FileReferenceSyntax(path, SourceLocation.Start), [.. Bindings(screen)], SourceLocation.Start);
     }
 
     /// <summary>
@@ -50,4 +53,32 @@ public class ScreenSyntaxBuilder(IScreenplayNaming naming)
     /// <returns>The relative path.</returns>
     static string Conventional(string @namespace, string name) =>
         string.Join('/', @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries).Skip(1).Append($"{name}{Extension}"));
+
+    /// <summary>
+    /// Builds the <c>data</c> directive of every query the screen binds.
+    /// </summary>
+    /// <param name="screen">The screen to build for.</param>
+    /// <returns>The directives, ordered by the query they read through.</returns>
+    IEnumerable<ScreenDirectiveSyntax> Bindings(ScreenModel screen) =>
+        screen.Data
+            .Select(Binding)
+            .OrderBy(_ => _.Query, StringComparer.Ordinal)
+            .ThenBy(_ => _.By ?? string.Empty, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Builds one <c>data</c> directive.
+    /// </summary>
+    /// <param name="data">The binding to build for.</param>
+    /// <returns>The <see cref="ScreenDataSyntax"/>.</returns>
+    /// <remarks>
+    /// A <c>data</c> directive has no room for an optional marker - the parser rejects one, so writing it would
+    /// produce a document that does not compile - and it needs none, since the query declaration in the same slice
+    /// already states what it returns and whether it may return nothing.
+    /// </remarks>
+    ScreenDataSyntax Binding(ScreenDataModel data) =>
+        new(
+            types.Convert(data.Type) with { IsOptional = false },
+            naming.ToDeclarationName(data.Query),
+            data.By is null ? null : naming.ToPropertyName(data.By),
+            SourceLocation.Start);
 }

--- a/Source/DotNET/Screenplay/Emission/Slices/PlacedSlice.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/PlacedSlice.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Slices;
+
+/// <summary>
+/// Represents a built slice together with the namespace that determines where it is placed in the tree.
+/// </summary>
+/// <param name="Namespace">The namespace the slice lives in.</param>
+/// <param name="Slice">The built <see cref="SliceSyntax"/>.</param>
+public record PlacedSlice(string Namespace, SliceSyntax Slice);

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceContent.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceContent.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Slices;
+
+/// <summary>
+/// Determines whether a slice declares anything.
+/// </summary>
+/// <remarks>
+/// A slice can end up with nothing to declare - a read model whose projection could not be expressed, with no query
+/// onto it, is the common case. Such a slice carries no information and its header alone is not a valid slice body,
+/// so it is dropped rather than emitted.
+/// </remarks>
+public static class SliceContent
+{
+    /// <summary>
+    /// Determines whether a slice declares nothing at all.
+    /// </summary>
+    /// <param name="slice">The slice to check.</param>
+    /// <returns>True when the slice has no body.</returns>
+    public static bool IsEmpty(SliceSyntax slice) =>
+        !slice.Events.Any() &&
+        !slice.Commands.Any() &&
+        !slice.Queries.Any() &&
+        slice.Projection is null &&
+        !slice.Captures.Any() &&
+        !slice.Reactors.Any() &&
+        !slice.Screens.Any() &&
+        !slice.Constraints.Any() &&
+        !slice.Specifications.Any() &&
+        slice.Description is null;
+}

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
@@ -51,7 +51,7 @@ public class SliceSyntaxBuilder(
         new(
             SliceTypes.Convert(slice.Kind),
             GetName(slice),
-            [.. slice.Events.Select(events.Build).OrderBy(_ => _.Name, StringComparer.Ordinal)],
+            [.. slice.Events.Select(_ => events.Build(_, slice.Namespace)).OrderBy(_ => _.Name, StringComparer.Ordinal)],
             [.. slice.Commands.Select(_ => commands.Build(_, slice.Namespace)).OrderBy(_ => _.Name, StringComparer.Ordinal)],
             [.. slice.Queries.Select(queries.Build).OrderBy(_ => _.Name, StringComparer.Ordinal)],
             BuildProjection(slice),

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Commands;
+using Cratis.Arc.Screenplay.Emission.Constraints;
+using Cratis.Arc.Screenplay.Emission.Events;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Emission.Projections;
+using Cratis.Arc.Screenplay.Emission.Queries;
+using Cratis.Arc.Screenplay.Emission.Reactors;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+using Cratis.Screenplay.Syntax.Projections;
+
+namespace Cratis.Arc.Screenplay.Emission.Slices;
+
+/// <summary>
+/// Builds the Screenplay <c>slice</c> declaration for a slice.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="commands">The <see cref="CommandSyntaxBuilder"/> for the commands of the slice.</param>
+/// <param name="events">The <see cref="EventSyntaxBuilder"/> for the events of the slice.</param>
+/// <param name="queries">The <see cref="QuerySyntaxBuilder"/> for the queries of the slice.</param>
+/// <param name="constraints">The <see cref="ConstraintSyntaxBuilder"/> for the constraints of the slice.</param>
+/// <param name="reactors">The <see cref="ReactorSyntaxBuilder"/> for the reactors of the slice.</param>
+/// <param name="projections">The <see cref="ProjectionSyntaxBuilder"/> for the projection of the slice.</param>
+public class SliceSyntaxBuilder(
+    IScreenplayNaming naming,
+    CommandSyntaxBuilder commands,
+    EventSyntaxBuilder events,
+    QuerySyntaxBuilder queries,
+    ConstraintSyntaxBuilder constraints,
+    ReactorSyntaxBuilder reactors,
+    ProjectionSyntaxBuilder projections)
+{
+    /// <summary>
+    /// The name given to a slice whose own name yields nothing usable.
+    /// </summary>
+    public const string DefaultSliceName = "Slice";
+
+    /// <summary>
+    /// Builds the slice declaration.
+    /// </summary>
+    /// <param name="slice">The slice to build for.</param>
+    /// <returns>The <see cref="SliceSyntax"/>.</returns>
+    public SliceSyntax Build(SliceModel slice) =>
+        new(
+            SliceTypes.Convert(slice.Kind),
+            GetName(slice),
+            [.. slice.Events.Select(events.Build).OrderBy(_ => _.Name, StringComparer.Ordinal)],
+            [.. slice.Commands.Select(_ => commands.Build(_, slice.Namespace)).OrderBy(_ => _.Name, StringComparer.Ordinal)],
+            [.. slice.Queries.Select(queries.Build).OrderBy(_ => _.Name, StringComparer.Ordinal)],
+            BuildProjection(slice),
+            [],
+            [
+                .. slice.Reactors
+                    .Select(_ => reactors.Build(_, slice.Namespace))
+                    .OfType<ReactorSyntax>()
+                    .OrderBy(_ => _.Name, StringComparer.Ordinal)
+            ],
+            [],
+            [
+                .. slice.Constraints
+                    .Select(_ => constraints.Build(_, slice.Namespace))
+                    .OrderBy(_ => _.Name, StringComparer.Ordinal)
+            ],
+            [],
+            SourceLocation.Start,
+            naming.ToStringLiteral(slice.Description));
+
+    /// <summary>
+    /// Builds the single projection a slice may declare.
+    /// </summary>
+    /// <param name="slice">The slice to build for.</param>
+    /// <returns>The projection, or <see langword="null"/> when the slice has none.</returns>
+    ProjectionSyntax? BuildProjection(SliceModel slice) =>
+        slice.Projection is null ? null : projections.Build(slice.Projection, slice.Namespace);
+
+    /// <summary>
+    /// Gets the name of the slice, falling back to the last segment of its namespace.
+    /// </summary>
+    /// <param name="slice">The slice to name.</param>
+    /// <returns>The slice name.</returns>
+    string GetName(SliceModel slice)
+    {
+        var name = naming.ToDeclarationName(slice.Name);
+        if (name.Length > 1)
+        {
+            return name;
+        }
+
+        var segments = slice.Namespace.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        name = segments.Length == 0 ? string.Empty : naming.ToDeclarationName(segments[^1]);
+
+        return name.Length <= 1 ? DefaultSliceName : name;
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
@@ -8,6 +8,7 @@ using Cratis.Arc.Screenplay.Emission.Naming;
 using Cratis.Arc.Screenplay.Emission.Projections;
 using Cratis.Arc.Screenplay.Emission.Queries;
 using Cratis.Arc.Screenplay.Emission.Reactors;
+using Cratis.Arc.Screenplay.Emission.Screens;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Diagnostics;
 using Cratis.Screenplay.Syntax;
@@ -25,6 +26,7 @@ namespace Cratis.Arc.Screenplay.Emission.Slices;
 /// <param name="constraints">The <see cref="ConstraintSyntaxBuilder"/> for the constraints of the slice.</param>
 /// <param name="reactors">The <see cref="ReactorSyntaxBuilder"/> for the reactors of the slice.</param>
 /// <param name="projections">The <see cref="ProjectionSyntaxBuilder"/> for the projection of the slice.</param>
+/// <param name="screens">The <see cref="ScreenSyntaxBuilder"/> for the screens of the slice.</param>
 public class SliceSyntaxBuilder(
     IScreenplayNaming naming,
     CommandSyntaxBuilder commands,
@@ -32,7 +34,8 @@ public class SliceSyntaxBuilder(
     QuerySyntaxBuilder queries,
     ConstraintSyntaxBuilder constraints,
     ReactorSyntaxBuilder reactors,
-    ProjectionSyntaxBuilder projections)
+    ProjectionSyntaxBuilder projections,
+    ScreenSyntaxBuilder screens)
 {
     /// <summary>
     /// The name given to a slice whose own name yields nothing usable.
@@ -59,7 +62,12 @@ public class SliceSyntaxBuilder(
                     .OfType<ReactorSyntax>()
                     .OrderBy(_ => _.Name, StringComparer.Ordinal)
             ],
-            [],
+            [
+                .. slice.Screens
+                    .Select(_ => screens.Build(_, slice.Namespace))
+                    .OrderBy(_ => _.Name, StringComparer.Ordinal)
+                    .ThenBy(_ => _.File?.Path ?? string.Empty, StringComparer.Ordinal)
+            ],
             [
                 .. slice.Constraints
                     .Select(_ => constraints.Build(_, slice.Namespace))

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceTreeBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceTreeBuilder.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Slices;
+
+/// <summary>
+/// Arranges slices into the module and feature tree of a Screenplay document.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+public class SliceTreeBuilder(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// Builds the module holding every slice, nesting features after the namespace segments of each slice.
+    /// </summary>
+    /// <param name="slices">The slices to arrange, keyed on the namespace they live in.</param>
+    /// <param name="moduleName">The name of the module.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments to skip.</param>
+    /// <returns>The modules of the document.</returns>
+    public IEnumerable<ModuleSyntax> Build(IEnumerable<PlacedSlice> slices, string moduleName, int segmentsToSkip)
+    {
+        var root = new FeatureNode();
+
+        foreach (var placed in slices)
+        {
+            var path = GetFeaturePath(placed.Namespace, moduleName, segmentsToSkip);
+            root.Resolve(path).Slices.Add(placed.Slice);
+        }
+
+        var features = root.BuildChildren();
+
+        return features.Length == 0 ? [] : [new ModuleSyntax(moduleName, [], features, SourceLocation.Start)];
+    }
+
+    /// <summary>
+    /// Resolves the feature path a slice is placed under, excluding the slice itself.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="moduleName">The name of the module.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments to skip.</param>
+    /// <returns>The feature names, outermost first.</returns>
+    string[] GetFeaturePath(string @namespace, string moduleName, int segmentsToSkip)
+    {
+        var segments = @namespace
+            .Split('.', StringSplitOptions.RemoveEmptyEntries)
+            .Skip(segmentsToSkip)
+            .Select(naming.ToDeclarationName)
+            .ToArray();
+
+        if (segments.Length > 1 && string.Equals(segments[0], moduleName, StringComparison.Ordinal))
+        {
+            segments = [.. segments.Skip(1)];
+        }
+
+        return segments.Length switch
+        {
+            0 => [moduleName],
+            1 => [segments[0]],
+            _ => [.. segments[..^1]]
+        };
+    }
+
+    /// <summary>
+    /// Represents a node while the feature tree is being assembled.
+    /// </summary>
+    sealed class FeatureNode
+    {
+        public SortedDictionary<string, FeatureNode> Children { get; } = new(StringComparer.Ordinal);
+
+        public List<SliceSyntax> Slices { get; } = [];
+
+        public FeatureNode Resolve(IEnumerable<string> path)
+        {
+            var current = this;
+            foreach (var segment in path)
+            {
+                if (!current.Children.TryGetValue(segment, out var child))
+                {
+                    child = new FeatureNode();
+                    current.Children[segment] = child;
+                }
+
+                current = child;
+            }
+
+            return current;
+        }
+
+        public FeatureSyntax[] BuildChildren() =>
+            [.. Children.Select(_ => new FeatureSyntax(
+                _.Key,
+                _.Value.BuildChildren(),
+                [.. _.Value.Slices.OrderBy(slice => slice.Name, StringComparer.Ordinal)],
+                SourceLocation.Start))];
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceTypes.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceTypes.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Slices;
+
+/// <summary>
+/// Converts the kind of a slice into the Screenplay slice type.
+/// </summary>
+public static class SliceTypes
+{
+    /// <summary>
+    /// Converts a slice kind.
+    /// </summary>
+    /// <param name="kind">The kind to convert.</param>
+    /// <returns>The <see cref="SliceType"/>.</returns>
+    public static SliceType Convert(SliceKind kind) => kind switch
+    {
+        SliceKind.StateChange => SliceType.StateChange,
+        SliceKind.Automation => SliceType.Automation,
+        SliceKind.Translate => SliceType.Translate,
+        _ => SliceType.StateView
+    };
+}

--- a/Source/DotNET/Screenplay/Emission/Types/ScreenplayPrimitiveTypes.cs
+++ b/Source/DotNET/Screenplay/Emission/Types/ScreenplayPrimitiveTypes.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Emission.Types;
+
+/// <summary>
+/// Holds the Screenplay primitive type names and the mapping from the fully qualified names of the framework types
+/// that back them.
+/// </summary>
+/// <remarks>
+/// This deliberately does not reuse the proxy generator's TypeScript map - TypeScript collapses every number onto
+/// <c>number</c> and every date onto <c>Date</c>, while Screenplay distinguishes <c>Int</c> from <c>Decimal</c> and
+/// <c>Date</c> from <c>DateTime</c>.
+/// </remarks>
+public static class ScreenplayPrimitiveTypes
+{
+#pragma warning disable CA1720 // Identifier contains type name. These are the Screenplay primitive names and cannot be renamed.
+    /// <summary>
+    /// The Screenplay primitive representing a universally unique identifier.
+    /// </summary>
+    public const string Uuid = "Uuid";
+
+    /// <summary>
+    /// The Screenplay primitive representing textual content.
+    /// </summary>
+    public const string String = "String";
+
+    /// <summary>
+    /// The Screenplay primitive representing a whole number.
+    /// </summary>
+    public const string Int = "Int";
+
+    /// <summary>
+    /// The Screenplay primitive representing a fractional number.
+    /// </summary>
+    public const string Decimal = "Decimal";
+
+    /// <summary>
+    /// The Screenplay primitive representing a boolean.
+    /// </summary>
+    public const string Bool = "Bool";
+
+    /// <summary>
+    /// The Screenplay primitive representing a date without a time component.
+    /// </summary>
+    public const string Date = "Date";
+
+    /// <summary>
+    /// The Screenplay primitive representing a point in time.
+    /// </summary>
+    public const string DateTime = "DateTime";
+
+    /// <summary>
+    /// The Screenplay type discriminator used for enumerations.
+    /// </summary>
+    public const string Enum = "Enum";
+#pragma warning restore CA1720 // Identifier contains type name
+
+    static readonly Dictionary<ScreenplayPrimitive, string> _names = new()
+    {
+        { ScreenplayPrimitive.Uuid, Uuid },
+        { ScreenplayPrimitive.String, String },
+        { ScreenplayPrimitive.Int, Int },
+        { ScreenplayPrimitive.Decimal, Decimal },
+        { ScreenplayPrimitive.Bool, Bool },
+        { ScreenplayPrimitive.Date, Date },
+        { ScreenplayPrimitive.DateTime, DateTime },
+        { ScreenplayPrimitive.Enum, Enum }
+    };
+
+    static readonly Dictionary<string, ScreenplayPrimitive> _byFrameworkType = new(StringComparer.Ordinal)
+    {
+        { "System.Guid", ScreenplayPrimitive.Uuid },
+        { "System.String", ScreenplayPrimitive.String },
+        { "System.Char", ScreenplayPrimitive.String },
+        { "System.Uri", ScreenplayPrimitive.String },
+        { "System.TimeSpan", ScreenplayPrimitive.String },
+        { "System.Byte", ScreenplayPrimitive.Int },
+        { "System.SByte", ScreenplayPrimitive.Int },
+        { "System.Int16", ScreenplayPrimitive.Int },
+        { "System.UInt16", ScreenplayPrimitive.Int },
+        { "System.Int32", ScreenplayPrimitive.Int },
+        { "System.UInt32", ScreenplayPrimitive.Int },
+        { "System.Int64", ScreenplayPrimitive.Int },
+        { "System.UInt64", ScreenplayPrimitive.Int },
+        { "System.Decimal", ScreenplayPrimitive.Decimal },
+        { "System.Single", ScreenplayPrimitive.Decimal },
+        { "System.Double", ScreenplayPrimitive.Decimal },
+        { "System.Boolean", ScreenplayPrimitive.Bool },
+        { "System.DateOnly", ScreenplayPrimitive.Date },
+        { "System.DateTime", ScreenplayPrimitive.DateTime },
+        { "System.DateTimeOffset", ScreenplayPrimitive.DateTime },
+        { "System.TimeOnly", ScreenplayPrimitive.DateTime }
+    };
+
+    /// <summary>
+    /// Gets the Screenplay name of a primitive.
+    /// </summary>
+    /// <param name="primitive">The primitive to get the name of.</param>
+    /// <returns>The Screenplay type name.</returns>
+    public static string GetName(ScreenplayPrimitive primitive) => _names.TryGetValue(primitive, out var name) ? name : String;
+
+    /// <summary>
+    /// Tries to resolve the Screenplay primitive backing a framework type.
+    /// </summary>
+    /// <param name="fullyQualifiedTypeName">The fully qualified name of the type, for example <c>System.Guid</c>.</param>
+    /// <param name="primitive">The resolved primitive.</param>
+    /// <returns>True when the type maps onto a Screenplay primitive.</returns>
+    public static bool TryResolve(string fullyQualifiedTypeName, out ScreenplayPrimitive primitive) =>
+        _byFrameworkType.TryGetValue(fullyQualifiedTypeName, out primitive);
+}

--- a/Source/DotNET/Screenplay/Emission/Types/TypeReferenceConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Types/TypeReferenceConverter.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Types;
+
+/// <summary>
+/// Converts a <see cref="TypeReferenceModel"/> into the Screenplay type reference it corresponds to.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <remarks>
+/// A concept keeps its own name rather than being reduced to the primitive behind it, because the concept is
+/// declared once at the top of the document and referenced by name from there on.
+/// </remarks>
+public class TypeReferenceConverter(IScreenplayNaming naming)
+{
+    /// <summary>
+    /// The name used when a type reference carries nothing usable.
+    /// </summary>
+    public const string UnknownTypeName = ScreenplayPrimitiveTypes.String;
+
+    /// <summary>
+    /// Converts a type reference.
+    /// </summary>
+    /// <param name="type">The type reference to convert.</param>
+    /// <returns>The <see cref="TypeRefSyntax"/>.</returns>
+    public TypeRefSyntax Convert(TypeReferenceModel type)
+    {
+        var name = naming.ToDeclarationName(type.Name);
+
+        return new(name.Length <= 1 ? UnknownTypeName : name, type.IsCollection, type.IsOptional, SourceLocation.Start);
+    }
+}

--- a/Source/DotNET/Screenplay/Emission/Validation/ValidationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Validation/ValidationSyntaxBuilder.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Expressions;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+using ModelRuleKind = Cratis.Arc.Screenplay.Model.ValidationRuleKind;
+using SyntaxRuleKind = Cratis.Screenplay.Syntax.ValidationRuleKind;
+
+namespace Cratis.Arc.Screenplay.Emission.Validation;
+
+/// <summary>
+/// Builds the Screenplay <c>validate</c> block for a set of validation rules.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
+public class ValidationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Builds the validation blocks for a set of rules.
+    /// </summary>
+    /// <param name="rules">The rules to build for.</param>
+    /// <param name="location">Where the rules were declared, for use in diagnostics.</param>
+    /// <param name="impliedSubject">Whether the rules apply to an implied subject rather than a named property.</param>
+    /// <returns>The validation blocks, empty when there is nothing to declare.</returns>
+    /// <remarks>
+    /// Rules inside a <c>concept</c> block carry no property name - the concept's own value is the implied subject -
+    /// so every rule is emitted against <see cref="ValidationRuleSyntax.ConceptValue"/> regardless of the member the
+    /// rule was declared on.
+    /// </remarks>
+    public IEnumerable<ValidateSyntax> Build(IEnumerable<ValidationRuleModel> rules, string location, bool impliedSubject = false)
+    {
+        var converted = new List<ValidationRuleSyntax>();
+
+        foreach (var rule in rules)
+        {
+            var operand = ToOperand(rule);
+            if (operand is null && rule.Kind != ModelRuleKind.NotEmpty)
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.ValidationRuleWithoutOperand,
+                    $"The '{rule.Kind}' rule on '{rule.Property}' carries no value to compare against and was left out",
+                    location);
+                continue;
+            }
+
+            converted.Add(new(
+                impliedSubject ? ValidationRuleSyntax.ConceptValue : naming.ToPropertyPath(rule.Property),
+                ToKind(rule.Kind),
+                rule.Kind == ModelRuleKind.NotEmpty ? null : operand,
+                ToMessage(rule.Message),
+                SourceLocation.Start));
+        }
+
+        return converted.Count == 0 ? [] : [new DeclarativeValidateSyntax(converted, SourceLocation.Start)];
+    }
+
+    /// <summary>
+    /// Converts the kind of a rule.
+    /// </summary>
+    /// <param name="kind">The kind to convert.</param>
+    /// <returns>The Screenplay rule kind.</returns>
+    static SyntaxRuleKind ToKind(ModelRuleKind kind) => kind switch
+    {
+        ModelRuleKind.Max => SyntaxRuleKind.Max,
+        ModelRuleKind.Min => SyntaxRuleKind.Min,
+        ModelRuleKind.GreaterThan => SyntaxRuleKind.GreaterThan,
+        ModelRuleKind.GreaterThanOrEqual => SyntaxRuleKind.GreaterThanOrEqual,
+        ModelRuleKind.LessThan => SyntaxRuleKind.LessThan,
+        ModelRuleKind.LessThanOrEqual => SyntaxRuleKind.LessThanOrEqual,
+        ModelRuleKind.Equal => SyntaxRuleKind.Equal,
+        ModelRuleKind.Length => SyntaxRuleKind.Length,
+        ModelRuleKind.Matches => SyntaxRuleKind.Matches,
+        ModelRuleKind.AllGreaterThan => SyntaxRuleKind.AllGreaterThan,
+        ModelRuleKind.AllGreaterThanOrEqual => SyntaxRuleKind.AllGreaterThanOrEqual,
+        _ => SyntaxRuleKind.NotEmpty
+    };
+
+    /// <summary>
+    /// Converts the operand of a rule.
+    /// </summary>
+    /// <param name="rule">The rule to convert the operand of.</param>
+    /// <returns>The operand, or <see langword="null"/> when the rule carries none.</returns>
+    /// <remarks>
+    /// A pattern that is a bare word - <c>email</c> is the one the grammar knows - is written unquoted, because that
+    /// is how the named patterns are referenced. Everything else is a string literal.
+    /// </remarks>
+    ExpressionSyntax? ToOperand(ValidationRuleModel rule)
+    {
+        if (rule.Value is null)
+        {
+            return null;
+        }
+
+        if (rule.Kind == ModelRuleKind.Matches && rule.Value is string pattern && ScreenplayIdentifier.IsBareIdentifier(pattern))
+        {
+            return new PathExpressionSyntax(pattern, SourceLocation.Start);
+        }
+
+        return LiteralConverter.Convert(rule.Value, naming);
+    }
+
+    /// <summary>
+    /// Converts the message of a rule, leaving a localization key untouched.
+    /// </summary>
+    /// <param name="message">The message to convert.</param>
+    /// <returns>The message, or <see langword="null"/> when there is none.</returns>
+    string? ToMessage(string? message) =>
+        ScreenplayIdentifier.IsLocalizationKey(message) ? message : naming.ToStringLiteral(message);
+}

--- a/Source/DotNET/Screenplay/IScreenplayGenerator.cs
+++ b/Source/DotNET/Screenplay/IScreenplayGenerator.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Defines a system that generates a Screenplay document from the source of an application.
+/// </summary>
+/// <remarks>
+/// The generator never loads an MSBuild workspace - the caller supplies the <see cref="Compilation"/>. That single
+/// seam is what lets the same generator run from a command line tool, from an MSBuild task, from an analyzer and
+/// from a specification built with <c>CSharpCompilation.Create</c>.
+/// </remarks>
+public interface IScreenplayGenerator
+{
+    /// <summary>
+    /// Generates the Screenplay document describing an application.
+    /// </summary>
+    /// <param name="compilation">The compilation to generate from.</param>
+    /// <param name="options">The options to generate with.</param>
+    /// <returns>The <see cref="ScreenplayGenerationResult"/>.</returns>
+    ScreenplayGenerationResult Generate(Compilation compilation, ScreenplayOptions options);
+}

--- a/Source/DotNET/Screenplay/Model/ApplicationModel.cs
+++ b/Source/DotNET/Screenplay/Model/ApplicationModel.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents everything a Screenplay document is generated from.
+/// </summary>
+/// <param name="Domain">The name of the domain the document belongs to.</param>
+/// <param name="Module">The name of the module every feature is placed within.</param>
+/// <param name="Concepts">The concepts declared at the document level.</param>
+/// <param name="Policies">The policies declared at the document level.</param>
+/// <param name="Slices">Every slice of the application, flat - emission builds the feature tree from the namespaces.</param>
+public record ApplicationModel(
+    string Domain,
+    string Module,
+    IEnumerable<ConceptModel> Concepts,
+    IEnumerable<PolicyModel> Policies,
+    IEnumerable<SliceModel> Slices)
+{
+    /// <summary>
+    /// Represents an application that declares nothing at all.
+    /// </summary>
+    public static readonly ApplicationModel Empty = new(string.Empty, string.Empty, [], [], []);
+}

--- a/Source/DotNET/Screenplay/Model/AuthenticatedRequirement.cs
+++ b/Source/DotNET/Screenplay/Model/AuthenticatedRequirement.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a policy requiring nothing of the caller beyond being authenticated.
+/// </summary>
+public record AuthenticatedRequirement : PolicyRequirementModel
+{
+    /// <summary>
+    /// The single instance, since the requirement carries no state.
+    /// </summary>
+    public static readonly AuthenticatedRequirement Instance = new();
+}

--- a/Source/DotNET/Screenplay/Model/AuthorizationModel.cs
+++ b/Source/DotNET/Screenplay/Model/AuthorizationModel.cs
@@ -14,4 +14,14 @@ public record AuthorizationModel(bool RequiresAuthentication, IEnumerable<string
     /// Represents an artifact that is open to anonymous callers.
     /// </summary>
     public static readonly AuthorizationModel None = new(false, []);
+
+    /// <summary>
+    /// Gets the named policies the caller has to satisfy, all of them.
+    /// </summary>
+    /// <remarks>
+    /// A policy is named on the artifact but declared where the application is composed, so the name is all the
+    /// artifact itself says. Carrying it is what keeps a document from flattening every policy into the one thing
+    /// they all have in common, which is that somebody has to be there at all.
+    /// </remarks>
+    public IEnumerable<string> Policies { get; init; } = [];
 }

--- a/Source/DotNET/Screenplay/Model/AuthorizationModel.cs
+++ b/Source/DotNET/Screenplay/Model/AuthorizationModel.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents what an artifact requires of the caller.
+/// </summary>
+/// <param name="RequiresAuthentication">Whether the caller has to be authenticated.</param>
+/// <param name="Roles">The roles the caller may hold - any one of them is sufficient.</param>
+public record AuthorizationModel(bool RequiresAuthentication, IEnumerable<string> Roles)
+{
+    /// <summary>
+    /// Represents an artifact that is open to anonymous callers.
+    /// </summary>
+    public static readonly AuthorizationModel None = new(false, []);
+}

--- a/Source/DotNET/Screenplay/Model/ClaimRequirement.cs
+++ b/Source/DotNET/Screenplay/Model/ClaimRequirement.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a policy requiring the caller to carry a claim with a given value.
+/// </summary>
+/// <param name="Claim">The name of the claim.</param>
+/// <param name="Value">The value the claim has to match.</param>
+public record ClaimRequirement(string Claim, string Value) : PolicyRequirementModel;

--- a/Source/DotNET/Screenplay/Model/CombinedRequirement.cs
+++ b/Source/DotNET/Screenplay/Model/CombinedRequirement.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents two policy requirements combined with a logical operator.
+/// </summary>
+/// <param name="Left">The left hand requirement.</param>
+/// <param name="IsOr">Whether the requirements are combined with <c>or</c> rather than <c>and</c>.</param>
+/// <param name="Right">The right hand requirement.</param>
+/// <remarks>
+/// Requirements registered one after the other all have to hold, while the several values one of them accepts are
+/// alternatives. Build these trees left associatively - Screenplay has no parentheses in a policy condition, so
+/// anything else changes meaning on a round trip.
+/// </remarks>
+public record CombinedRequirement(PolicyRequirementModel Left, bool IsOr, PolicyRequirementModel Right) : PolicyRequirementModel;

--- a/Source/DotNET/Screenplay/Model/CommandModel.cs
+++ b/Source/DotNET/Screenplay/Model/CommandModel.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents the imperative intent a slice exposes.
+/// </summary>
+/// <param name="Name">The name of the command.</param>
+/// <param name="Description">The description of the command, if it has one.</param>
+/// <param name="Properties">The properties making up the input of the command.</param>
+/// <param name="Authorization">What the command requires of the caller, if anything.</param>
+/// <param name="Validations">The validation rules declared for the command.</param>
+/// <param name="Produces">The events the command produces.</param>
+/// <param name="Concurrency">The concurrency scope the command appends within, if it declares one.</param>
+/// <param name="SourceFilePath">The path of the file implementing the command, if it is known.</param>
+/// <remarks>
+/// A command declares either <paramref name="Produces"/> or a handler file, never both - the two together do not
+/// compile. The source file path is therefore only emitted as a handler when nothing is produced declaratively.
+/// </remarks>
+public record CommandModel(
+    string Name,
+    string? Description,
+    IEnumerable<PropertyModel> Properties,
+    AuthorizationModel? Authorization,
+    IEnumerable<ValidationRuleModel> Validations,
+    IEnumerable<ProducesModel> Produces,
+    ConcurrencyModel? Concurrency,
+    string? SourceFilePath);

--- a/Source/DotNET/Screenplay/Model/ComparisonCondition.cs
+++ b/Source/DotNET/Screenplay/Model/ComparisonCondition.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a condition comparing a property against a value.
+/// </summary>
+/// <param name="Left">The dotted path of the property being compared, in its original casing.</param>
+/// <param name="Operator">The comparison being made.</param>
+/// <param name="Right">What the property is compared against.</param>
+public record ComparisonCondition(string Left, ComparisonKind Operator, MappingSourceModel Right) : ConditionModel;

--- a/Source/DotNET/Screenplay/Model/ComparisonKind.cs
+++ b/Source/DotNET/Screenplay/Model/ComparisonKind.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents the comparison a condition makes.
+/// </summary>
+public enum ComparisonKind
+{
+    /// <summary>
+    /// The values are equal.
+    /// </summary>
+    Equal = 0,
+
+    /// <summary>
+    /// The values are not equal.
+    /// </summary>
+    NotEqual = 1,
+
+    /// <summary>
+    /// The left hand value is greater than the right hand value.
+    /// </summary>
+    GreaterThan = 2,
+
+    /// <summary>
+    /// The left hand value is greater than or equal to the right hand value.
+    /// </summary>
+    GreaterThanOrEqual = 3,
+
+    /// <summary>
+    /// The left hand value is less than the right hand value.
+    /// </summary>
+    LessThan = 4,
+
+    /// <summary>
+    /// The left hand value is less than or equal to the right hand value.
+    /// </summary>
+    LessThanOrEqual = 5
+}

--- a/Source/DotNET/Screenplay/Model/ConceptModel.cs
+++ b/Source/DotNET/Screenplay/Model/ConceptModel.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a strongly typed domain value declared at the document level.
+/// </summary>
+/// <param name="Name">The name of the concept.</param>
+/// <param name="Primitive">The primitive the concept is backed by.</param>
+/// <param name="IsPii">Whether the concept carries personally identifiable information.</param>
+/// <param name="EnumValues">The enumeration values, empty unless <paramref name="Primitive"/> is <see cref="ScreenplayPrimitive.Enum"/>.</param>
+/// <param name="Validations">The validation rules the concept declares for itself.</param>
+/// <remarks>
+/// The <see cref="ValidationRuleModel.Property"/> of every rule is ignored - inside a concept declaration the
+/// concept's own value is the implied subject.
+/// </remarks>
+public record ConceptModel(
+    string Name,
+    ScreenplayPrimitive Primitive,
+    bool IsPii,
+    IEnumerable<string> EnumValues,
+    IEnumerable<ValidationRuleModel> Validations);

--- a/Source/DotNET/Screenplay/Model/ConcurrencyModel.cs
+++ b/Source/DotNET/Screenplay/Model/ConcurrencyModel.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents the scope a command's appends are checked for concurrent writers within.
+/// </summary>
+/// <param name="EventSource">Whether the scope includes the event source.</param>
+/// <param name="SourceType">The event source type the scope is narrowed to, if any.</param>
+/// <param name="StreamType">The event stream type the scope is narrowed to, if any.</param>
+/// <param name="StreamId">The event stream identifier the scope is narrowed to, if any.</param>
+/// <param name="EventTypes">The event types the scope is narrowed to.</param>
+/// <remarks>
+/// A concurrency block that narrows nothing at all is a compile error, so a model carrying no dimension is left out
+/// of the document rather than emitted empty.
+/// </remarks>
+public record ConcurrencyModel(
+    bool EventSource,
+    string? SourceType,
+    string? StreamType,
+    string? StreamId,
+    IEnumerable<string> EventTypes);

--- a/Source/DotNET/Screenplay/Model/ConditionModel.cs
+++ b/Source/DotNET/Screenplay/Model/ConditionModel.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a condition guarding the production of an event.
+/// </summary>
+public abstract record ConditionModel;

--- a/Source/DotNET/Screenplay/Model/ConstraintModel.cs
+++ b/Source/DotNET/Screenplay/Model/ConstraintModel.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents an invariant enforced when events are appended.
+/// </summary>
+/// <param name="Name">The name of the constraint.</param>
+public abstract record ConstraintModel(string Name);

--- a/Source/DotNET/Screenplay/Model/ContextSource.cs
+++ b/Source/DotNET/Screenplay/Model/ContextSource.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a value taken from the ambient execution context.
+/// </summary>
+/// <param name="Path">The dotted path within the context, for example <c>occurred</c> or <c>identity.id</c>.</param>
+public record ContextSource(string Path) : MappingSourceModel;

--- a/Source/DotNET/Screenplay/Model/CustomConstraintModel.cs
+++ b/Source/DotNET/Screenplay/Model/CustomConstraintModel.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a constraint whose rule lives in code rather than in the declaration.
+/// </summary>
+/// <param name="Name">The name of the constraint.</param>
+/// <param name="SourceFilePath">The path of the file implementing the constraint, if it is known.</param>
+public record CustomConstraintModel(string Name, string? SourceFilePath) : ConstraintModel(Name);

--- a/Source/DotNET/Screenplay/Model/EnumValue.cs
+++ b/Source/DotNET/Screenplay/Model/EnumValue.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a constant that names a member of an enumeration.
+/// </summary>
+/// <param name="Member">The name of the member, in the casing the enumeration declares it.</param>
+/// <remarks>
+/// A constant of an enumeration arrives from the compiler as the number behind the member rather than as the member,
+/// so a literal carrying the number alone refers to a value by a form the document never declares - the concept says
+/// <c>clientContact</c> and the reference would read <c>6</c>. Naming the member is what lets emission write the form
+/// the concept declares, while the model keeps to a name and stays free of anything the compiler knows.
+/// </remarks>
+public record EnumValue(string Member);

--- a/Source/DotNET/Screenplay/Model/EventModel.cs
+++ b/Source/DotNET/Screenplay/Model/EventModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents an immutable fact about something that happened.
+/// </summary>
+/// <param name="Name">The name of the event.</param>
+/// <param name="Properties">The properties carried by the event.</param>
+/// <param name="Tags">The tags the event is classified by.</param>
+public record EventModel(string Name, IEnumerable<PropertyModel> Properties, IEnumerable<string> Tags);

--- a/Source/DotNET/Screenplay/Model/LiteralSource.cs
+++ b/Source/DotNET/Screenplay/Model/LiteralSource.cs
@@ -6,9 +6,13 @@ namespace Cratis.Arc.Screenplay.Model;
 /// <summary>
 /// Represents a constant value.
 /// </summary>
-/// <param name="Value">The value - <see langword="null"/>, a <see cref="bool"/>, a <see cref="string"/> or a number.</param>
+/// <param name="Value">The value - <see langword="null"/>, a <see cref="bool"/>, a <see cref="string"/>, a number or an <see cref="EnumValue"/>.</param>
 /// <remarks>
 /// Every number reaching the printer has to be a <see cref="double"/>, because anything else is formatted with the
 /// current culture. Emission converts numeric values, so any numeric type may be carried here.
+/// <para>
+/// A member of an enumeration is carried as an <see cref="EnumValue"/> rather than as the number behind it, because
+/// the number says nothing about which member of the concept it names.
+/// </para>
 /// </remarks>
 public record LiteralSource(object? Value) : MappingSourceModel;

--- a/Source/DotNET/Screenplay/Model/LiteralSource.cs
+++ b/Source/DotNET/Screenplay/Model/LiteralSource.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a constant value.
+/// </summary>
+/// <param name="Value">The value - <see langword="null"/>, a <see cref="bool"/>, a <see cref="string"/> or a number.</param>
+/// <remarks>
+/// Every number reaching the printer has to be a <see cref="double"/>, because anything else is formatted with the
+/// current culture. Emission converts numeric values, so any numeric type may be carried here.
+/// </remarks>
+public record LiteralSource(object? Value) : MappingSourceModel;

--- a/Source/DotNET/Screenplay/Model/LogicalCondition.cs
+++ b/Source/DotNET/Screenplay/Model/LogicalCondition.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents two conditions combined with a logical operator.
+/// </summary>
+/// <param name="Left">The left hand condition.</param>
+/// <param name="IsOr">Whether the conditions are combined with <c>or</c> rather than <c>and</c>.</param>
+/// <param name="Right">The right hand condition.</param>
+/// <remarks>
+/// Screenplay has no parentheses in conditions, so nesting is flattened when printed. Build these trees left
+/// associatively - anything else changes meaning on a round trip.
+/// </remarks>
+public record LogicalCondition(ConditionModel Left, bool IsOr, ConditionModel Right) : ConditionModel;

--- a/Source/DotNET/Screenplay/Model/MappingSourceModel.cs
+++ b/Source/DotNET/Screenplay/Model/MappingSourceModel.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents where the value of a mapped property comes from.
+/// </summary>
+public abstract record MappingSourceModel;

--- a/Source/DotNET/Screenplay/Model/PolicyModel.cs
+++ b/Source/DotNET/Screenplay/Model/PolicyModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a named authorization rule declared at the document level.
+/// </summary>
+/// <param name="Name">The name of the policy.</param>
+/// <param name="RequiresAuthentication">Whether the policy requires an authenticated caller.</param>
+/// <param name="Role">The role the caller has to hold, or <see langword="null"/> when the policy names no role.</param>
+public record PolicyModel(string Name, bool RequiresAuthentication, string? Role);

--- a/Source/DotNET/Screenplay/Model/PolicyModel.cs
+++ b/Source/DotNET/Screenplay/Model/PolicyModel.cs
@@ -7,6 +7,15 @@ namespace Cratis.Arc.Screenplay.Model;
 /// Represents a named authorization rule declared at the document level.
 /// </summary>
 /// <param name="Name">The name of the policy.</param>
-/// <param name="RequiresAuthentication">Whether the policy requires an authenticated caller.</param>
-/// <param name="Role">The role the caller has to hold, or <see langword="null"/> when the policy names no role.</param>
-public record PolicyModel(string Name, bool RequiresAuthentication, string? Role);
+/// <param name="Requirement">
+/// What the policy requires of the caller, or <see langword="null"/> when it could not be recovered.
+/// </param>
+public record PolicyModel(string Name, PolicyRequirementModel? Requirement)
+{
+    /// <summary>
+    /// Creates the policy a role implies.
+    /// </summary>
+    /// <param name="role">The name of the role.</param>
+    /// <returns>The <see cref="PolicyModel"/>.</returns>
+    public static PolicyModel ForRole(string role) => new(role, new RoleRequirement(role));
+}

--- a/Source/DotNET/Screenplay/Model/PolicyRequirementModel.cs
+++ b/Source/DotNET/Screenplay/Model/PolicyRequirementModel.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents what a named authorization policy requires of the caller.
+/// </summary>
+/// <remarks>
+/// A policy is more than a role - it can require a claim to carry a value, and it can combine requirements - so the
+/// requirement is a tree rather than a single name. What a policy requires is declared where the application is
+/// composed rather than on the artifact using it, which is why it is recovered separately from the authorization.
+/// </remarks>
+public abstract record PolicyRequirementModel;

--- a/Source/DotNET/Screenplay/Model/ProducesModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProducesModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents an event a command produces.
+/// </summary>
+/// <param name="EventName">The name of the event produced.</param>
+/// <param name="When">The condition the production is guarded by, or <see langword="null"/> when it is unconditional.</param>
+/// <param name="Mappings">The mappings from command input onto event properties.</param>
+public record ProducesModel(
+    string EventName,
+    ConditionModel? When,
+    IEnumerable<PropertyMappingModel> Mappings);

--- a/Source/DotNET/Screenplay/Model/ProjectionAutoMapMode.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionAutoMapMode.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents how automatic property mapping applies to a projection scope.
+/// </summary>
+public enum ProjectionAutoMapMode
+{
+    /// <summary>
+    /// Inherit the setting of the enclosing scope.
+    /// </summary>
+    Inherit = 0,
+
+    /// <summary>
+    /// Do not map properties automatically.
+    /// </summary>
+    Disabled = 1,
+
+    /// <summary>
+    /// Map properties automatically.
+    /// </summary>
+    Enabled = 2
+}

--- a/Source/DotNET/Screenplay/Model/ProjectionChildScopeModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionChildScopeModel.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a child collection or nested object of a projection.
+/// </summary>
+/// <param name="Property">The read model property holding the children or nested object.</param>
+/// <param name="IdentifiedBy">The expression identifying each child, empty for a nested object.</param>
+/// <param name="AutoMap">How automatic property mapping applies.</param>
+/// <param name="Scope">Everything declared within the child or nested scope.</param>
+public record ProjectionChildScopeModel(
+    string Property,
+    string IdentifiedBy,
+    ProjectionAutoMapMode AutoMap,
+    ProjectionScopeModel Scope);

--- a/Source/DotNET/Screenplay/Model/ProjectionEveryModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionEveryModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a block applying to every event a projection observes.
+/// </summary>
+/// <param name="Properties">The read model property to event expression map.</param>
+/// <param name="IncludeChildren">Whether the block also applies to child objects.</param>
+/// <param name="AutoMap">How automatic property mapping applies.</param>
+public record ProjectionEveryModel(
+    IReadOnlyDictionary<string, string> Properties,
+    bool IncludeChildren,
+    ProjectionAutoMapMode AutoMap);

--- a/Source/DotNET/Screenplay/Model/ProjectionFromModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionFromModel.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a block observing one or more event types.
+/// </summary>
+/// <param name="EventTypes">The identifiers of the event types observed.</param>
+/// <param name="Key">The key expression, if the block declares one.</param>
+/// <param name="ParentKey">The parent key expression, if the block declares one.</param>
+/// <param name="Properties">The read model property to event expression map.</param>
+public record ProjectionFromModel(
+    IEnumerable<string> EventTypes,
+    string? Key,
+    string? ParentKey,
+    IReadOnlyDictionary<string, string> Properties);

--- a/Source/DotNET/Screenplay/Model/ProjectionJoinModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionJoinModel.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a block joining data from another event onto a read model property.
+/// </summary>
+/// <param name="Property">The read model property holding the joined data.</param>
+/// <param name="EventType">The identifier of the event type joined from.</param>
+/// <param name="On">The read model property the join keys on.</param>
+/// <param name="Properties">The read model property to event expression map.</param>
+/// <remarks>
+/// The grammar names the property holding the joined data and the property the join keys on separately. The
+/// model-bound form declares both directly - the attribute sits on the property being filled in - while the fluent
+/// form has no such property, so analysis names the join after the first property it fills in.
+/// </remarks>
+public record ProjectionJoinModel(
+    string Property,
+    string EventType,
+    string On,
+    IReadOnlyDictionary<string, string> Properties);

--- a/Source/DotNET/Screenplay/Model/ProjectionModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionModel.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a projection that builds a read model from events.
+/// </summary>
+/// <param name="Identifier">The identifier of the projection.</param>
+/// <param name="ReadModel">The name of the read model the projection builds.</param>
+/// <param name="EventSequenceId">The identifier of the event sequence the projection observes.</param>
+/// <param name="AutoMap">How automatic property mapping applies at the root.</param>
+/// <param name="SubscribesToAllEvents">Whether the projection observes every event type in the system.</param>
+/// <param name="Scope">Everything the projection declares at its root.</param>
+public record ProjectionModel(
+    string Identifier,
+    string ReadModel,
+    string EventSequenceId,
+    ProjectionAutoMapMode AutoMap,
+    bool SubscribesToAllEvents,
+    ProjectionScopeModel Scope);

--- a/Source/DotNET/Screenplay/Model/ProjectionRemoveModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionRemoveModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a block removing a read model instance when an event occurs.
+/// </summary>
+/// <param name="EventType">The identifier of the event type triggering the removal.</param>
+/// <param name="Key">The key expression, if the block declares one.</param>
+/// <param name="ParentKey">The parent key expression, if the block declares one.</param>
+public record ProjectionRemoveModel(string EventType, string? Key, string? ParentKey);

--- a/Source/DotNET/Screenplay/Model/ProjectionScopeModel.cs
+++ b/Source/DotNET/Screenplay/Model/ProjectionScopeModel.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents everything declared within one projection scope - the projection itself, or a child or nested object.
+/// </summary>
+/// <param name="From">The blocks observing specific event types.</param>
+/// <param name="Every">The block applying to every observed event, if the scope declares one.</param>
+/// <param name="Joins">The blocks joining data from other events.</param>
+/// <param name="Children">The child collections of the scope.</param>
+/// <param name="Nested">The nested objects of the scope.</param>
+/// <param name="RemovedWith">The blocks removing instances when an event occurs.</param>
+/// <param name="RemovedWithJoin">The blocks removing joined instances when an event occurs.</param>
+public record ProjectionScopeModel(
+    IEnumerable<ProjectionFromModel> From,
+    ProjectionEveryModel? Every,
+    IEnumerable<ProjectionJoinModel> Joins,
+    IEnumerable<ProjectionChildScopeModel> Children,
+    IEnumerable<ProjectionChildScopeModel> Nested,
+    IEnumerable<ProjectionRemoveModel> RemovedWith,
+    IEnumerable<ProjectionRemoveModel> RemovedWithJoin)
+{
+    /// <summary>
+    /// Represents a scope declaring nothing at all.
+    /// </summary>
+    public static readonly ProjectionScopeModel Empty = new([], null, [], [], [], [], []);
+}

--- a/Source/DotNET/Screenplay/Model/PropertyMappingModel.cs
+++ b/Source/DotNET/Screenplay/Model/PropertyMappingModel.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a single property of a produced event and where its value comes from.
+/// </summary>
+/// <param name="Property">The name of the property being mapped onto, in its original casing.</param>
+/// <param name="Source">Where the value comes from.</param>
+public record PropertyMappingModel(string Property, MappingSourceModel Source);

--- a/Source/DotNET/Screenplay/Model/PropertyModel.cs
+++ b/Source/DotNET/Screenplay/Model/PropertyModel.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a property of a command, an event or a query parameter.
+/// </summary>
+/// <param name="Name">The name of the property, in its original casing - emission camel cases it.</param>
+/// <param name="Type">The type of the property.</param>
+public record PropertyModel(string Name, TypeReferenceModel Type);

--- a/Source/DotNET/Screenplay/Model/PropertyPathSource.cs
+++ b/Source/DotNET/Screenplay/Model/PropertyPathSource.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a value taken from a property of the command.
+/// </summary>
+/// <param name="Path">The dotted path to the property, in its original casing.</param>
+public record PropertyPathSource(string Path) : MappingSourceModel;

--- a/Source/DotNET/Screenplay/Model/QueryModel.cs
+++ b/Source/DotNET/Screenplay/Model/QueryModel.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a read side entry point onto a read model.
+/// </summary>
+/// <param name="Name">The name of the query.</param>
+/// <param name="ReturnType">The type the query returns.</param>
+/// <param name="By">The parameter identifying a single instance, if the query takes one.</param>
+/// <param name="Filters">The parameters narrowing the result.</param>
+/// <param name="Authorization">What the query requires of the caller, if anything.</param>
+public record QueryModel(
+    string Name,
+    TypeReferenceModel ReturnType,
+    PropertyModel? By,
+    IEnumerable<PropertyModel> Filters,
+    AuthorizationModel? Authorization);

--- a/Source/DotNET/Screenplay/Model/ReactorModel.cs
+++ b/Source/DotNET/Screenplay/Model/ReactorModel.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents something that observes events and causes an effect.
+/// </summary>
+/// <param name="Name">The name of the reactor.</param>
+/// <param name="ObservedEvents">The names of the events the reactor observes.</param>
+/// <param name="IsTranslating">Whether the reactor turns events into further events or commands.</param>
+/// <param name="SourceFilePath">The path of the file implementing the reactor, if it is known.</param>
+public record ReactorModel(
+    string Name,
+    IEnumerable<string> ObservedEvents,
+    bool IsTranslating,
+    string? SourceFilePath);

--- a/Source/DotNET/Screenplay/Model/RoleRequirement.cs
+++ b/Source/DotNET/Screenplay/Model/RoleRequirement.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a policy requiring the caller to hold a role.
+/// </summary>
+/// <param name="Role">The name of the role.</param>
+public record RoleRequirement(string Role) : PolicyRequirementModel;

--- a/Source/DotNET/Screenplay/Model/ScreenDataModel.cs
+++ b/Source/DotNET/Screenplay/Model/ScreenDataModel.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a read model a screen binds through one of the queries its slice declares.
+/// </summary>
+/// <param name="Query">The name of the query providing the data, as the slice declares it.</param>
+/// <param name="Type">The type the query returns.</param>
+/// <param name="By">The name of the parameter the query is keyed by, if it has one.</param>
+/// <remarks>
+/// A binding is the one part of a screen a compilation can vouch for. The component names the query it imports, and
+/// that name either is a query the slice declares or is not - so what the document says about the binding comes from
+/// the model rather than from reading a user interface. Everything the binding is then described with - the return
+/// type, the parameter it is keyed by - comes from the query itself and never from the component.
+/// </remarks>
+public record ScreenDataModel(string Query, TypeReferenceModel Type, string? By);

--- a/Source/DotNET/Screenplay/Model/ScreenModel.cs
+++ b/Source/DotNET/Screenplay/Model/ScreenModel.cs
@@ -4,13 +4,21 @@
 namespace Cratis.Arc.Screenplay.Model;
 
 /// <summary>
-/// Represents a screen of a slice, realized by a file rather than described declaratively.
+/// Represents a screen of a slice, realized by a file and bound to the queries it reads.
 /// </summary>
 /// <param name="Name">The name of the screen, as the file realizing it is named.</param>
 /// <param name="FilePath">The path of the file realizing the screen, relative to the root of the source.</param>
 /// <remarks>
-/// A screen is the one part of a slice whose realization is not C#, so the only thing recovered about it is which
-/// file realizes it. Saying that much is worth doing - it is what lets a reader open the screen a slice ends in -
-/// and saying more would mean inventing structure that nothing in the source states.
+/// A screen is the one part of a slice whose realization is not C#, so most of what it shows stays where it is
+/// written. Two things are still recovered: which file realizes it, which is what lets a reader open it, and which
+/// of the slice's queries it binds, which is a name the model already holds and can be checked against. What the
+/// screen then does with that data - its sections, tables, columns and actions - is structure expressed in JSX, and
+/// inventing it would put a confident falsehood into a document whose whole value is that it is true.
 /// </remarks>
-public record ScreenModel(string Name, string FilePath);
+public record ScreenModel(string Name, string FilePath)
+{
+    /// <summary>
+    /// Gets the read models the screen binds through the queries of its slice.
+    /// </summary>
+    public IEnumerable<ScreenDataModel> Data { get; init; } = [];
+}

--- a/Source/DotNET/Screenplay/Model/ScreenModel.cs
+++ b/Source/DotNET/Screenplay/Model/ScreenModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a screen of a slice, realized by a file rather than described declaratively.
+/// </summary>
+/// <param name="Name">The name of the screen, as the file realizing it is named.</param>
+/// <param name="FilePath">The path of the file realizing the screen, relative to the root of the source.</param>
+/// <remarks>
+/// A screen is the one part of a slice whose realization is not C#, so the only thing recovered about it is which
+/// file realizes it. Saying that much is worth doing - it is what lets a reader open the screen a slice ends in -
+/// and saying more would mean inventing structure that nothing in the source states.
+/// </remarks>
+public record ScreenModel(string Name, string FilePath);

--- a/Source/DotNET/Screenplay/Model/ScreenplayPrimitive.cs
+++ b/Source/DotNET/Screenplay/Model/ScreenplayPrimitive.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+#pragma warning disable CA1720 // Identifier contains type name. These are the Screenplay primitive names and cannot be renamed.
+
+/// <summary>
+/// Represents the primitive a concept is backed by.
+/// </summary>
+public enum ScreenplayPrimitive
+{
+    /// <summary>
+    /// A universally unique identifier.
+    /// </summary>
+    Uuid = 0,
+
+    /// <summary>
+    /// Textual content.
+    /// </summary>
+    String = 1,
+
+    /// <summary>
+    /// A whole number.
+    /// </summary>
+    Int = 2,
+
+    /// <summary>
+    /// A fractional number.
+    /// </summary>
+    Decimal = 3,
+
+    /// <summary>
+    /// A boolean.
+    /// </summary>
+    Bool = 4,
+
+    /// <summary>
+    /// A date without a time component.
+    /// </summary>
+    Date = 5,
+
+    /// <summary>
+    /// A point in time.
+    /// </summary>
+    DateTime = 6,
+
+    /// <summary>
+    /// An enumeration, whose members are declared as values.
+    /// </summary>
+    Enum = 7
+}
+
+#pragma warning restore CA1720 // Identifier contains type name

--- a/Source/DotNET/Screenplay/Model/SliceKind.cs
+++ b/Source/DotNET/Screenplay/Model/SliceKind.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents the Event Modeling kind of a slice.
+/// </summary>
+public enum SliceKind
+{
+    /// <summary>
+    /// The command to events strip - it changes the system.
+    /// </summary>
+    StateChange = 0,
+
+    /// <summary>
+    /// The events to read model to user interface strip - it reads the system.
+    /// </summary>
+    StateView = 1,
+
+    /// <summary>
+    /// The event to side effect strip - it reacts to what happened.
+    /// </summary>
+    Automation = 2,
+
+    /// <summary>
+    /// The adaptation strip - it turns one part of the model, or an external system, into events.
+    /// </summary>
+    Translate = 3
+}

--- a/Source/DotNET/Screenplay/Model/SliceModel.cs
+++ b/Source/DotNET/Screenplay/Model/SliceModel.cs
@@ -29,6 +29,15 @@ public record SliceModel(
     IEnumerable<ConstraintModel> Constraints)
 {
     /// <summary>
+    /// Gets the screens the slice ends in.
+    /// </summary>
+    /// <remarks>
+    /// Screens are the only part of a slice that is not recovered from the compilation, so they are carried
+    /// alongside what is rather than within it - a slice that nothing knows the screens of is still a slice.
+    /// </remarks>
+    public IEnumerable<ScreenModel> Screens { get; init; } = [];
+
+    /// <summary>
     /// Creates a slice that declares nothing, for use as a starting point.
     /// </summary>
     /// <param name="namespace">The full namespace the slice lives in.</param>

--- a/Source/DotNET/Screenplay/Model/SliceModel.cs
+++ b/Source/DotNET/Screenplay/Model/SliceModel.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a single vertical slice of the application.
+/// </summary>
+/// <param name="Namespace">The full namespace the slice lives in, for example <c>Library.Authors.Registration</c>.</param>
+/// <param name="Name">The name of the slice.</param>
+/// <param name="Kind">The Event Modeling kind of the slice.</param>
+/// <param name="Description">The description of the slice, if it has one.</param>
+/// <param name="Commands">The commands the slice declares.</param>
+/// <param name="Events">The events the slice declares.</param>
+/// <param name="Queries">The queries the slice declares.</param>
+/// <param name="Projection">The single projection the slice declares, if it has one.</param>
+/// <param name="Reactors">The reactors the slice declares.</param>
+/// <param name="Constraints">The constraints the slice declares.</param>
+public record SliceModel(
+    string Namespace,
+    string Name,
+    SliceKind Kind,
+    string? Description,
+    IEnumerable<CommandModel> Commands,
+    IEnumerable<EventModel> Events,
+    IEnumerable<QueryModel> Queries,
+    ProjectionModel? Projection,
+    IEnumerable<ReactorModel> Reactors,
+    IEnumerable<ConstraintModel> Constraints)
+{
+    /// <summary>
+    /// Creates a slice that declares nothing, for use as a starting point.
+    /// </summary>
+    /// <param name="namespace">The full namespace the slice lives in.</param>
+    /// <param name="name">The name of the slice.</param>
+    /// <param name="kind">The Event Modeling kind of the slice.</param>
+    /// <returns>The empty <see cref="SliceModel"/>.</returns>
+    public static SliceModel Empty(string @namespace, string name, SliceKind kind) =>
+        new(@namespace, name, kind, null, [], [], [], null, [], []);
+}

--- a/Source/DotNET/Screenplay/Model/TypeReferenceModel.cs
+++ b/Source/DotNET/Screenplay/Model/TypeReferenceModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a reference to a type - a Screenplay primitive, a concept or a declared model.
+/// </summary>
+/// <param name="Name">The name of the type being referenced.</param>
+/// <param name="IsCollection">Whether the reference is to a collection of the type.</param>
+/// <param name="IsOptional">Whether the reference is optional.</param>
+public record TypeReferenceModel(string Name, bool IsCollection, bool IsOptional);

--- a/Source/DotNET/Screenplay/Model/UniqueEventConstraintModel.cs
+++ b/Source/DotNET/Screenplay/Model/UniqueEventConstraintModel.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a constraint requiring an event to occur at most once per event source.
+/// </summary>
+/// <param name="Name">The name of the constraint.</param>
+/// <param name="EventName">The name of the event the constraint applies to.</param>
+public record UniqueEventConstraintModel(string Name, string EventName) : ConstraintModel(Name);

--- a/Source/DotNET/Screenplay/Model/UniquePropertyConstraintModel.cs
+++ b/Source/DotNET/Screenplay/Model/UniquePropertyConstraintModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a constraint requiring a property of an event to be unique.
+/// </summary>
+/// <param name="Name">The name of the constraint.</param>
+/// <param name="Property">The property that has to be unique, in its original casing.</param>
+/// <param name="EventName">The name of the event the constraint applies to.</param>
+public record UniquePropertyConstraintModel(string Name, string Property, string EventName) : ConstraintModel(Name);

--- a/Source/DotNET/Screenplay/Model/ValidationRuleKind.cs
+++ b/Source/DotNET/Screenplay/Model/ValidationRuleKind.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents the kind of a declarative validation rule.
+/// </summary>
+public enum ValidationRuleKind
+{
+    /// <summary>
+    /// The value has to be present.
+    /// </summary>
+    NotEmpty = 0,
+
+    /// <summary>
+    /// The value has to be at most the operand.
+    /// </summary>
+    Max = 1,
+
+    /// <summary>
+    /// The value has to be at least the operand.
+    /// </summary>
+    Min = 2,
+
+    /// <summary>
+    /// The value has to be greater than the operand.
+    /// </summary>
+    GreaterThan = 3,
+
+    /// <summary>
+    /// The value has to be greater than or equal to the operand.
+    /// </summary>
+    GreaterThanOrEqual = 4,
+
+    /// <summary>
+    /// The value has to be less than the operand.
+    /// </summary>
+    LessThan = 5,
+
+    /// <summary>
+    /// The value has to be less than or equal to the operand.
+    /// </summary>
+    LessThanOrEqual = 6,
+
+    /// <summary>
+    /// The value has to equal the operand.
+    /// </summary>
+    Equal = 7,
+
+    /// <summary>
+    /// The length of the value has to equal the operand.
+    /// </summary>
+    Length = 8,
+
+    /// <summary>
+    /// The value has to match the pattern in the operand.
+    /// </summary>
+    Matches = 9,
+
+    /// <summary>
+    /// Every element of the collection has to be greater than the operand.
+    /// </summary>
+    AllGreaterThan = 10,
+
+    /// <summary>
+    /// Every element of the collection has to be greater than or equal to the operand.
+    /// </summary>
+    AllGreaterThanOrEqual = 11
+}

--- a/Source/DotNET/Screenplay/Model/ValidationRuleModel.cs
+++ b/Source/DotNET/Screenplay/Model/ValidationRuleModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a single declarative validation rule.
+/// </summary>
+/// <param name="Property">The dotted path of the property the rule applies to, in its original casing.</param>
+/// <param name="Kind">The kind of rule.</param>
+/// <param name="Value">The operand, or <see langword="null"/> when the rule takes none.</param>
+/// <param name="Message">The message shown when the rule is broken, or <see langword="null"/> for the default.</param>
+/// <remarks>
+/// A message starting with <c>$strings.</c> is a localization key and is emitted unquoted.
+/// </remarks>
+public record ValidationRuleModel(string Property, ValidationRuleKind Kind, object? Value, string? Message);

--- a/Source/DotNET/Screenplay/Screenplay.csproj
+++ b/Source/DotNET/Screenplay/Screenplay.csproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.Screenplay</AssemblyName>
+        <RootNamespace>Cratis.Arc.Screenplay</RootNamespace>
+        <Description>Generates a Cratis Screenplay .play file from the source of a Cratis Arc application</Description>
+        <PackageTags>cratis;arc;screenplay;event-modeling;play</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Cratis.Arc.Screenplay.Specs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Cratis.Screenplay" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Screenplay/ScreenplayDiagnostic.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnostic.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Represents something the generator could not express, reported instead of being silently dropped.
+/// </summary>
+/// <param name="Severity">How serious the diagnostic is.</param>
+/// <param name="Code">The stable code identifying the kind of diagnostic, for example <c>SP0001</c>.</param>
+/// <param name="Message">What happened, in terms the reader can act on.</param>
+/// <param name="Location">Where it happened - a namespace, a declaration name or a file path.</param>
+public record ScreenplayDiagnostic(
+    ScreenplayDiagnosticSeverity Severity,
+    string Code,
+    string Message,
+    string? Location)
+{
+    /// <inheritdoc/>
+    public override string ToString() =>
+        Location is null ? $"{Severity} {Code}: {Message}" : $"{Severity} {Code}: {Message} ({Location})";
+}

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Holds the stable codes every <see cref="ScreenplayDiagnostic"/> is identified by.
+/// </summary>
+/// <remarks>
+/// Codes are never reused and never renumbered - consumers suppress and group on them.
+/// </remarks>
+public static class ScreenplayDiagnosticCodes
+{
+    /// <summary>
+    /// Source analysis has not produced a model.
+    /// </summary>
+    public const string AnalysisUnavailable = "SP0001";
+
+    /// <summary>
+    /// A slice declared nothing that can be expressed and was left out.
+    /// </summary>
+    public const string EmptySlice = "SP0002";
+
+    /// <summary>
+    /// A concept declared an enumeration without any values and was left out.
+    /// </summary>
+    public const string EnumWithoutValues = "SP0003";
+
+    /// <summary>
+    /// A projection produced no directives at all and was left out.
+    /// </summary>
+    public const string EmptyProjection = "SP0004";
+
+    /// <summary>
+    /// A projection property expression has no counterpart in the projection definition language.
+    /// </summary>
+    public const string UnmappableProjectionExpression = "SP0005";
+
+    /// <summary>
+    /// A projection key has no counterpart in the projection definition language.
+    /// </summary>
+    public const string UnmappableProjectionKey = "SP0006";
+
+    /// <summary>
+    /// A child or nested projection scope could not be expressed and was left out.
+    /// </summary>
+    public const string UnmappableProjectionScope = "SP0007";
+
+    /// <summary>
+    /// A join declared no property to key on and was left out.
+    /// </summary>
+    public const string UnmappableProjectionJoin = "SP0008";
+
+    /// <summary>
+    /// A reactor observed no events and was left out.
+    /// </summary>
+    public const string ReactorWithoutEvents = "SP0009";
+
+    /// <summary>
+    /// A concurrency scope narrowed nothing at all and was left out.
+    /// </summary>
+    public const string EmptyConcurrencyScope = "SP0010";
+
+    /// <summary>
+    /// A validation rule requires an operand it was not given, and was left out.
+    /// </summary>
+    public const string ValidationRuleWithoutOperand = "SP0011";
+
+    /// <summary>
+    /// A command handler produces events in a way that could not be read from the source.
+    /// </summary>
+    public const string UnmappableCommandProduction = "SP0012";
+
+    /// <summary>
+    /// A command handler yields the identifier of the event source it appends to, which Screenplay cannot express.
+    /// </summary>
+    public const string UnmappableEventSourceIdResult = "SP0013";
+
+    /// <summary>
+    /// An event declares generations, a tombstone or a compensation, none of which Screenplay has a counterpart for.
+    /// </summary>
+    public const string EventFeatureWithoutCounterpart = "SP0014";
+
+    /// <summary>
+    /// A projection declares something the projection definition language has no counterpart for.
+    /// </summary>
+    public const string UnmappableProjectionConstruct = "SP0015";
+
+    /// <summary>
+    /// A validator declares a rule that could not be expressed declaratively.
+    /// </summary>
+    public const string UnmappableValidationRule = "SP0016";
+
+    /// <summary>
+    /// A constraint declares a rule that is neither unique on a property nor unique on an event type.
+    /// </summary>
+    public const string UnmappableConstraint = "SP0017";
+
+    /// <summary>
+    /// An aggregate root produces events from code, which Screenplay has no counterpart for.
+    /// </summary>
+    public const string AggregateRootWithoutCounterpart = "SP0018";
+
+    /// <summary>
+    /// A query returns something that could not be expressed as a Screenplay type reference.
+    /// </summary>
+    public const string UnmappableQuery = "SP0019";
+
+    /// <summary>
+    /// A reducer folds events into a read model, which Screenplay has no counterpart for.
+    /// </summary>
+    public const string ReducerWithoutCounterpart = "SP0020";
+
+    /// <summary>
+    /// An event referenced by the application is declared outside the compilation being analyzed.
+    /// </summary>
+    public const string EventDeclaredOutsideCompilation = "SP0021";
+
+    /// <summary>
+    /// More than one query in a slice is declared under the same name.
+    /// </summary>
+    public const string AmbiguousQueryName = "SP0022";
+
+    /// <summary>
+    /// A namespace carries no structure to arrange the document by, so several levels take the same name.
+    /// </summary>
+    public const string NamespaceWithoutStructure = "SP0023";
+}

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -130,4 +130,28 @@ public static class ScreenplayDiagnosticCodes
     /// The source did not compile, so nothing recovered from it can be relied on.
     /// </summary>
     public const string SourceDidNotCompile = "SP0024";
+
+    /// <summary>
+    /// A user interface file sits alongside the source of a slice whose relationship to it is not certain.
+    /// </summary>
+    /// <remarks>
+    /// A screen is recovered as a <c>file</c> reference and nothing more. The declarative form - <c>data</c> via a
+    /// query, <c>section</c>, <c>table</c> and <c>summary</c> with their columns and fields, <c>action</c> and
+    /// <c>navigate to</c> - is never inferred, because it would have to be read out of TypeScript and JSX rather
+    /// than out of the compilation, and a guess at a screen's structure is worse than saying which file realizes it.
+    /// Which file that is comes from where the file sits, so this reports every case where sitting there says less
+    /// than usual: source spread over several folders, one folder holding the source of several slices, and two
+    /// files claiming one screen name.
+    /// </remarks>
+    public const string AmbiguousScreenFile = "SP0025";
+
+    /// <summary>
+    /// A named authorization policy is referred to, but what it requires of the caller could not be recovered.
+    /// </summary>
+    /// <remarks>
+    /// The name of a policy sits on the artifact, while what it requires sits where the application is composed.
+    /// When the registration cannot be found or cannot be read, the document still declares the policy - a reference
+    /// to something undeclared is a document that warns - but it declares the least it can say rather than a guess.
+    /// </remarks>
+    public const string PolicyRequirementsUnrecoverable = "SP0026";
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -135,13 +135,9 @@ public static class ScreenplayDiagnosticCodes
     /// A user interface file sits alongside the source of a slice whose relationship to it is not certain.
     /// </summary>
     /// <remarks>
-    /// A screen is recovered as a <c>file</c> reference and nothing more. The declarative form - <c>data</c> via a
-    /// query, <c>section</c>, <c>table</c> and <c>summary</c> with their columns and fields, <c>action</c> and
-    /// <c>navigate to</c> - is never inferred, because it would have to be read out of TypeScript and JSX rather
-    /// than out of the compilation, and a guess at a screen's structure is worse than saying which file realizes it.
-    /// Which file that is comes from where the file sits, so this reports every case where sitting there says less
-    /// than usual: source spread over several folders, one folder holding the source of several slices, and two
-    /// files claiming one screen name.
+    /// Which file realizes a screen comes from where the file sits, so this reports every case where sitting there
+    /// says less than usual: source spread over several folders, one folder holding the source of several slices,
+    /// and two files claiming one screen name.
     /// </remarks>
     public const string AmbiguousScreenFile = "SP0025";
 
@@ -154,4 +150,42 @@ public static class ScreenplayDiagnosticCodes
     /// to something undeclared is a document that warns - but it declares the least it can say rather than a guess.
     /// </remarks>
     public const string PolicyRequirementsUnrecoverable = "SP0026";
+
+    /// <summary>
+    /// An event is produced from a branch guarded by the state an aggregate root holds.
+    /// </summary>
+    /// <remarks>
+    /// A <c>produces when</c> condition compares the input of the command and nothing else, because the input is all
+    /// a document knows about at the moment a command is issued. An aggregate root deciding on what it has already
+    /// seen is a real decision with nowhere in the language to go, which is a different thing from a guard that could
+    /// not be read - so it is reported apart from one, and the production is stated unconditionally.
+    /// </remarks>
+    public const string UnmappableAggregateStateCondition = "SP0027";
+
+    /// <summary>
+    /// The declarative body of a screen beyond the queries it binds is not inferred.
+    /// </summary>
+    /// <remarks>
+    /// A <c>data</c> directive is recovered, because the query a component imports is a name the model already knows
+    /// and can be checked against. Everything else a screen declares - <c>title</c>, <c>section</c>, <c>table</c> and
+    /// <c>summary</c> with their columns and fields, <c>action</c> and <c>navigate to</c> - is structure expressed in
+    /// JSX and component properties, which this generator does not read. A guessed column is worse than an absent
+    /// one, so none of it is inferred and every screen says so.
+    /// </remarks>
+    public const string ScreenStructureNotInferred = "SP0028";
+
+    /// <summary>
+    /// A type is referred to by a name that does not say what it is, because Screenplay cannot express it.
+    /// </summary>
+    /// <remarks>
+    /// A Screenplay type reference is a single identifier. A constructed generic loses its arguments the moment it is
+    /// written as one - a map of names to values becomes the word <c>KeyValuePair</c> - and the document then refers
+    /// to a type it never declares. Nothing better can be written, so what was lost is said instead.
+    /// </remarks>
+    public const string UnmappableTypeReference = "SP0030";
+
+    /// <summary>
+    /// Two types share the simple name a concept is declared under, so only the first of them is described.
+    /// </summary>
+    public const string AmbiguousConceptName = "SP0031";
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -125,4 +125,9 @@ public static class ScreenplayDiagnosticCodes
     /// A namespace carries no structure to arrange the document by, so several levels take the same name.
     /// </summary>
     public const string NamespaceWithoutStructure = "SP0023";
+
+    /// <summary>
+    /// The source did not compile, so nothing recovered from it can be relied on.
+    /// </summary>
+    public const string SourceDidNotCompile = "SP0024";
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -200,4 +200,15 @@ public static class ScreenplayDiagnosticCodes
     /// way and no other name describes the member, so the line is left out and what was lost is said instead.
     /// </remarks>
     public const string NameReservedByGrammar = "SP0032";
+
+    /// <summary>
+    /// A constant of an enumeration carries a value that enumeration declares no member with.
+    /// </summary>
+    /// <remarks>
+    /// A member of an enumeration is written as the name the concept declares it under - <c>"clientContact"</c> -
+    /// which is recovered from the number the compiler hands over. A number nothing is declared with is a cast or
+    /// several flags combined into one, and naming it would describe a value the application does not have, so the
+    /// number is written as it stands and what it names is left unsaid.
+    /// </remarks>
+    public const string UnnamedEnumerationValue = "SP0033";
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -188,4 +188,16 @@ public static class ScreenplayDiagnosticCodes
     /// Two types share the simple name a concept is declared under, so only the first of them is described.
     /// </summary>
     public const string AmbiguousConceptName = "SP0031";
+
+    /// <summary>
+    /// A name is one the block it is written in reads as a directive of its own, so the line carrying it is left out.
+    /// </summary>
+    /// <remarks>
+    /// Screenplay is line based and every block decides what a line is from its first word. A command property called
+    /// <c>Description</c> is written as <c>description RequestDescription</c>, which the command body reads as the
+    /// description of the command and rejects; an event property called <c>Tag</c> is written as <c>tag Something</c>,
+    /// which the event body reads as a tag and quietly swallows. The language has no escape for a name colliding this
+    /// way and no other name describes the member, so the line is left out and what was lost is said instead.
+    /// </remarks>
+    public const string NameReservedByGrammar = "SP0032";
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticSeverity.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticSeverity.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Represents how serious a <see cref="ScreenplayDiagnostic"/> is.
+/// </summary>
+public enum ScreenplayDiagnosticSeverity
+{
+    /// <summary>
+    /// Something worth knowing that does not affect the generated document.
+    /// </summary>
+    Information = 0,
+
+    /// <summary>
+    /// Something that could not be expressed and was left out of the generated document.
+    /// </summary>
+    Warning = 1,
+
+    /// <summary>
+    /// Something that stopped the document from being generated.
+    /// </summary>
+    Error = 2
+}

--- a/Source/DotNET/Screenplay/ScreenplayDiagnostics.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnostics.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Collects the diagnostics produced while a document is generated.
+/// </summary>
+/// <remarks>
+/// Silent loss is what makes generated output impossible to trust, so every construct that cannot be expressed is
+/// recorded here rather than quietly dropped. One collector is used per generation, which keeps generation
+/// reentrant.
+/// </remarks>
+public class ScreenplayDiagnostics
+{
+    readonly List<ScreenplayDiagnostic> _diagnostics = [];
+
+    /// <summary>
+    /// Gets everything collected so far, in the order it was reported.
+    /// </summary>
+    public IReadOnlyList<ScreenplayDiagnostic> All => _diagnostics;
+
+    /// <summary>
+    /// Reports something worth knowing that does not affect the document.
+    /// </summary>
+    /// <param name="code">The code identifying the kind of diagnostic.</param>
+    /// <param name="message">What happened.</param>
+    /// <param name="location">Where it happened.</param>
+    public void Information(string code, string message, string? location = null) =>
+        _diagnostics.Add(new(ScreenplayDiagnosticSeverity.Information, code, message, location));
+
+    /// <summary>
+    /// Reports something that could not be expressed and was left out of the document.
+    /// </summary>
+    /// <param name="code">The code identifying the kind of diagnostic.</param>
+    /// <param name="message">What happened.</param>
+    /// <param name="location">Where it happened.</param>
+    public void Warning(string code, string message, string? location = null) =>
+        _diagnostics.Add(new(ScreenplayDiagnosticSeverity.Warning, code, message, location));
+
+    /// <summary>
+    /// Reports something that stopped the document from being generated.
+    /// </summary>
+    /// <param name="code">The code identifying the kind of diagnostic.</param>
+    /// <param name="message">What happened.</param>
+    /// <param name="location">Where it happened.</param>
+    public void Error(string code, string message, string? location = null) =>
+        _diagnostics.Add(new(ScreenplayDiagnosticSeverity.Error, code, message, location));
+
+    /// <summary>
+    /// Adds everything from another set of diagnostics.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics to add.</param>
+    public void AddRange(IEnumerable<ScreenplayDiagnostic> diagnostics) => _diagnostics.AddRange(diagnostics);
+}

--- a/Source/DotNET/Screenplay/ScreenplayGenerationResult.cs
+++ b/Source/DotNET/Screenplay/ScreenplayGenerationResult.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Represents everything generating a Screenplay document produced.
+/// </summary>
+/// <param name="Source">The <c>.play</c> text, empty when generation failed outright.</param>
+/// <param name="Model">The model the document was generated from.</param>
+/// <param name="Diagnostics">Everything that could not be expressed, reported rather than dropped.</param>
+public record ScreenplayGenerationResult(
+    string Source,
+    ApplicationModel Model,
+    IReadOnlyList<ScreenplayDiagnostic> Diagnostics)
+{
+    /// <summary>
+    /// Gets a value indicating whether the document was generated without anything being reported as an error.
+    /// </summary>
+    public bool IsSuccess => !Diagnostics.Any(_ => _.Severity == ScreenplayDiagnosticSeverity.Error);
+}

--- a/Source/DotNET/Screenplay/ScreenplayGenerator.cs
+++ b/Source/DotNET/Screenplay/ScreenplayGenerator.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Represents an implementation of <see cref="IScreenplayGenerator"/>.
+/// </summary>
+/// <param name="analyzer">The <see cref="IApplicationModelAnalyzer"/> recovering the model from the source.</param>
+/// <param name="emitter">The <see cref="IScreenplayEmitter"/> turning the model into a document.</param>
+/// <remarks>
+/// The package ships no dependency injection of its own, so a consumer that just wants to generate a document says
+/// <c>new ScreenplayGenerator()</c> and gets everything wired. The constructor taking collaborators exists for
+/// specifications and for hosts that want to substitute one half.
+/// </remarks>
+public class ScreenplayGenerator(IApplicationModelAnalyzer analyzer, IScreenplayEmitter emitter) : IScreenplayGenerator
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScreenplayGenerator"/> class with everything wired up.
+    /// </summary>
+    /// <remarks>
+    /// This is the single place the default halves are chosen, so a host that substitutes one of them changes
+    /// nothing else.
+    /// </remarks>
+    public ScreenplayGenerator()
+        : this(new ApplicationModelAnalyzer(), new ScreenplayEmitter())
+    {
+    }
+
+    /// <inheritdoc/>
+    public ScreenplayGenerationResult Generate(Compilation compilation, ScreenplayOptions options)
+    {
+        var resolved = options.WithDefaults(compilation.AssemblyName);
+        var analysis = analyzer.Analyze(compilation, resolved);
+        var emission = emitter.Emit(analysis.Model, resolved);
+
+        return new(emission.Source, analysis.Model, [.. analysis.Diagnostics, .. emission.Diagnostics]);
+    }
+}

--- a/Source/DotNET/Screenplay/ScreenplayOptions.cs
+++ b/Source/DotNET/Screenplay/ScreenplayOptions.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Represents the options a Screenplay document is generated with.
+/// </summary>
+public record ScreenplayOptions
+{
+    /// <summary>
+    /// The name used for the domain and module when nothing else can be resolved.
+    /// </summary>
+    public const string DefaultName = "Application";
+
+    /// <summary>
+    /// Gets the name of the domain the generated document belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to the name of the assembly being analyzed.
+    /// </remarks>
+    public string? Domain { get; init; }
+
+    /// <summary>
+    /// Gets the name of the module every discovered feature is placed within.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to the same value as <see cref="Domain"/>.
+    /// </remarks>
+    public string? Module { get; init; }
+
+    /// <summary>
+    /// Gets the number of leading namespace segments to skip when arranging slices into features.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to zero. Regardless of this value, a leading segment matching the module name is always dropped so
+    /// that the module is never repeated as a feature.
+    /// </remarks>
+    public int? SegmentsToSkip { get; init; }
+
+    /// <summary>
+    /// Resolves the options with every value filled in.
+    /// </summary>
+    /// <param name="fallbackName">The name to use for the domain when none is configured.</param>
+    /// <returns>The resolved options.</returns>
+    public ScreenplayOptions WithDefaults(string? fallbackName)
+    {
+        var domain = Coalesce(Domain, Coalesce(fallbackName, DefaultName));
+
+        return this with
+        {
+            Domain = domain,
+            Module = Coalesce(Module, domain),
+            SegmentsToSkip = SegmentsToSkip ?? 0
+        };
+    }
+
+    /// <summary>
+    /// Gets the first of two values that carries content.
+    /// </summary>
+    /// <param name="value">The preferred value.</param>
+    /// <param name="fallback">The value to fall back to.</param>
+    /// <returns>The resolved value.</returns>
+    static string Coalesce(string? value, string fallback) => string.IsNullOrWhiteSpace(value) ? fallback : value;
+}


### PR DESCRIPTION
# Summary

Generates a Cratis Screenplay `.play` document from the source of an Arc application.

## Added

- `Cratis.Arc.Screenplay` package that generates a Screenplay `.play` document describing an Arc application - concepts, policies, modules, features and slices, with the commands, events, queries, projections, reactors, constraints and screens in each
- Generation from source rather than from a running application, so a `.play` file can be produced from a checkout and regenerated in CI
- Generation from a Roslyn `Compilation`, so the package can be driven from a CLI, an MSBuild task or a source generator
- Diagnostics naming any construct that has no Screenplay counterpart, and where it was found
- Model-bound `[ChildrenFrom]` and `[Nested]` projections are recovered, matching what the fluent form already produced (#2385)
- Named authorization policies are recovered, with their requirements read from `AddPolicy` registrations where those can be read (#2386)
- Aggregate roots are followed from the command that reaches them, so a handler that mutates an aggregate states the events it produces
- Screens are declared for the component beside each slice
