### PR TITLE
Describe an application split across several projects as one document

### DIFF
--- a/Source/DotNET/Screenplay.EndToEnd/Program.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/Program.cs
@@ -8,7 +8,7 @@ using Cratis.Screenplay;
 if (args.Length < 2)
 {
     Console.WriteLine("Usage:");
-    Console.WriteLine("  Cratis.Arc.Screenplay.EndToEnd <project> <output-file>");
+    Console.WriteLine("  Cratis.Arc.Screenplay.EndToEnd <project-or-solution> <output-file>");
 
     return 2;
 }
@@ -19,21 +19,26 @@ var output = Path.GetFullPath(args[1]);
 Console.WriteLine($"Generating the Screenplay document of '{project}'");
 
 var failures = new List<string>();
-var compilation = await ProjectCompilation.Of(project, failures);
+var compilations = await ProjectCompilation.Of(project, failures);
 
 foreach (var failure in failures)
 {
     Console.WriteLine($"  workspace: {failure}");
 }
 
-if (compilation is null)
+if (compilations.Count == 0)
 {
     Console.WriteLine($"'{project}' yielded no compilation, so there is nothing to generate from");
 
     return 1;
 }
 
-var generated = new ScreenplayGenerator().Generate(compilation, new ScreenplayOptions());
+foreach (var loaded in compilations)
+{
+    Console.WriteLine($"  project: {loaded.AssemblyName}");
+}
+
+var generated = new ScreenplayGenerator().Generate(compilations, new ScreenplayOptions());
 
 Directory.CreateDirectory(Path.GetDirectoryName(output)!);
 await File.WriteAllTextAsync(output, generated.Source);

--- a/Source/DotNET/Screenplay.EndToEnd/ProjectCompilation.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/ProjectCompilation.cs
@@ -9,53 +9,122 @@ using Microsoft.CodeAnalysis.MSBuild;
 namespace Cratis.Arc.Screenplay.EndToEnd;
 
 /// <summary>
-/// Reads a real project file into the compilation the generator is handed.
+/// Reads a real project, or a real solution, into the compilations the generator is handed.
 /// </summary>
 /// <remarks>
-/// The generator itself never loads a workspace - it takes a <see cref="Compilation"/> and nothing else - which is
-/// what lets every specification build one from source strings. That seam is exactly what this check exists to get
-/// behind: a compilation built from strings has no intermediate folder, no source generator output on disk and no
-/// referenced package that declares an event, so a defect that only shows in one of those is invisible to a
-/// specification by construction. Two shipped that way.
+/// The generator itself never loads a workspace - it takes compilations and nothing else - which is what lets every
+/// specification build them from source strings. That seam is exactly what this check exists to get behind: a
+/// compilation built from strings has no intermediate folder, no source generator output on disk and no referenced
+/// package that declares an event, so a defect that only shows in one of those is invisible to a specification by
+/// construction. Two shipped that way.
+/// <para>
+/// A solution is read as every project it holds that is not a specification project, which is what an application
+/// written as several projects really is. Whether a project is one is decided by its name, the convention a solution
+/// is laid out by.
+/// </para>
 /// </remarks>
 public static class ProjectCompilation
 {
+    static readonly string[] _specifications = ["Specs", "Tests", "Specs.AppHost"];
+    static readonly string[] _solutions = [".sln", ".slnx", ".slnf"];
+
     /// <summary>
-    /// Loads a project and everything it references.
+    /// Loads a project or a solution and everything it references.
     /// </summary>
-    /// <param name="path">The full path of the project file.</param>
+    /// <param name="path">The full path of the project or solution file.</param>
     /// <param name="failures">Everything the workspace reported while loading, in the order it reported them.</param>
-    /// <returns>The <see cref="Compilation"/>, or <see langword="null"/> when the project yielded none.</returns>
+    /// <returns>The compilations, empty when nothing yielded one.</returns>
     /// <remarks>
-    /// Registering the SDK has to happen before any MSBuild type is touched, which is why the member touching one is
-    /// marked as not inlinable - the JIT would otherwise resolve those types while registration is still running.
+    /// Registering the SDK has to happen before any MSBuild type is touched, which is why the members touching one
+    /// are marked as not inlinable - the JIT would otherwise resolve those types while registration is still running.
     /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static async Task<Compilation?> Of(string path, ICollection<string> failures)
+    public static async Task<IReadOnlyList<Compilation>> Of(string path, ICollection<string> failures)
     {
         if (!MSBuildLocator.IsRegistered)
         {
             MSBuildLocator.RegisterDefaults();
         }
 
-        return await Load(path, failures);
+        return IsSolution(path) ? await LoadSolution(path, failures) : await LoadProject(path, failures);
     }
 
+    /// <summary>
+    /// Determines whether a path names a solution rather than a project.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True when it names a solution.</returns>
+    static bool IsSolution(string path) =>
+        Array.Exists(_solutions, extension => string.Equals(Path.GetExtension(path), extension, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Loads a single project.
+    /// </summary>
+    /// <param name="path">The full path of the project file.</param>
+    /// <param name="failures">Everything the workspace reported while loading.</param>
+    /// <returns>The compilation, empty when the project yielded none.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static async Task<Compilation?> Load(string path, ICollection<string> failures)
+    static async Task<IReadOnlyList<Compilation>> LoadProject(string path, ICollection<string> failures)
     {
         var reported = new Lock();
         using var workspace = MSBuildWorkspace.Create();
-        using var subscription = workspace.RegisterWorkspaceFailedHandler(args =>
-        {
-            lock (reported)
-            {
-                failures.Add(args.Diagnostic.Message);
-            }
-        });
+        using var subscription = workspace.RegisterWorkspaceFailedHandler(args => Report(args, reported, failures));
 
         var project = await workspace.OpenProjectAsync(path);
 
-        return await project.GetCompilationAsync();
+        return await project.GetCompilationAsync() is { } compilation ? [compilation] : [];
+    }
+
+    /// <summary>
+    /// Loads every project of a solution that holds part of the application.
+    /// </summary>
+    /// <param name="path">The full path of the solution file.</param>
+    /// <param name="failures">Everything the workspace reported while loading.</param>
+    /// <returns>The compilations, ordered by the name of the project each one came from.</returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<IReadOnlyList<Compilation>> LoadSolution(string path, ICollection<string> failures)
+    {
+        var reported = new Lock();
+        using var workspace = MSBuildWorkspace.Create();
+        using var subscription = workspace.RegisterWorkspaceFailedHandler(args => Report(args, reported, failures));
+
+        var solution = await workspace.OpenSolutionAsync(path);
+        var compilations = new List<Compilation>();
+
+        foreach (var project in solution.Projects
+            .Where(_ => !IsSpecifications(_.Name))
+            .OrderBy(_ => _.Name, StringComparer.Ordinal))
+        {
+            if (await project.GetCompilationAsync() is { } compilation)
+            {
+                compilations.Add(compilation);
+            }
+        }
+
+        return compilations;
+    }
+
+    /// <summary>
+    /// Determines whether a project holds specifications rather than part of the application.
+    /// </summary>
+    /// <param name="name">The name of the project.</param>
+    /// <returns>True when it holds specifications.</returns>
+    static bool IsSpecifications(string name) =>
+        Array.Exists(_specifications, suffix =>
+            string.Equals(name, suffix, StringComparison.Ordinal) ||
+            name.EndsWith($".{suffix}", StringComparison.Ordinal));
+
+    /// <summary>
+    /// Records what the workspace reported while loading.
+    /// </summary>
+    /// <param name="args">What was reported.</param>
+    /// <param name="reported">The lock guarding the collection.</param>
+    /// <param name="failures">The failures collected so far.</param>
+    static void Report(WorkspaceDiagnosticEventArgs args, Lock reported, ICollection<string> failures)
+    {
+        lock (reported)
+        {
+            failures.Add(args.Diagnostic.Message);
+        }
     }
 }

--- a/Source/DotNET/Screenplay.Specs/Analyzed.cs
+++ b/Source/DotNET/Screenplay.Specs/Analyzed.cs
@@ -146,6 +146,56 @@ public static class Analyzed
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
 
     /// <summary>
+    /// Compiles source into one project of an application written as several.
+    /// </summary>
+    /// <param name="name">The name of the assembly the project builds.</param>
+    /// <param name="references">What the project references beyond the platform, its sibling projects included.</param>
+    /// <param name="sources">The source files, keyed by the path each one is compiled as.</param>
+    /// <returns>The <see cref="Compilation"/>.</returns>
+    /// <remarks>
+    /// Nothing is added to what the specification declares, unlike the compilations built around a single file, which
+    /// carry a root of their own so that paths in the document start somewhere sensible. A project of a real
+    /// application already has its own root, and a specification about several of them has to say where each one is
+    /// written or there is nothing for the paths of the document to be relative to.
+    /// </remarks>
+    public static Compilation Project(
+        string name,
+        IEnumerable<MetadataReference> references,
+        params (string Path, string Text)[] sources) =>
+        CSharpCompilation.Create(
+            name,
+            sources.Select(_ => CSharpSyntaxTree.ParseText(
+                _.Text,
+                new CSharpParseOptions(documentationMode: DocumentationMode.Parse),
+                path: _.Path)),
+            _references.Concat(references),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+    /// <summary>
+    /// Recovers the model the projects of an application describe together.
+    /// </summary>
+    /// <param name="compilations">The projects, in whatever order the specification hands them over.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    /// <remarks>
+    /// No name is offered, which is what a host generating from several projects without configuring one does - no
+    /// single assembly names an application written as several.
+    /// </remarks>
+    public static ApplicationModelAnalysis Projects(params Compilation[] compilations) =>
+        new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None)
+            .Analyze(compilations, new ScreenplayOptions().WithDefaults(null));
+
+    /// <summary>
+    /// Gets everything the compiler itself reported about a compilation.
+    /// </summary>
+    /// <param name="compilation">The compilation to read.</param>
+    /// <returns>The errors, empty when the source compiles.</returns>
+    public static IEnumerable<string> ErrorsIn(Compilation compilation) =>
+        compilation
+            .GetDiagnostics()
+            .Where(_ => _.Severity == DiagnosticSeverity.Error)
+            .Select(_ => _.ToString());
+
+    /// <summary>
     /// Gets everything the compiler itself reported, so that a specification never asserts against broken source.
     /// </summary>
     /// <param name="sources">The source files, keyed by the path each one is compiled as.</param>

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_command_two_of_them_declare_under_one_name.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_command_two_of_them_declare_under_one_name.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// Two projects declaring into one namespace write one slice, and everything within a slice is named once - a
+/// document declaring two commands called <c>PlaceOrder</c> in one slice says the same word twice and means it
+/// differently. Only the first can be described, so the second has to be reported rather than dropped where nobody
+/// would see it.
+/// </summary>
+public class a_command_two_of_them_declare_under_one_name : Specification
+{
+    const string First = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        [EventType]
+        public record OrderPlaced(string Reference);
+
+        [Command]
+        public record PlaceOrder(string Reference)
+        {
+            public OrderPlaced Handle() => new(Reference);
+        }
+        """;
+
+    const string Second = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        [EventType]
+        public record OrderRejected(string Reference);
+
+        [Command]
+        public record PlaceOrder(string Reference)
+        {
+            public OrderRejected Handle() => new(Reference);
+        }
+        """;
+
+    Compilation _adapter;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+    SliceModel _slice;
+    ScreenplayDiagnostic _reported;
+
+    void Establish()
+    {
+        _adapter = Analyzed.Project(
+            "Library.Adapter",
+            [],
+            ("Source/Library.Adapter/Adapter.cs", "namespace Library.Adapter;"),
+            ("Source/Library.Adapter/Ordering/Placing/Placing.cs", Second));
+
+        _application = Analyzed.Project(
+            "Library",
+            [],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Ordering/Placing/Placing.cs", First));
+    }
+
+    void Because()
+    {
+        _analysis = Analyzed.Projects(_adapter, _application);
+        _slice = _analysis.Model.Slices.Single();
+        _reported = _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.RepeatedDeclarationAcrossProjects);
+    }
+
+    [Fact] void should_compile_the_one_project() => Analyzed.ErrorsIn(_adapter).ShouldBeEmpty();
+    [Fact] void should_compile_the_other_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_declare_the_command_once() => _slice.Commands.Count().ShouldEqual(1);
+    [Fact] void should_keep_the_one_the_first_project_read_declares() => _slice.Commands.Single().Produces.Single().EventName.ShouldEqual("OrderPlaced");
+    [Fact] void should_keep_everything_that_does_not_repeat_a_name() => _slice.Events.Select(_ => _.Name).ShouldContainOnly(["OrderPlaced", "OrderRejected"]);
+    [Fact] void should_say_what_was_left_out() => _reported.Message.Contains("'PlaceOrder' is a command", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_locate_the_report_at_the_slice() => _reported.Location.ShouldEqual("Library.Ordering.Placing");
+    [Fact] void should_report_it_as_a_loss() => _reported.Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Warning);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_concept_two_of_them_refer_to.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_concept_two_of_them_refer_to.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// A concept is declared once at the top of the document and referred to by name from there on, which is a fact
+/// about the document rather than about a project. A shared kernel referred to from every project of an application
+/// is the ordinary case, and declaring it once per project would leave a document declaring the same concept three
+/// times - and the rules a validator states for it attached to whichever copy happened to be first.
+/// </summary>
+public class a_concept_two_of_them_refer_to : Specification
+{
+    const string Kernel = """
+        using Cratis.Arc.Validation;
+        using Cratis.Concepts;
+        using FluentValidation;
+
+        namespace Library;
+
+        public record Isbn(string Value) : ConceptAs<string>(Value);
+
+        public class IsbnValidator : ConceptValidator<Isbn>
+        {
+            public IsbnValidator()
+            {
+                RuleFor(_ => _.Value).NotEmpty();
+            }
+        }
+        """;
+
+    const string Reserving = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reserving;
+
+        [EventType]
+        public record BookReserved(Isbn Isbn);
+        """;
+
+    const string Returning = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Returning;
+
+        [EventType]
+        public record BookReturned(Isbn Isbn);
+        """;
+
+    Compilation _kernel;
+    Compilation _lending;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish()
+    {
+        _kernel = Analyzed.Project(
+            "Library.Kernel",
+            [],
+            ("Source/Library.Kernel/Kernel.cs", "namespace Library.Kernel;"),
+            ("Source/Library.Kernel/Isbn.cs", Kernel));
+
+        _lending = Analyzed.Project(
+            "Library.Lending",
+            [_kernel.ToMetadataReference()],
+            ("Source/Library.Lending/Lending.cs", "namespace Library.Lending;"),
+            ("Source/Library.Lending/Reserving/Reserving.cs", Reserving),
+            ("Source/Library.Lending/Returning/Returning.cs", Returning));
+    }
+
+    void Because() => _analysis = Analyzed.Projects(_lending, _kernel);
+
+    [Fact] void should_compile_the_kernel_project() => Analyzed.ErrorsIn(_kernel).ShouldBeEmpty();
+    [Fact] void should_compile_the_lending_project() => Analyzed.ErrorsIn(_lending).ShouldBeEmpty();
+    [Fact] void should_declare_the_concept_once() => _analysis.Model.Concepts.Count(_ => string.Equals(_.Name, "Isbn", StringComparison.Ordinal)).ShouldEqual(1);
+    [Fact] void should_attach_the_rules_the_project_declaring_it_states() => _analysis.Model.Concepts.Single(_ => string.Equals(_.Name, "Isbn", StringComparison.Ordinal)).Validations.ShouldNotBeEmpty();
+    [Fact] void should_not_report_it_as_sharing_its_name() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.AmbiguousConceptName).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_namespace_two_of_them_declare_into.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_namespace_two_of_them_declare_into.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// A slice is recovered from a namespace, and nothing says a namespace belongs to one project. A contracts project
+/// publishing the events of a slice while the project beside it handles the command producing them writes one slice
+/// from two compilations - and a document holding it twice would say the slice twice and describe half of it in
+/// each.
+/// </summary>
+public class a_namespace_two_of_them_declare_into : Specification
+{
+    const string Contracts = """
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Ordering.Placing;
+
+        public record OrderReference(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        public record OrderPlaced(OrderReference Reference);
+        """;
+
+    const string Handling = """
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Ordering.Placing;
+
+        [Command]
+        public record PlaceOrder(OrderReference Reference)
+        {
+            public OrderPlaced Handle() => new(Reference);
+        }
+        """;
+
+    Compilation _contracts;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+    SliceModel _slice;
+
+    void Establish()
+    {
+        _contracts = Analyzed.Project(
+            "Library.Contracts",
+            [],
+            ("Source/Library.Contracts/Contracts.cs", "namespace Library.Contracts;"),
+            ("Source/Library.Contracts/Ordering/Placing/Placing.cs", Contracts));
+
+        _application = Analyzed.Project(
+            "Library",
+            [_contracts.ToMetadataReference()],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Ordering/Placing/Placing.cs", Handling));
+    }
+
+    void Because()
+    {
+        _analysis = Analyzed.Projects(_contracts, _application);
+        _slice = _analysis.Model.Slices.Single();
+    }
+
+    [Fact] void should_compile_the_contracts_project() => Analyzed.ErrorsIn(_contracts).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_describe_the_namespace_as_one_slice() => _slice.Namespace.ShouldEqual("Library.Ordering.Placing");
+    [Fact] void should_hold_the_command_the_one_project_declares() => _slice.Commands.Single().Name.ShouldEqual("PlaceOrder");
+    [Fact] void should_hold_the_event_the_other_project_declares() => _slice.Events.Single().Name.ShouldEqual("OrderPlaced");
+    [Fact] void should_state_what_the_command_produces() => _slice.Commands.Single().Produces.Single().EventName.ShouldEqual("OrderPlaced");
+    [Fact] void should_take_the_kind_from_everything_the_projects_hold_together() => _slice.Kind.ShouldEqual(SliceKind.StateChange);
+    [Fact] void should_report_nothing_at_all() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_policy_registered_where_the_host_is_composed.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_policy_registered_where_the_host_is_composed.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// An artifact names a policy and the composition root says what it means, and the whole point of layering an
+/// application is that the host is not where the behavior lives. Reading only the project the artifact is in would
+/// find no registration at all and declare every policy of a layered application as one whose rule is not stated.
+/// </summary>
+public class a_policy_registered_where_the_host_is_composed : Specification
+{
+    const string Framework = """
+        using System;
+
+        namespace Microsoft.AspNetCore.Authorization;
+
+        public class AuthorizationPolicyBuilder
+        {
+            public AuthorizationPolicyBuilder RequireRole(params string[] roles) => this;
+        }
+
+        public class AuthorizationOptions
+        {
+            public void AddPolicy(string name, Action<AuthorizationPolicyBuilder> configurePolicy)
+            {
+            }
+        }
+        """;
+
+    const string Composition = """
+        using Microsoft.AspNetCore.Authorization;
+
+        namespace Library.Host;
+
+        public static class Composition
+        {
+            public static void Authorization(AuthorizationOptions options) =>
+                options.AddPolicy("CanReserve", policy => policy.RequireRole("Librarian"));
+        }
+        """;
+
+    const string Slice = """
+        using Cratis.Arc.Authorization;
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Lending.Reserving;
+
+        [Command]
+        [Authorize(Policy = "CanReserve")]
+        public record ReserveBook(string Isbn)
+        {
+            public void Handle()
+            {
+            }
+        }
+        """;
+
+    Compilation _domain;
+    Compilation _host;
+    ApplicationModelAnalysis _analysis;
+
+    void Establish()
+    {
+        _domain = Analyzed.Project(
+            "Library.Domain",
+            [],
+            ("Source/Library.Domain/Domain.cs", "namespace Library.Domain;"),
+            ("Source/Library.Domain/Lending/Reserving/Reserving.cs", Slice));
+
+        _host = Analyzed.Project(
+            "Library.Host",
+            [],
+            ("Source/Library.Host/Authorization.cs", Framework),
+            ("Source/Library.Host/Composition.cs", Composition));
+    }
+
+    void Because() => _analysis = Analyzed.Projects(_domain, _host);
+
+    PolicyModel Policy => _analysis.Model.Policies.Single();
+
+    [Fact] void should_compile_the_domain_project() => Analyzed.ErrorsIn(_domain).ShouldBeEmpty();
+    [Fact] void should_compile_the_host_project() => Analyzed.ErrorsIn(_host).ShouldBeEmpty();
+    [Fact] void should_declare_the_policy_the_command_names() => Policy.Name.ShouldEqual("CanReserve");
+    [Fact] void should_state_what_the_host_registered_it_as_requiring() => Policy.Requirement.ShouldBeOfExactType<RoleRequirement>();
+    [Fact] void should_not_report_it_as_unregistered() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/an_aggregate_root_a_command_in_another_of_them_uses.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/an_aggregate_root_a_command_in_another_of_them_uses.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// What an aggregate root applies is stated through the command that hands it its work, and an aggregate root
+/// nothing calls is reported because its events then go unstated. An aggregate root in a domain project called by a
+/// command in the project above it is called by the application, and reading the two projects apart would report
+/// every aggregate root of a layered application as one nothing uses.
+/// </summary>
+public class an_aggregate_root_a_command_in_another_of_them_uses : Specification
+{
+    const string Domain = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Aggregates;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Lending.Reservations;
+
+        [EventType]
+        public record BookReserved(string Isbn, string Member);
+
+        public class Reservation : AggregateRoot
+        {
+            public Task Reserve(string isbn, string member) => Apply(new BookReserved(isbn, member));
+        }
+        """;
+
+    const string Application = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Commands.ModelBound;
+        using Library.Lending.Reservations;
+
+        namespace Library.Lending.Reserving;
+
+        [Command]
+        public record ReserveBook(string Isbn, string MemberId)
+        {
+            public async Task Handle(Reservation reservation)
+            {
+                await reservation.Reserve(Isbn, MemberId);
+                await reservation.Commit();
+            }
+        }
+        """;
+
+    Compilation _domain;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+
+    void Establish()
+    {
+        _domain = Analyzed.Project(
+            "Library.Domain",
+            [],
+            ("Source/Library.Domain/Domain.cs", "namespace Library.Domain;"),
+            ("Source/Library.Domain/Lending/Reservations/Reservations.cs", Domain));
+
+        _application = Analyzed.Project(
+            "Library.Application",
+            [_domain.ToMetadataReference()],
+            ("Source/Library.Application/Application.cs", "namespace Library.Application;"),
+            ("Source/Library.Application/Lending/Reserving/Reserving.cs", Application));
+    }
+
+    void Because() => _analysis = Analyzed.Projects(_domain, _application);
+
+    ProducesModel Produces => _analysis.Model.Slices.SelectMany(_ => _.Commands).Single().Produces.Single();
+
+    [Fact] void should_compile_the_domain_project() => Analyzed.ErrorsIn(_domain).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_state_the_event_the_aggregate_root_applies_as_produced_by_the_command() => Produces.EventName.ShouldEqual("BookReserved");
+    [Fact] void should_not_report_the_aggregate_root_as_one_nothing_uses() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.AggregateRootWithoutCounterpart).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/an_event_a_package_beyond_all_of_them_declares.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/an_event_a_package_beyond_all_of_them_declares.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// A sibling project stops being something to import because it is part of the application. A package is not, and
+/// leaving the projects out of the search must not leave the packages out with them - an event a sibling bounded
+/// context publishes is still real, still referred to, and still has to be stated rather than left as a name the
+/// document never introduces.
+/// </summary>
+public class an_event_a_package_beyond_all_of_them_declares : Specification
+{
+    const string Package = """
+        using Cratis.Chronicle.Events;
+
+        namespace Partners.Contracts;
+
+        [EventType]
+        public record InvitationAccepted(string Email);
+        """;
+
+    const string Contracts = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        [EventType]
+        public record OrderPlaced(string Reference);
+        """;
+
+    const string Slice = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+        using Partners.Contracts;
+
+        namespace Library.Admin.Invitations;
+
+        public class AcceptedInvitationProvisioner : IReactor
+        {
+            public Task Provision(InvitationAccepted @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    MetadataReference _package;
+    Compilation _contracts;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+
+    void Establish()
+    {
+        _package = Analyzed.Package("Partners.Contracts", Package);
+
+        _contracts = Analyzed.Project(
+            "Library.Contracts",
+            [],
+            ("Source/Library.Contracts/Contracts.cs", "namespace Library.Contracts;"),
+            ("Source/Library.Contracts/Ordering/Placing/Placing.cs", Contracts));
+
+        _application = Analyzed.Project(
+            "Library",
+            [_contracts.ToMetadataReference(), _package],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Admin/Invitations/Provision.cs", Slice));
+    }
+
+    void Because() => _analysis = Analyzed.Projects(_application, _contracts);
+
+    [Fact] void should_compile_the_contracts_project() => Analyzed.ErrorsIn(_contracts).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_import_the_event_the_package_declares() => _analysis.Model.Imports.ShouldContainOnly(["Partners.Contracts.InvitationAccepted"]);
+    [Fact] void should_not_import_the_event_a_project_of_the_application_declares() => _analysis.Model.Imports.Any(_ => _.Contains("OrderPlaced", StringComparison.Ordinal)).ShouldBeFalse();
+    [Fact] void should_not_report_anything_as_undeclared() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.EventDeclaredOutsideCompilation).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/an_event_a_sibling_project_declares.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/an_event_a_sibling_project_declares.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// An event a referenced package declares is imported, because it is real and outside the application. A sibling
+/// project reaches the analyzer through exactly the same door - a project reference is a referenced assembly - and
+/// it is not outside the application at all. Importing it would state a dependency on part of the application
+/// itself, so it has to be declared like anything else the application holds.
+/// </summary>
+public class an_event_a_sibling_project_declares : Specification
+{
+    const string Contracts = """
+        using Cratis.Chronicle.Events;
+
+        namespace Partners.Invitations;
+
+        [EventType]
+        public record InvitationAccepted(string Email);
+        """;
+
+    const string Slice = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+        using Partners.Invitations;
+
+        namespace Library.Admin.Invitations;
+
+        public class AcceptedInvitationProvisioner : IReactor
+        {
+            public Task Provision(InvitationAccepted @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    Compilation _contracts;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+
+    void Establish()
+    {
+        _contracts = Analyzed.Project(
+            "Partners.Contracts",
+            [],
+            ("Source/Partners.Contracts/Contracts.cs", "namespace Partners;"),
+            ("Source/Partners.Contracts/Invitations/Invitations.cs", Contracts));
+
+        _application = Analyzed.Project(
+            "Library",
+            [_contracts.ToMetadataReference()],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Admin/Invitations/Provision.cs", Slice));
+    }
+
+    void Because() => _analysis = Analyzed.Projects(_application, _contracts);
+
+    SliceModel SliceIn(string @namespace) => _analysis.Model.Slices.Single(_ => string.Equals(_.Namespace, @namespace, StringComparison.Ordinal));
+
+    [Fact] void should_compile_the_contracts_project() => Analyzed.ErrorsIn(_contracts).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_declare_the_event_in_the_slice_the_sibling_project_wrote_it_in() => SliceIn("Partners.Invitations").Events.Single().Name.ShouldEqual("InvitationAccepted");
+    [Fact] void should_still_observe_it_from_the_reactor() => SliceIn("Library.Admin.Invitations").Reactors.Single().ObservedEvents.ShouldContainOnly(["InvitationAccepted"]);
+    [Fact] void should_import_nothing() => _analysis.Model.Imports.ShouldBeEmpty();
+    [Fact] void should_not_report_it_as_undeclared() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.EventDeclaredOutsideCompilation).ShouldBeFalse();
+    [Fact] void should_report_nothing_at_all() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/projects_that_share_no_directory.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/projects_that_share_no_directory.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// Projects checked out beside each other in unrelated places share nothing but the root of the file system, and
+/// writing a path relative to that is not writing it relative to anything - it leaves the machine's own layout
+/// behind while looking like a relative path, which is the one thing a path in a document must never do. Each
+/// project's own root is used instead, and a path then says where a file sits within its project and nothing about
+/// which project that is, so it is said outright.
+/// </summary>
+public class projects_that_share_no_directory : Specification
+{
+    const string Placing = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        [EventType]
+        public record OrderPlaced(string Reference);
+        """;
+
+    const string Shipping = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+        using Library.Ordering.Placing;
+
+        namespace Library.Shipping.Dispatching;
+
+        public class Dispatcher : IReactor
+        {
+            public Task Dispatch(OrderPlaced @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    Compilation _contracts;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+    ScreenplayDiagnostic _reported;
+
+    void Establish()
+    {
+        _contracts = Analyzed.Project(
+            "Library.Contracts",
+            [],
+            ("/partners/contracts/Contracts.cs", "namespace Library.Contracts;"),
+            ("/partners/contracts/Ordering/Placing/Placing.cs", Placing));
+
+        _application = Analyzed.Project(
+            "Library",
+            [_contracts.ToMetadataReference()],
+            ("/library/source/Program.cs", "namespace Library;"),
+            ("/library/source/Shipping/Dispatching/Dispatching.cs", Shipping));
+    }
+
+    void Because()
+    {
+        _analysis = Analyzed.Projects(_contracts, _application);
+        _reported = _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.ProjectsWithoutASharedRoot);
+    }
+
+    ReactorModel Reactor => _analysis.Model.Slices.SelectMany(_ => _.Reactors).Single();
+
+    [Fact] void should_compile_the_contracts_project() => Analyzed.ErrorsIn(_contracts).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_write_the_path_relative_to_the_root_of_its_own_project() => Reactor.SourceFilePath.ShouldEqual("Shipping/Dispatching/Dispatching.cs");
+    [Fact] void should_leave_the_layout_of_the_machine_out_of_the_path() => Reactor.SourceFilePath!.StartsWith('/').ShouldBeFalse();
+    [Fact] void should_say_how_many_projects_could_not_be_placed_together() => _reported.Message.Contains("The 2 projects", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_report_it_as_a_loss() => _reported.Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Warning);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/projects_written_under_one_directory.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/projects_written_under_one_directory.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// Every path in a document is written relative to a directory, or the document carries the absolute layout of the
+/// machine that generated it and nobody can commit or diff it. One project answers that with its own root. Several
+/// projects each have their own, and using them would leave <c>Ordering/Placing.cs</c> as the path of a file in two
+/// projects with nothing saying which - so the directory they are all written under is used and every path opens
+/// with the project it belongs to.
+/// </summary>
+public class projects_written_under_one_directory : Specification
+{
+    const string Placing = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        [EventType]
+        public record OrderPlaced(string Reference);
+        """;
+
+    const string Shipping = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+        using Library.Ordering.Placing;
+
+        namespace Library.Shipping.Dispatching;
+
+        public class Dispatcher : IReactor
+        {
+            public Task Dispatch(OrderPlaced @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    Compilation _contracts;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+
+    void Establish()
+    {
+        _contracts = Analyzed.Project(
+            "Library.Contracts",
+            [],
+            ("Source/Library.Contracts/Contracts.cs", "namespace Library.Contracts;"),
+            ("Source/Library.Contracts/Ordering/Placing/Placing.cs", Placing));
+
+        _application = Analyzed.Project(
+            "Library",
+            [_contracts.ToMetadataReference()],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Shipping/Dispatching/Dispatching.cs", Shipping));
+    }
+
+    void Because() => _analysis = Analyzed.Projects(_contracts, _application);
+
+    ReactorModel Reactor => _analysis.Model.Slices.SelectMany(_ => _.Reactors).Single();
+
+    [Fact] void should_compile_the_contracts_project() => Analyzed.ErrorsIn(_contracts).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_write_the_path_relative_to_the_directory_the_projects_share() => Reactor.SourceFilePath.ShouldEqual("Library/Shipping/Dispatching/Dispatching.cs");
+    [Fact] void should_not_report_the_projects_as_sharing_nothing() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.ProjectsWithoutASharedRoot).ShouldBeFalse();
+    [Fact] void should_report_nothing_at_all() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/the_same_projects_handed_over_in_another_order.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/the_same_projects_handed_over_in_another_order.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// Two projects declaring an artifact of one name in one slice is where "the first wins" becomes visible, and it is
+/// therefore where the order the projects arrive in could decide what the document says. Nothing decides that order -
+/// a solution names its projects in whatever order its file happens to list them - so the answer has to be the same
+/// list either way round or the document reorders itself for reasons nobody can see.
+/// </summary>
+public class the_same_projects_handed_over_in_another_order : Specification
+{
+    const string First = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        [EventType]
+        public record OrderPlaced(string Reference);
+
+        [Command]
+        public record PlaceOrder(string Reference)
+        {
+            public OrderPlaced Handle() => new(Reference);
+        }
+        """;
+
+    const string Second = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        [EventType]
+        public record OrderRejected(string Reference);
+
+        [Command]
+        public record PlaceOrder(string Reference)
+        {
+            public OrderRejected Handle() => new(Reference);
+        }
+        """;
+
+    string _asGiven;
+    string _reversed;
+
+    void Because()
+    {
+        _asGiven = Kept(Adapter(), Application());
+        _reversed = Kept(Application(), Adapter());
+    }
+
+    static Compilation Adapter() =>
+        Analyzed.Project(
+            "Library.Adapter",
+            [],
+            ("Source/Library.Adapter/Adapter.cs", "namespace Library.Adapter;"),
+            ("Source/Library.Adapter/Ordering/Placing/Placing.cs", Second));
+
+    static Compilation Application() =>
+        Analyzed.Project(
+            "Library",
+            [],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Ordering/Placing/Placing.cs", First));
+
+    static string Kept(params Compilation[] compilations) =>
+        Analyzed.Projects(compilations)
+            .Model.Slices.Single()
+            .Commands.Single()
+            .Produces.Single()
+            .EventName;
+
+    [Fact] void should_keep_a_command_at_all() => _asGiven.ShouldNotBeEmpty();
+    [Fact] void should_keep_the_same_one_either_way() => _reversed.ShouldEqual(_asGiven);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_recovered_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_recovered_model.cs
@@ -20,7 +20,11 @@ public class a_recovered_model(ApplicationModel model, params ScreenplayDiagnost
     public ScreenplayOptions? Options { get; private set; }
 
     /// <inheritdoc/>
-    public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options)
+    public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options) =>
+        Analyze([compilation], options);
+
+    /// <inheritdoc/>
+    public ApplicationModelAnalysis Analyze(IReadOnlyList<Compilation> compilations, ScreenplayOptions options)
     {
         Options = options;
 

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/LayeredSource.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/LayeredSource.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The source of a small application written as two projects, the way a layered Arc application really is written.
+/// </summary>
+/// <remarks>
+/// A contracts project publishes the events of a bounded context and the project beside it handles the commands that
+/// produce them, which is the arrangement a single project generation described half of. The events live in the
+/// namespace of the slice they belong to, so the command and the events it produces are one slice written from two
+/// compilations - and a second slice is declared by the application project alone, so a document holding only one of
+/// the projects would be visibly short either way round.
+/// </remarks>
+public static class LayeredSource
+{
+    /// <summary>
+    /// The name of the assembly the contracts project builds.
+    /// </summary>
+    public const string ContractsAssembly = "Library.Contracts";
+
+    /// <summary>
+    /// The name of the assembly the application project builds.
+    /// </summary>
+    public const string ApplicationAssembly = "Library";
+
+    const string Contracts = """
+        using Cratis.Chronicle.Compliance.GDPR;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Ordering.Placing;
+
+        public record OrderReference(string Value) : ConceptAs<string>(Value);
+
+        [PII("The name of a person")]
+        public record CustomerName(string Value) : ConceptAs<string>(Value);
+
+        /// <summary>
+        /// An order was placed by a customer.
+        /// </summary>
+        [EventType]
+        public record OrderPlaced(OrderReference Reference, CustomerName Customer);
+        """;
+
+    const string Placing = """
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Ordering.Placing;
+
+        /// <summary>
+        /// Places an order for a customer.
+        /// </summary>
+        [Command]
+        public record PlaceOrder(OrderReference Reference, CustomerName Customer)
+        {
+            public OrderPlaced Handle() => new(Reference, Customer);
+        }
+        """;
+
+    const string Dispatching = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Reactors;
+        using Library.Ordering.Placing;
+
+        namespace Library.Shipping.Dispatching;
+
+        public class Dispatcher : IReactor
+        {
+            public Task Dispatch(OrderPlaced @event, EventContext context) => Task.CompletedTask;
+        }
+        """;
+
+    const string Listing = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Projections;
+        using Library.Ordering.Placing;
+
+        namespace Library.Ordering.Listing;
+
+        [ReadModel]
+        public record Order
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public OrderReference Reference { get; init; } = new(string.Empty);
+
+            public static IEnumerable<Order> AllOrders() => [];
+        }
+
+        public class OrderProjection : IProjectionFor<Order>
+        {
+            public void Define(IProjectionBuilderFor<Order> builder) => builder
+                .AutoMap()
+                .From<OrderPlaced>(_ => _
+                    .Set(m => m.Id).ToEventSourceId()
+                    .Set(m => m.Reference).To(e => e.Reference));
+        }
+        """;
+
+    /// <summary>
+    /// Builds the contracts project, which declares the events of the ordering context.
+    /// </summary>
+    /// <returns>The <see cref="Compilation"/>.</returns>
+    public static Compilation ContractsProject() =>
+        Analyzed.Project(
+            ContractsAssembly,
+            [],
+            ("Source/Library.Contracts/Contracts.cs", "namespace Library.Contracts;"),
+            ("Source/Library.Contracts/Ordering/Placing/Placing.cs", Contracts));
+
+    /// <summary>
+    /// Builds the application project, which handles the commands of the ordering context.
+    /// </summary>
+    /// <param name="contracts">The contracts project it references.</param>
+    /// <returns>The <see cref="Compilation"/>.</returns>
+    /// <remarks>
+    /// The reference is the compilation itself rather than an emitted image, which is what a project reference within
+    /// one solution really is once a workspace has loaded it - and is the shape in which a sibling project looks
+    /// exactly like the referenced package an import exists for.
+    /// </remarks>
+    public static Compilation ApplicationProject(Compilation contracts) =>
+        Analyzed.Project(
+            ApplicationAssembly,
+            [contracts.ToMetadataReference()],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Ordering/Placing/Placing.cs", Placing),
+            ("Source/Library/Ordering/Listing/Listing.cs", Listing),
+            ("Source/Library/Shipping/Dispatching/Dispatching.cs", Dispatching));
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_projects_of_a_layered_application.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_projects_of_a_layered_application.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Screenplay;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The whole promise again, for the applications that are not one project. Two compilations go in - a contracts
+/// project and the project handling the commands its events belong to - and one document comes out that the
+/// Screenplay compiler accepts without a diagnostic. Pointed at either project alone, the generator described half
+/// of this and referred to an event it never introduced.
+/// </summary>
+public class from_the_projects_of_a_layered_application : Specification
+{
+    Compilation _contracts;
+    Compilation _application;
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+
+    void Establish()
+    {
+        _contracts = LayeredSource.ContractsProject();
+        _application = LayeredSource.ApplicationProject(_contracts);
+    }
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator(
+                new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None),
+                new ScreenplayEmitter())
+            .Generate([_application, _contracts], new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+    }
+
+    bool Says(string text) => _result.Source.Contains(text, StringComparison.Ordinal);
+
+    int Counted(string text) => _result.Source.Split(text, StringSplitOptions.None).Length - 1;
+
+    [Fact] void should_compile_the_contracts_project() => Analyzed.ErrorsIn(_contracts).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_declare_the_command_the_application_project_holds() => Says("command PlaceOrder").ShouldBeTrue();
+    [Fact] void should_declare_the_event_the_contracts_project_holds() => Says("event OrderPlaced").ShouldBeTrue();
+    [Fact] void should_state_what_the_command_produces() => Says("produces OrderPlaced").ShouldBeTrue();
+    [Fact] void should_declare_the_slice_only_the_application_project_holds() => Says("query AllOrders").ShouldBeTrue();
+    [Fact] void should_observe_the_event_of_one_project_from_a_reactor_in_the_other() => Says("reactor Dispatcher").ShouldBeTrue();
+    [Fact] void should_declare_a_concept_both_projects_refer_to_once() => Counted("concept CustomerName : String @pii").ShouldEqual(1);
+    [Fact] void should_write_the_path_of_a_file_relative_to_the_directory_the_projects_share() => Says("Library/Shipping/Dispatching/Dispatching.cs").ShouldBeTrue();
+    [Fact] void should_import_nothing() => _result.Model.Imports.ShouldBeEmpty();
+    [Fact] void should_not_refer_to_an_event_it_never_introduces() => _result.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.EventDeclaredOutsideCompilation).ShouldBeFalse();
+    [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_same_projects_handed_over_in_another_order.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_same_projects_handed_over_in_another_order.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// The same files in another order already have to print the same bytes. With several projects there is a second
+/// order nobody decides - the one a host enumerates the projects of a solution in - and a document that reordered
+/// itself with it would be exactly as impossible to commit, diff and review. This is that promise, stated as
+/// something that can fail.
+/// </summary>
+public class from_the_same_projects_handed_over_in_another_order : Specification
+{
+    string _asGiven;
+    string _reversed;
+
+    void Because()
+    {
+        _asGiven = Generate(contracts => [LayeredSource.ApplicationProject(contracts), contracts]);
+        _reversed = Generate(contracts => [contracts, LayeredSource.ApplicationProject(contracts)]);
+    }
+
+    static string Generate(Func<Compilation, IReadOnlyList<Compilation>> arrange) =>
+        new ScreenplayGenerator(
+                new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None),
+                new ScreenplayEmitter())
+            .Generate(arrange(LayeredSource.ContractsProject()), new ScreenplayOptions())
+            .Source;
+
+    [Fact] void should_have_produced_a_document_at_all() => _asGiven.ShouldNotBeEmpty();
+    [Fact] void should_produce_the_same_document_either_way() => _reversed.ShouldEqual(_asGiven);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/with_a_command_in_one_of_them.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/with_a_command_in_one_of_them.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_combining_the_parts_of_a_slice;
+
+/// <summary>
+/// A contracts project holding only the events of a slice reads as a state view on its own, because nothing in it
+/// changes anything. The command in the project beside it is what the slice is really about, and joining the two
+/// has to say so.
+/// </summary>
+public class with_a_command_in_one_of_them : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Combine([SliceKind.StateView, SliceKind.StateChange]);
+
+    [Fact] void should_infer_state_change() => _result.ShouldEqual(SliceKind.StateChange);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/with_a_reactor_in_one_of_them.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/with_a_reactor_in_one_of_them.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_combining_the_parts_of_a_slice;
+
+/// <summary>
+/// A reactor decides the kind of a slice even when a command sits alongside it, and it decides it just as much when
+/// the command was written in another project - what the slice is about is the reaction wherever the two halves of
+/// it happen to live.
+/// </summary>
+public class with_a_reactor_in_one_of_them : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Combine([SliceKind.StateChange, SliceKind.Automation]);
+
+    [Fact] void should_infer_automation() => _result.ShouldEqual(SliceKind.Automation);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/with_a_translating_reactor_in_one_of_them.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/with_a_translating_reactor_in_one_of_them.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_combining_the_parts_of_a_slice;
+
+/// <summary>
+/// A reactor turning an event into further events adapts one part of the model into another, which outranks every
+/// other reading of the slice - including the automation another part of it would be on its own.
+/// </summary>
+public class with_a_translating_reactor_in_one_of_them : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Combine([SliceKind.Automation, SliceKind.Translate, SliceKind.StateChange]);
+
+    [Fact] void should_infer_translate() => _result.ShouldEqual(SliceKind.Translate);
+}

--- a/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/without_a_part_that_changes_anything.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceKindInference/when_combining_the_parts_of_a_slice/without_a_part_that_changes_anything.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_SliceKindInference.when_combining_the_parts_of_a_slice;
+
+public class without_a_part_that_changes_anything : Specification
+{
+    SliceKind _result;
+
+    void Because() => _result = SliceKindInference.Combine([SliceKind.StateView, SliceKind.StateView]);
+
+    [Fact] void should_infer_state_view() => _result.ShouldEqual(SliceKind.StateView);
+}

--- a/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootBehaviors.cs
+++ b/Source/DotNET/Screenplay/Analysis/Aggregates/AggregateRootBehaviors.cs
@@ -26,11 +26,10 @@ public static class AggregateRootBehaviors
     /// Finds the behaviors a handler body reaches.
     /// </summary>
     /// <param name="body">The body of the handler.</param>
-    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="semanticModel">The model the body is read through.</param>
     /// <returns>The behaviors, in the order the handler calls them.</returns>
-    public static IEnumerable<AggregateRootInvocation> ReachedFrom(SyntaxNode body, Compilation compilation)
+    public static IEnumerable<AggregateRootInvocation> ReachedFrom(SyntaxNode body, SemanticModel semanticModel)
     {
-        var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
         var reached = new List<AggregateRootInvocation>();
 
         foreach (var call in body.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>())

--- a/Source/DotNET/Screenplay/Analysis/AnalyzedCompilations.cs
+++ b/Source/DotNET/Screenplay/Analysis/AnalyzedCompilations.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Puts the compilations an application is analyzed from into the order everything else reads them in.
+/// </summary>
+/// <remarks>
+/// An application written as several projects is handed over as a list, and nothing decides what order a host builds
+/// that list in - a solution enumerates its projects in whatever order its file happens to name them, and a folder
+/// scan in whatever order the file system answers. A document that reordered itself with the list would be no more
+/// worth committing than one that reordered itself between builds, so the list is ordered here once and every union
+/// downstream is a concatenation in this order.
+/// <para>
+/// Assemblies are named uniquely within an application, so the name is the whole of the key in practice. The
+/// ordinally first source file breaks a tie anyway, because two compilations of one assembly - the same project built
+/// for two target frameworks - is a list a host can hand over without meaning to.
+/// </para>
+/// </remarks>
+public static class AnalyzedCompilations
+{
+    /// <summary>
+    /// Orders the compilations an application is analyzed from.
+    /// </summary>
+    /// <param name="compilations">The compilations to order.</param>
+    /// <returns>The compilations, ordered by the name of the assembly each one builds.</returns>
+    public static IReadOnlyList<Compilation> Ordered(IEnumerable<Compilation> compilations) =>
+    [
+        .. compilations
+            .OrderBy(_ => _.AssemblyName ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(FirstFileOf, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Gets the name the application falls back to when nothing configures one.
+    /// </summary>
+    /// <param name="compilations">The compilations being analyzed.</param>
+    /// <returns>The name, or <see langword="null"/> when no single assembly names the application.</returns>
+    /// <remarks>
+    /// One project is the application, so the assembly it builds names it. Several projects are the application
+    /// together and none of them names it - picking one would put the name of a layer where the name of the
+    /// application belongs, and which layer got picked would be an accident of the alphabet. Nothing is offered
+    /// instead, so a caller that says what the application is called is answered and one that does not gets the
+    /// neutral default rather than a wrong name that looks deliberate.
+    /// </remarks>
+    public static string? NameOf(IReadOnlyList<Compilation> compilations) =>
+        compilations.Count == 1 ? compilations[0].AssemblyName : null;
+
+    /// <summary>
+    /// Gets the ordinally first file a compilation was built from.
+    /// </summary>
+    /// <param name="compilation">The compilation to read.</param>
+    /// <returns>The path, empty when it was built from none.</returns>
+    static string FirstFileOf(Compilation compilation) =>
+        compilation.SyntaxTrees.Select(_ => _.FilePath).Order(StringComparer.Ordinal).FirstOrDefault() ?? string.Empty;
+}

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -5,6 +5,7 @@ using Cratis.Arc.Screenplay.Analysis.Events;
 using Cratis.Arc.Screenplay.Analysis.Policies;
 using Cratis.Arc.Screenplay.Analysis.Screens;
 using Cratis.Arc.Screenplay.Analysis.Slices;
+using Cratis.Arc.Screenplay.Analysis.Types;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
 
@@ -15,8 +16,9 @@ namespace Cratis.Arc.Screenplay.Analysis;
 /// </summary>
 /// <param name="userInterfaceFiles">The <see cref="IUserInterfaceFiles"/> the screens of a slice are found through.</param>
 /// <remarks>
-/// Namespaces are read in order and everything within a slice is ordered explicitly, so the same compilation always
-/// yields the same model - which is what makes the document it produces something worth committing.
+/// Projects are read in a fixed order, namespaces within a project are read in order and everything within a slice is
+/// ordered explicitly, so the same source always yields the same model whichever order its projects were handed over
+/// in - which is what makes the document it produces something worth committing.
 /// </remarks>
 public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : IApplicationModelAnalyzer
 {
@@ -35,55 +37,62 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
     }
 
     /// <inheritdoc/>
-    public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options)
+    public ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options) =>
+        Analyze([compilation], options);
+
+    /// <inheritdoc/>
+    public ApplicationModelAnalysis Analyze(IReadOnlyList<Compilation> compilations, ScreenplayOptions options)
     {
-        var diagnostics = new ScreenplayDiagnostics();
-        var catalog = ArtifactCatalog.From(compilation);
-        var readers = ArtifactReaders.For(compilation, catalog, diagnostics);
-        var elsewhere = new CrossSliceQueries();
-        var screens = new ScreenReader(
-            userInterfaceFiles,
-            SourcePaths.For(compilation, catalog),
-            new(diagnostics),
-            new(userInterfaceFiles, diagnostics, elsewhere),
-            elsewhere);
+        var ordered = AnalyzedCompilations.Ordered(compilations);
+        var domain = options.Domain ?? AnalyzedCompilations.NameOf(ordered) ?? ScreenplayOptions.DefaultName;
+        var whole = new WholeApplication(ordered, new ScreenplayDiagnostics()) { Files = userInterfaceFiles };
+        var diagnostics = whole.Diagnostics;
 
-        var recovered = new RecoveredArtifacts();
-        var reader = new SliceReader(readers, diagnostics, screens, recovered);
-
-        var slices = catalog.Namespaces
-            .Select(@namespace => reader.Read(@namespace, catalog.In(@namespace)))
-            .OfType<SliceModel>()
+        var catalogs = ordered.Select(ArtifactCatalog.From).ToList();
+        var paths = SourceRoots.Across(ordered, catalogs, diagnostics, domain);
+        var projects = ordered
+            .Select((compilation, index) => CompilationAnalysis.Of(compilation, catalogs[index], paths[index], whole))
             .ToList();
 
-        ConceptValidations.Link(catalog, readers);
-        readers.AggregateRoots.Report(diagnostics);
-        elsewhere.Report(diagnostics);
-        ReportTypesTheDocumentCannotName(readers, diagnostics, compilation.AssemblyName);
-        var imports = ExternalEvents.Resolve(compilation, slices, diagnostics);
-        ReportNamespacesWithoutStructure(slices, diagnostics, options.SegmentsToSkip ?? 0);
+        foreach (var project in projects)
+        {
+            project.LinkConceptValidations();
+        }
+
+        whole.AggregateRoots.Report(diagnostics);
+        whole.Elsewhere.Report(diagnostics);
+        TypesTheDocumentCannotName.Report(whole.Types, diagnostics, domain);
+
+        var slices = SliceUnion.Of(projects.SelectMany(_ => _.Slices), diagnostics);
+        var imports = ExternalEvents.Resolve(ordered, slices, diagnostics);
+        NamespacesWithoutStructure.Report(slices, diagnostics, options.SegmentsToSkip ?? 0);
 
         // How serious source that did not compile is depends on how much survived it, so it is reported once the
         // slices are in rather than on the way in. Source that did not compile still suppresses "declares nothing" -
         // an empty document from a broken build is the broken build, not an application with nothing in it - and
         // when it is reported as a warning the suppression can never apply, because a warning is only ever reached
-        // when something was recovered and something recovered is a slice.
-        var failedToCompile = CompilationErrors.Report(compilation, recovered, diagnostics);
+        // when something was recovered and something recovered is a slice. Each project answers for its own source,
+        // so a build broken in one of them says nothing about the ones that built.
+        var failedToCompile = false;
+        foreach (var project in projects)
+        {
+            failedToCompile |= project.ReportCompilationErrors(diagnostics);
+        }
 
         if (slices.Count == 0 && !failedToCompile)
         {
             diagnostics.Information(
                 ScreenplayDiagnosticCodes.AnalysisUnavailable,
                 "The source declares nothing that can be expressed, so the generated document describes nothing",
-                compilation.AssemblyName);
+                domain);
         }
 
         return new(
             new ApplicationModel(
-                options.Domain ?? compilation.AssemblyName ?? ScreenplayOptions.DefaultName,
+                domain,
                 options.Module ?? options.Domain ?? ScreenplayOptions.DefaultName,
-                readers.Types.Concepts,
-                new PolicyCatalog(compilation, diagnostics).Declare(slices.SelectMany(AuthorizationsIn)),
+                whole.Types.Concepts,
+                new PolicyCatalog(ordered, domain, diagnostics).Declare(slices.SelectMany(AuthorizationsIn)),
                 slices)
             {
                 Imports = imports
@@ -98,77 +107,4 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
     /// <returns>The authorizations.</returns>
     static IEnumerable<AuthorizationModel> AuthorizationsIn(SliceModel slice) =>
         slice.Commands.Select(_ => _.Authorization).Concat(slice.Queries.Select(_ => _.Authorization)).OfType<AuthorizationModel>();
-
-    /// <summary>
-    /// Reports every type the document had to refer to by a name that does not say what it is.
-    /// </summary>
-    /// <param name="readers">The readers holding the types encountered.</param>
-    /// <param name="diagnostics">The diagnostics to report to.</param>
-    /// <param name="location">Where to report against.</param>
-    /// <remarks>
-    /// A Screenplay type reference is a single identifier, so a type the grammar cannot hold is written as whatever
-    /// of its name survives - and the property then claims a type nothing declares. Saying which types those were is
-    /// the difference between a document with a known gap and a document that is quietly wrong.
-    /// </remarks>
-    static void ReportTypesTheDocumentCannotName(ArtifactReaders readers, ScreenplayDiagnostics diagnostics, string? location)
-    {
-        foreach (var type in readers.Types.Unmappable)
-        {
-            diagnostics.Warning(
-                ScreenplayDiagnosticCodes.UnmappableTypeReference,
-                $"'{type}' has no Screenplay counterpart, so it is referred to by a name the document never declares",
-                location);
-        }
-
-        foreach (var type in readers.Types.Ambiguous)
-        {
-            diagnostics.Warning(
-                ScreenplayDiagnosticCodes.AmbiguousConceptName,
-                $"'{type}' shares its simple name with a concept the document already declares, so what it is is described by the first one instead",
-                location);
-        }
-
-        foreach (var shape in readers.Types.Shapes)
-        {
-            diagnostics.Information(
-                ScreenplayDiagnosticCodes.UndeclarableShape,
-                $"'{shape}' is a record an artifact carries, and there is no way to declare what a record holds, so the document names it without saying what is in it - the concepts it carries are declared, the shape itself is not",
-                location);
-        }
-    }
-
-    /// <summary>
-    /// Reports a namespace that carries nothing to arrange the document by.
-    /// </summary>
-    /// <param name="slices">The slices to check.</param>
-    /// <param name="diagnostics">The diagnostics to report to.</param>
-    /// <param name="segmentsToSkip">The number of leading namespace segments being skipped.</param>
-    /// <remarks>
-    /// Artifacts sitting in the root namespace leave the module, the feature and the slice with nothing to be named
-    /// after but the assembly, so all of them end up saying the same word. Naming them anything else would be
-    /// fiction - the source really does say nothing about where they belong - so this says what would fix it
-    /// instead, which is either a namespace per slice or a leading segment skipped.
-    /// </remarks>
-    static void ReportNamespacesWithoutStructure(
-        IEnumerable<SliceModel> slices,
-        ScreenplayDiagnostics diagnostics,
-        int segmentsToSkip)
-    {
-        foreach (var slice in slices.Where(_ => Segments(_.Namespace, segmentsToSkip) <= 1))
-        {
-            diagnostics.Information(
-                ScreenplayDiagnosticCodes.NamespaceWithoutStructure,
-                "The namespace carries no feature or slice to arrange by, so the module, the feature and the slice all take the same name - give the slice a namespace of its own, or skip a leading segment",
-                slice.Namespace);
-        }
-    }
-
-    /// <summary>
-    /// Counts the namespace segments left to arrange a slice by.
-    /// </summary>
-    /// <param name="namespace">The namespace to count.</param>
-    /// <param name="segmentsToSkip">The number of leading segments being skipped.</param>
-    /// <returns>The number of segments.</returns>
-    static int Segments(string @namespace, int segmentsToSkip) =>
-        @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries).Length - segmentsToSkip;
 }

--- a/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
@@ -97,7 +97,7 @@ public class ArtifactReaders
         var properties = new PropertyReader(types);
         var paths = SourcePaths.For(compilation, catalog);
         var aggregates = new AggregateRootCatalog();
-        var produces = new ProducesReader(compilation, aggregates, diagnostics);
+        var produces = new ProducesReader(new SemanticModels([compilation]), aggregates, diagnostics);
         var validators = ValidatorCatalog.From(catalog, new(compilation, diagnostics));
 
         return new(

--- a/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
@@ -91,18 +91,39 @@ public class ArtifactReaders
     /// <param name="catalog">The catalogue of everything the compilation declares.</param>
     /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
     /// <returns>The <see cref="ArtifactReaders"/>.</returns>
-    public static ArtifactReaders For(Compilation compilation, ArtifactCatalog catalog, ScreenplayDiagnostics diagnostics)
+    public static ArtifactReaders For(Compilation compilation, ArtifactCatalog catalog, ScreenplayDiagnostics diagnostics) =>
+        For(compilation, catalog, SourcePaths.For(compilation, catalog), WholeApplication.Of(compilation, diagnostics));
+
+    /// <summary>
+    /// Composes every reader for one project of an application, sharing what belongs to the application as a whole.
+    /// </summary>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="catalog">The catalogue of everything the compilation declares.</param>
+    /// <param name="paths">The <see cref="SourcePaths"/> the paths of this project are written relative to.</param>
+    /// <param name="whole">What the application as a whole holds.</param>
+    /// <returns>The <see cref="ArtifactReaders"/>.</returns>
+    /// <remarks>
+    /// A concept is declared once at the top of a document however many projects refer to it, an aggregate root one
+    /// project declares is handed its work by a command another project may hold, and the body of that aggregate
+    /// root's behavior is read through the project it was written in rather than the one calling it. Everything else
+    /// here reads a declaration the project itself catalogued, which is why there is a set of readers per project at
+    /// all.
+    /// </remarks>
+    public static ArtifactReaders For(
+        Compilation compilation,
+        ArtifactCatalog catalog,
+        SourcePaths paths,
+        WholeApplication whole)
     {
-        var types = new TypeRegistry();
+        var types = whole.Types;
+        var diagnostics = whole.Diagnostics;
         var properties = new PropertyReader(types);
-        var paths = SourcePaths.For(compilation, catalog);
-        var aggregates = new AggregateRootCatalog();
-        var produces = new ProducesReader(new SemanticModels([compilation]), aggregates, diagnostics);
+        var produces = new ProducesReader(whole.Models, whole.AggregateRoots, diagnostics);
         var validators = ValidatorCatalog.From(catalog, new(compilation, diagnostics));
 
         return new(
             types,
-            aggregates,
+            whole.AggregateRoots,
             validators,
             new EventReader(properties, diagnostics),
             new CommandReader(properties, produces, validators, paths),

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducedBySignature.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducedBySignature.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Commands;
+
+/// <summary>
+/// States what the signature of a handler promises, for a command whose body could not be read.
+/// </summary>
+/// <remarks>
+/// Reading the body is what gives a production its mappings, so this is strictly the lesser answer - it says which
+/// events a command produces and nothing about what it puts in them. It is still much better than silence: a body
+/// that cannot be read is a partial documentation of the command rather than an argument for describing none of it,
+/// and what was lost is reported so the difference is visible.
+/// </remarks>
+public static class ProducedBySignature
+{
+    /// <summary>
+    /// Reads what the signatures of a command's handlers promise.
+    /// </summary>
+    /// <param name="handlers">The handler methods to read.</param>
+    /// <param name="location">Where the command lives, for use in diagnostics.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The productions, without mappings.</returns>
+    public static IEnumerable<ProducesModel> Of(
+        IReadOnlyList<IMethodSymbol> handlers,
+        string location,
+        ScreenplayDiagnostics diagnostics)
+    {
+        var events = handlers
+            .SelectMany(_ => HandlerBodies.EventTypesIn(_.ReturnType))
+            .Select(_ => _.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var name in events)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableCommandProduction,
+                $"'{name}' is named by the handler's signature but never constructed in a body that could be read, so it is stated without mappings",
+                location);
+        }
+
+        return [.. events.Select(_ => new ProducesModel(_, null, []))];
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/ProducesReader.cs
@@ -12,7 +12,7 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// <summary>
 /// Reads the events a command produces, from the body of its handler.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every body is read through.</param>
 /// <param name="aggregates">The <see cref="AggregateRootCatalog"/> recording which aggregate roots a command reaches.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <remarks>
@@ -23,8 +23,13 @@ namespace Cratis.Arc.Screenplay.Analysis.Commands;
 /// A handler that governs its change through an aggregate root constructs nothing itself, so the behaviors it calls
 /// are read as well. Both ways of writing an Arc command then describe the same thing in the document.
 /// </para>
+/// <para>
+/// That behavior is the one body here that need not belong to the project the command does - an aggregate root in a
+/// domain project called from the project above it is the ordinary layered arrangement - so which model reads it is
+/// asked rather than assumed.
+/// </para>
 /// </remarks>
-public class ProducesReader(Compilation compilation, AggregateRootCatalog aggregates, ScreenplayDiagnostics diagnostics)
+public class ProducesReader(SemanticModels models, AggregateRootCatalog aggregates, ScreenplayDiagnostics diagnostics)
 {
     readonly ProducesMappingReader _mappings = new(diagnostics);
     readonly ProducesConditionResolver _conditions = new(diagnostics);
@@ -46,17 +51,22 @@ public class ProducesReader(Compilation compilation, AggregateRootCatalog aggreg
 
             foreach (var body in HandlerBodies.Of(handler))
             {
-                ReadBody(command, body, location, produces, null);
+                if (models.For(body.SyntaxTree) is not { } semanticModel)
+                {
+                    continue;
+                }
 
-                foreach (var behavior in AggregateRootBehaviors.ReachedFrom(body, compilation))
+                ReadBody(command, body, semanticModel, location, produces, null);
+
+                foreach (var behavior in AggregateRootBehaviors.ReachedFrom(body, semanticModel))
                 {
                     aggregates.Reached(behavior.AggregateRoot);
-                    ReadBody(command, behavior.Body, location, produces, behavior);
+                    ReadBehavior(command, behavior, location, produces);
                 }
             }
         }
 
-        return produces.Count > 0 ? Deduplicate(produces) : FromSignatures(handlers, location);
+        return produces.Count > 0 ? Deduplicate(produces) : ProducedBySignature.Of(handlers, location, diagnostics);
     }
 
     /// <summary>
@@ -95,17 +105,18 @@ public class ProducesReader(Compilation compilation, AggregateRootCatalog aggreg
     /// </summary>
     /// <param name="command">The type declaring the command.</param>
     /// <param name="body">The body to read.</param>
+    /// <param name="semanticModel">The model the body is read through.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
     /// <param name="produces">The productions collected so far.</param>
     /// <param name="behavior">The behavior the body belongs to, when the handler reached it through an aggregate root.</param>
     void ReadBody(
         INamedTypeSymbol command,
         SyntaxNode body,
+        SemanticModel semanticModel,
         string location,
         List<ProducesModel> produces,
         AggregateRootInvocation? behavior)
     {
-        var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
         var scope = new ProducesScope(semanticModel, command, behavior?.Bindings, behavior?.AggregateRoot);
 
         foreach (var creation in body.DescendantNodesAndSelf().OfType<BaseObjectCreationExpressionSyntax>())
@@ -123,29 +134,34 @@ public class ProducesReader(Compilation compilation, AggregateRootCatalog aggreg
     }
 
     /// <summary>
-    /// Falls back to what the signatures of the handlers promise when no body could be read.
+    /// Reads what a behavior of an aggregate root the handler reached produces.
     /// </summary>
-    /// <param name="handlers">The handler methods to read.</param>
+    /// <param name="command">The type declaring the command.</param>
+    /// <param name="behavior">The behavior the handler reached.</param>
     /// <param name="location">Where the command lives, for use in diagnostics.</param>
-    /// <returns>The productions, without mappings.</returns>
-    IEnumerable<ProducesModel> FromSignatures(IReadOnlyList<IMethodSymbol> handlers, string location)
+    /// <param name="produces">The productions collected so far.</param>
+    /// <remarks>
+    /// The behavior is written wherever the aggregate root is, and a project that was not handed over is one whose
+    /// source cannot be read at all. Saying so is the difference between a command stated as producing nothing and a
+    /// reader who knows a project is missing from what the document was generated from.
+    /// </remarks>
+    void ReadBehavior(
+        INamedTypeSymbol command,
+        AggregateRootInvocation behavior,
+        string location,
+        List<ProducesModel> produces)
     {
-        var events = handlers
-            .SelectMany(_ => HandlerBodies.EventTypesIn(_.ReturnType))
-            .Select(_ => _.Name)
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-            .ToList();
-
-        foreach (var name in events)
+        if (models.For(behavior.Body.SyntaxTree) is { } semanticModel)
         {
-            diagnostics.Warning(
-                ScreenplayDiagnosticCodes.UnmappableCommandProduction,
-                $"'{name}' is named by the handler's signature but never constructed in a body that could be read, so it is stated without mappings",
-                location);
+            ReadBody(command, behavior.Body, semanticModel, location, produces, behavior);
+
+            return;
         }
 
-        return [.. events.Select(_ => new ProducesModel(_, null, []))];
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.UnmappableCommandProduction,
+            $"The command hands its work to '{behavior.AggregateRoot.Name}', which is written in a project the document was not generated from, so what it applies is not stated",
+            location);
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/CompilationAnalysis.cs
+++ b/Source/DotNET/Screenplay/Analysis/CompilationAnalysis.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Screens;
+using Cratis.Arc.Screenplay.Analysis.Slices;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Reads one project of an application into the slices it declares.
+/// </summary>
+/// <remarks>
+/// Everything within this reads symbols and syntax of a single compilation, which is what makes it the unit an
+/// application of several projects is read in. What comes out is joined to what the other projects yielded, and the
+/// two questions that can only be answered once every project has been read - what a validator declares about a
+/// concept another project holds, and how much the errors of this project left behind - are asked of this afterwards
+/// rather than kept inside it.
+/// </remarks>
+public class CompilationAnalysis
+{
+    readonly ArtifactCatalog _catalog;
+    readonly ArtifactReaders _readers;
+    readonly RecoveredArtifacts _recovered;
+
+    CompilationAnalysis(
+        Compilation compilation,
+        ArtifactCatalog catalog,
+        ArtifactReaders readers,
+        RecoveredArtifacts recovered,
+        IReadOnlyList<SliceModel> slices)
+    {
+        Compilation = compilation;
+        Slices = slices;
+        _catalog = catalog;
+        _readers = readers;
+        _recovered = recovered;
+    }
+
+    /// <summary>
+    /// Gets the compilation that was read.
+    /// </summary>
+    public Compilation Compilation { get; }
+
+    /// <summary>
+    /// Gets the slices the compilation declares, ordered by namespace.
+    /// </summary>
+    public IReadOnlyList<SliceModel> Slices { get; }
+
+    /// <summary>
+    /// Reads a compilation into the slices it declares.
+    /// </summary>
+    /// <param name="compilation">The compilation to read.</param>
+    /// <param name="catalog">The catalogue of everything it declares.</param>
+    /// <param name="paths">The <see cref="SourcePaths"/> its paths are written relative to.</param>
+    /// <param name="whole">What the application as a whole holds.</param>
+    /// <returns>The <see cref="CompilationAnalysis"/>.</returns>
+    public static CompilationAnalysis Of(
+        Compilation compilation,
+        ArtifactCatalog catalog,
+        SourcePaths paths,
+        WholeApplication whole)
+    {
+        var diagnostics = whole.Diagnostics;
+        var readers = ArtifactReaders.For(compilation, catalog, paths, whole);
+        var screens = new ScreenReader(
+            whole.Files,
+            paths,
+            new(diagnostics),
+            new(whole.Files, diagnostics, whole.Elsewhere),
+            whole.Elsewhere);
+
+        var recovered = new RecoveredArtifacts();
+        var reader = new SliceReader(readers, diagnostics, screens, recovered);
+
+        var slices = catalog.Namespaces
+            .Select(@namespace => reader.Read(@namespace, catalog.In(@namespace)))
+            .OfType<SliceModel>()
+            .ToList();
+
+        return new(compilation, catalog, readers, recovered, slices);
+    }
+
+    /// <summary>
+    /// Attaches the rules the validators of this project declare to the concepts they validate.
+    /// </summary>
+    /// <remarks>
+    /// This waits until every project has been read, because the concept a validator here declares rules for may only
+    /// have been reached by an artifact in a project read after this one.
+    /// </remarks>
+    public void LinkConceptValidations() => ConceptValidations.Link(_catalog, _readers);
+
+    /// <summary>
+    /// Reports the errors this compilation carries, at the severity what was recovered from it earns.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>True when the source of this project did not compile.</returns>
+    /// <remarks>
+    /// Each project answers for its own source. A project of an application that does not build says nothing about
+    /// the projects that do, and how much survived the errors is a count of what came out of this compilation.
+    /// </remarks>
+    public bool ReportCompilationErrors(ScreenplayDiagnostics diagnostics) =>
+        CompilationErrors.Report(Compilation, _recovered, diagnostics);
+}

--- a/Source/DotNET/Screenplay/Analysis/Directories.cs
+++ b/Source/DotNET/Screenplay/Analysis/Directories.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// The arithmetic of directories a document's paths are worked out with.
+/// </summary>
+/// <remarks>
+/// A path in a document is written relative to a directory, and which directory that is comes from comparing the
+/// directories the source of a project - or of several - is written in. This is what the comparing is done with, held
+/// apart from the paths themselves because the same three questions are asked of one project's directories and of the
+/// roots of all of them.
+/// </remarks>
+public static class Directories
+{
+    /// <summary>
+    /// Normalizes a path onto forward slashes.
+    /// </summary>
+    /// <param name="path">The path to normalize.</param>
+    /// <returns>The normalized path.</returns>
+    public static string Normalize(string path) => path.Replace('\\', '/');
+
+    /// <summary>
+    /// Finds the longest directory prefix every one of a set of directories shares.
+    /// </summary>
+    /// <param name="directories">The directories to compare.</param>
+    /// <returns>The shared prefix, ending in a separator, empty when they share none.</returns>
+    public static string SharedPrefixOf(IReadOnlyList<string> directories)
+    {
+        if (directories.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var prefix = directories[0];
+
+        foreach (var directory in directories.Skip(1))
+        {
+            var length = 0;
+            while (length < prefix.Length && length < directory.Length && prefix[length] == directory[length])
+            {
+                length++;
+            }
+
+            prefix = prefix[..length];
+        }
+
+        var separator = prefix.LastIndexOf('/');
+
+        return separator < 0 ? string.Empty : prefix[..(separator + 1)];
+    }
+
+    /// <summary>
+    /// Determines whether a directory is the root of a file system rather than a directory within one.
+    /// </summary>
+    /// <param name="directory">The directory to check.</param>
+    /// <returns>True when it is a file system root.</returns>
+    /// <remarks>
+    /// Writing a path relative to <c>/</c> is not writing it relative to anything - it removes one character and
+    /// leaves the machine's own layout behind, looking like a relative path while being nothing of the sort.
+    /// </remarks>
+    public static bool IsFileSystemRoot(string directory) =>
+        string.Equals(directory, "/", StringComparison.Ordinal) || (directory.Length == 3 && directory[1] == ':' && directory[2] == '/');
+}

--- a/Source/DotNET/Screenplay/Analysis/Events/ExternalEvents.cs
+++ b/Source/DotNET/Screenplay/Analysis/Events/ExternalEvents.cs
@@ -28,11 +28,30 @@ public static class ExternalEvents
     public static IReadOnlyList<string> Resolve(
         Compilation compilation,
         IReadOnlyList<SliceModel> slices,
+        ScreenplayDiagnostics diagnostics) =>
+        Resolve([compilation], slices, diagnostics);
+
+    /// <summary>
+    /// Resolves the events an application written as several projects refers to without declaring them.
+    /// </summary>
+    /// <param name="compilations">The compilations being analyzed, ordered.</param>
+    /// <param name="slices">The slices to read, joined across every project.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The fully qualified name of every event to import, ordered.</returns>
+    /// <remarks>
+    /// An import states a dependency on something outside the application, and a project of the application is not
+    /// outside it. One project referencing another puts the events they share in a referenced assembly, which is
+    /// exactly what an import looks in, so the assemblies being analyzed are left out of the search - an event a
+    /// sibling project declares is declared in the document rather than imported into it.
+    /// </remarks>
+    public static IReadOnlyList<string> Resolve(
+        IReadOnlyList<Compilation> compilations,
+        IReadOnlyList<SliceModel> slices,
         ScreenplayDiagnostics diagnostics)
     {
         var declared = slices.SelectMany(_ => _.Events).Select(_ => _.Name).ToHashSet(StringComparer.Ordinal);
         var undeclared = slices.SelectMany(ReferredToBy).Where(_ => !declared.Contains(_)).ToHashSet(StringComparer.Ordinal);
-        var imported = DeclaredByAReference(compilation, undeclared);
+        var imported = DeclaredByAReference(compilations, undeclared);
 
         foreach (var slice in slices)
         {
@@ -77,7 +96,7 @@ public static class ExternalEvents
     /// <summary>
     /// Finds the event a referenced assembly declares under each of a set of names.
     /// </summary>
-    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="compilations">The compilations being analyzed.</param>
     /// <param name="names">The names to look for.</param>
     /// <returns>The fully qualified name each one was found under, keyed by the name it is referred to by.</returns>
     /// <remarks>
@@ -85,8 +104,14 @@ public static class ExternalEvents
     /// the few that could answer. Assemblies and namespaces are both walked in name order and the first declaration
     /// of a name wins, because two packages declaring an event under one name is a document that would otherwise
     /// depend on the order the compiler happened to hand its references over.
+    /// <para>
+    /// The references of every project are searched together, and ordering them by name across all of them rather
+    /// than project by project is what keeps the answer the same whichever project happens to be read first. The
+    /// assemblies the projects themselves build are excluded, because they are the application rather than something
+    /// it depends on.
+    /// </para>
     /// </remarks>
-    static Dictionary<string, string> DeclaredByAReference(Compilation compilation, HashSet<string> names)
+    static Dictionary<string, string> DeclaredByAReference(IReadOnlyList<Compilation> compilations, HashSet<string> names)
     {
         var found = new Dictionary<string, string>(StringComparer.Ordinal);
         if (names.Count == 0)
@@ -94,7 +119,12 @@ public static class ExternalEvents
             return found;
         }
 
-        foreach (var assembly in compilation.SourceModule.ReferencedAssemblySymbols
+        var analyzed = compilations.Select(_ => _.AssemblyName).OfType<string>().ToHashSet(StringComparer.Ordinal);
+
+        foreach (var assembly in compilations
+            .SelectMany(_ => _.SourceModule.ReferencedAssemblySymbols)
+            .Where(_ => !analyzed.Contains(_.Identity.Name))
+            .DistinctBy(_ => _.Identity.GetDisplayName(), StringComparer.Ordinal)
             .OrderBy(_ => _.Identity.GetDisplayName(), StringComparer.Ordinal))
         {
             if (names.Any(assembly.TypeNames.Contains))

--- a/Source/DotNET/Screenplay/Analysis/IApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/IApplicationModelAnalyzer.cs
@@ -22,4 +22,18 @@ public interface IApplicationModelAnalyzer
     /// <param name="options">The options to analyze with, with every value already resolved.</param>
     /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
     ApplicationModelAnalysis Analyze(Compilation compilation, ScreenplayOptions options);
+
+    /// <summary>
+    /// Analyzes the projects an application is written as and recovers the model they describe together.
+    /// </summary>
+    /// <param name="compilations">The compilations to analyze.</param>
+    /// <param name="options">The options to analyze with, with every value already resolved.</param>
+    /// <returns>The <see cref="ApplicationModelAnalysis"/>.</returns>
+    /// <remarks>
+    /// Each compilation contributes what its own assembly declares and the results are joined into one model: a
+    /// namespace two projects declare into is one slice, a concept is declared once however many projects refer to
+    /// it, and an event a sibling project declares is one the application has rather than one it imports. The order
+    /// the list arrives in never reaches the model - the projects are put into assembly name order first.
+    /// </remarks>
+    ApplicationModelAnalysis Analyze(IReadOnlyList<Compilation> compilations, ScreenplayOptions options);
 }

--- a/Source/DotNET/Screenplay/Analysis/NamespacesWithoutStructure.cs
+++ b/Source/DotNET/Screenplay/Analysis/NamespacesWithoutStructure.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Reports a namespace that carries nothing to arrange the document by.
+/// </summary>
+/// <remarks>
+/// Artifacts sitting in the root namespace leave the module, the feature and the slice with nothing to be named after
+/// but the assembly, so all of them end up saying the same word. Naming them anything else would be fiction - the
+/// source really does say nothing about where they belong - so this says what would fix it instead, which is either a
+/// namespace per slice or a leading segment skipped.
+/// </remarks>
+public static class NamespacesWithoutStructure
+{
+    /// <summary>
+    /// Reports every slice whose namespace carries no feature or slice to arrange by.
+    /// </summary>
+    /// <param name="slices">The slices to check.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments being skipped.</param>
+    /// <remarks>
+    /// The number of segments to skip is one number for the whole application rather than one per project. It says
+    /// how the namespaces of the application are shaped, and the projects of one application share the root of their
+    /// namespaces - a value per project would have to be keyed on assembly names the caller configuring it has no
+    /// reason to know.
+    /// </remarks>
+    public static void Report(
+        IEnumerable<SliceModel> slices,
+        ScreenplayDiagnostics diagnostics,
+        int segmentsToSkip)
+    {
+        foreach (var slice in slices.Where(_ => Segments(_.Namespace, segmentsToSkip) <= 1))
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.NamespaceWithoutStructure,
+                "The namespace carries no feature or slice to arrange by, so the module, the feature and the slice all take the same name - give the slice a namespace of its own, or skip a leading segment",
+                slice.Namespace);
+        }
+    }
+
+    /// <summary>
+    /// Counts the namespace segments left to arrange a slice by.
+    /// </summary>
+    /// <param name="namespace">The namespace to count.</param>
+    /// <param name="segmentsToSkip">The number of leading segments being skipped.</param>
+    /// <returns>The number of segments.</returns>
+    static int Segments(string @namespace, int segmentsToSkip) =>
+        @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries).Length - segmentsToSkip;
+}

--- a/Source/DotNET/Screenplay/Analysis/Policies/PolicyCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Policies/PolicyCatalog.cs
@@ -9,16 +9,32 @@ namespace Cratis.Arc.Screenplay.Analysis.Policies;
 /// <summary>
 /// Declares a policy for everything the application asks of its callers.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="compilations">The compilations being analyzed, ordered.</param>
+/// <param name="location">Where a policy nothing registers is reported against.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unrecoverable is reported to.</param>
 /// <remarks>
 /// Only what something refers to is declared. A role named by an artifact is a policy whose rule is the role itself;
 /// a policy named by an artifact has its rule looked up where the application registers it. Declaring the ones that
 /// nothing refers to would fill the document with rules it never uses.
+/// <para>
+/// Where the application registers it is any of its projects. An artifact naming a policy is written where the
+/// behavior is, and the registration where the host is composed, which is a different project as soon as an
+/// application has more than one.
+/// </para>
 /// </remarks>
-public class PolicyCatalog(Compilation compilation, ScreenplayDiagnostics diagnostics)
+public class PolicyCatalog(IReadOnlyList<Compilation> compilations, string? location, ScreenplayDiagnostics diagnostics)
 {
     readonly PolicyRequirementReader _requirements = new(diagnostics);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PolicyCatalog"/> class for an application of a single project.
+    /// </summary>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unrecoverable is reported to.</param>
+    public PolicyCatalog(Compilation compilation, ScreenplayDiagnostics diagnostics)
+        : this([compilation], compilation.AssemblyName, diagnostics)
+    {
+    }
 
     /// <summary>
     /// Declares a policy for every role and every named policy the slices refer to.
@@ -28,7 +44,7 @@ public class PolicyCatalog(Compilation compilation, ScreenplayDiagnostics diagno
     public IEnumerable<PolicyModel> Declare(IEnumerable<AuthorizationModel> authorizations)
     {
         var declared = authorizations as IReadOnlyCollection<AuthorizationModel> ?? [.. authorizations];
-        var registrations = PolicyRegistrations.In(compilation);
+        var registrations = PolicyRegistrations.In(compilations);
         var policies = new Dictionary<string, PolicyModel>(StringComparer.Ordinal);
 
         foreach (var name in Names(declared, _ => _.Policies))
@@ -74,7 +90,7 @@ public class PolicyCatalog(Compilation compilation, ScreenplayDiagnostics diagno
         diagnostics.Warning(
             ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable,
             $"The policy '{name}' is referred to, but nothing in the compilation registers it, so what it requires is not stated",
-            compilation.AssemblyName);
+            location);
 
         return null;
     }

--- a/Source/DotNET/Screenplay/Analysis/Policies/PolicyRegistrations.cs
+++ b/Source/DotNET/Screenplay/Analysis/Policies/PolicyRegistrations.cs
@@ -31,13 +31,29 @@ public static class PolicyRegistrations
     /// The first registration of a name wins, which is the framework's own behavior for the options form and is the
     /// only choice that keeps the same compilation yielding the same document.
     /// </remarks>
-    public static IReadOnlyDictionary<string, PolicyRegistration> In(Compilation compilation)
+    public static IReadOnlyDictionary<string, PolicyRegistration> In(Compilation compilation) => In([compilation]);
+
+    /// <summary>
+    /// Finds every policy the projects of an application register.
+    /// </summary>
+    /// <param name="compilations">The compilations to read, ordered.</param>
+    /// <returns>The registrations, keyed by the name each policy is registered under.</returns>
+    /// <remarks>
+    /// An artifact naming a policy and the composition root registering it routinely sit in different projects - that
+    /// the host is not where the behavior lives is the whole point of layering an application - so every project is
+    /// read and the registrations of all of them form one set. The first registration of a name still wins, and the
+    /// projects arrive already ordered, so which one that is does not depend on how the caller listed them.
+    /// </remarks>
+    public static IReadOnlyDictionary<string, PolicyRegistration> In(IReadOnlyList<Compilation> compilations)
     {
         var registrations = new Dictionary<string, PolicyRegistration>(StringComparer.Ordinal);
 
-        foreach (var tree in compilation.SyntaxTrees.OrderBy(_ => _.FilePath, StringComparer.Ordinal))
+        foreach (var compilation in compilations)
         {
-            Collect(compilation.GetSemanticModel(tree), tree, registrations);
+            foreach (var tree in compilation.SyntaxTrees.OrderBy(_ => _.FilePath, StringComparer.Ordinal))
+            {
+                Collect(compilation.GetSemanticModel(tree), tree, registrations);
+            }
         }
 
         return registrations;

--- a/Source/DotNET/Screenplay/Analysis/SemanticModels.cs
+++ b/Source/DotNET/Screenplay/Analysis/SemanticModels.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Resolves the semantic model of a syntax tree, whichever project of the application it was written in.
+/// </summary>
+/// <param name="compilations">The compilations being analyzed, ordered.</param>
+/// <remarks>
+/// A compilation answers only for the trees it was built from and throws for any other, so reading a declaration
+/// through the wrong one is not a wrong answer but a crash. Nearly every declaration is read through the compilation
+/// that catalogued it, and for those this is that compilation. The exception is a body reached from another body: a
+/// command handing its work to an aggregate root written in the project below it reads a behavior whose source
+/// belongs to that project, which is exactly the shape a layered application takes.
+/// <para>
+/// A tree belonging to none of them is a project the caller did not hand over. Nothing is returned rather than
+/// something being guessed, and the caller says what was lost.
+/// </para>
+/// </remarks>
+public class SemanticModels(IReadOnlyList<Compilation> compilations)
+{
+    /// <summary>
+    /// Resolves the semantic model a syntax tree is read through.
+    /// </summary>
+    /// <param name="tree">The tree to read.</param>
+    /// <returns>The <see cref="SemanticModel"/>, or <see langword="null"/> when no project holds the tree.</returns>
+    public SemanticModel? For(SyntaxTree tree)
+    {
+        foreach (var compilation in compilations)
+        {
+            if (compilation.ContainsSyntaxTree(tree))
+            {
+                return compilation.GetSemanticModel(tree);
+            }
+        }
+
+        return null;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/SliceKindInference.cs
+++ b/Source/DotNET/Screenplay/Analysis/SliceKindInference.cs
@@ -47,4 +47,33 @@ public static class SliceKindInference
 
         return commands.Any() || hasAggregateRoot ? SliceKind.StateChange : SliceKind.StateView;
     }
+
+    /// <summary>
+    /// Infers the kind of a slice that several projects each declare a part of, from the kind of each part.
+    /// </summary>
+    /// <param name="kinds">The kind each part was inferred to be.</param>
+    /// <returns>The inferred <see cref="SliceKind"/>.</returns>
+    /// <remarks>
+    /// This is <see cref="Infer"/> applied to everything the parts hold together, said in terms of the kinds rather
+    /// than of the contents, and it answers identically. A part is a translation exactly when it holds a translating
+    /// reactor, an automation exactly when it holds a reactor and no translating one, and a state change exactly when
+    /// it holds a command or an aggregate root and no reactor at all - so taking the first of those that any part is
+    /// is the same first match the joined contents would have produced.
+    /// </remarks>
+    public static SliceKind Combine(IEnumerable<SliceKind> kinds)
+    {
+        var declared = kinds as IReadOnlyCollection<SliceKind> ?? [.. kinds];
+
+        if (declared.Contains(SliceKind.Translate))
+        {
+            return SliceKind.Translate;
+        }
+
+        if (declared.Contains(SliceKind.Automation))
+        {
+            return SliceKind.Automation;
+        }
+
+        return declared.Contains(SliceKind.StateChange) ? SliceKind.StateChange : SliceKind.StateView;
+    }
 }

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceUnion.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceUnion.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Slices;
+
+/// <summary>
+/// Joins what the projects of an application declare into one slice per namespace.
+/// </summary>
+/// <remarks>
+/// A slice is recovered from a namespace, and nothing says a namespace belongs to one project. A bounded context that
+/// publishes its events from a contracts project and handles its commands from the project beside it declares one
+/// slice from two compilations, and a document holding both of them separately would say the slice twice and describe
+/// half of it in each. So the parts are joined: the events of one and the commands of the other end up in the slice
+/// they were always written for.
+/// <para>
+/// Everything within a slice is named once, though, so what two projects declare under one name cannot both be
+/// described. The parts arrive in the order the projects are read, which is their assembly name order and the only
+/// order there is to prefer by, and the first of a name is kept.
+/// </para>
+/// </remarks>
+public static class SliceUnion
+{
+    /// <summary>
+    /// Joins the slices of every project into the slices of the application.
+    /// </summary>
+    /// <param name="slices">The slices each project declared, in the order the projects were read.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The slices, one per namespace, ordered by namespace.</returns>
+    public static IReadOnlyList<SliceModel> Of(IEnumerable<SliceModel> slices, ScreenplayDiagnostics diagnostics) =>
+    [
+        .. slices
+            .GroupBy(_ => _.Namespace, StringComparer.Ordinal)
+            .OrderBy(_ => _.Key, StringComparer.Ordinal)
+            .Select(group => Join([.. group], diagnostics))
+    ];
+
+    /// <summary>
+    /// Joins the parts of one slice.
+    /// </summary>
+    /// <param name="parts">The parts, in the order the projects declaring them were read.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The slice.</returns>
+    /// <remarks>
+    /// A namespace declared by a single project is that project's slice exactly as it read it, which is what an
+    /// application of one project has always produced.
+    /// </remarks>
+    static SliceModel Join(IReadOnlyList<SliceModel> parts, ScreenplayDiagnostics diagnostics)
+    {
+        if (parts.Count == 1)
+        {
+            return parts[0];
+        }
+
+        var @namespace = parts[0].Namespace;
+
+        return new(
+            @namespace,
+            parts[0].Name,
+            SliceKindInference.Combine(parts.Select(_ => _.Kind)),
+            parts.Select(_ => _.Description).FirstOrDefault(_ => _ is not null),
+            Once(parts.SelectMany(_ => _.Commands), _ => _.Name, "command", @namespace, diagnostics),
+            Once(parts.SelectMany(_ => _.Events), _ => _.Name, "event", @namespace, diagnostics),
+            Once(parts.SelectMany(_ => _.Queries), _ => _.Name, "query", @namespace, diagnostics),
+            OneProjection(parts, @namespace, diagnostics),
+            Once(parts.SelectMany(_ => _.Reactors), _ => _.Name, "reactor", @namespace, diagnostics),
+            Once(parts.SelectMany(_ => _.Constraints), _ => _.Name, "constraint", @namespace, diagnostics))
+        {
+            Screens = Once(parts.SelectMany(_ => _.Screens), _ => _.Name, "screen", @namespace, diagnostics)
+        };
+    }
+
+    /// <summary>
+    /// Keeps the first artifact declared under each name, reporting every one that repeats a name.
+    /// </summary>
+    /// <typeparam name="T">The kind of artifact.</typeparam>
+    /// <param name="declared">Everything the projects declared, in the order they were read.</param>
+    /// <param name="name">How an artifact is named.</param>
+    /// <param name="kind">What an artifact of this kind is called, for use in the report.</param>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The artifacts kept, ordered by name.</returns>
+    static IReadOnlyList<T> Once<T>(
+        IEnumerable<T> declared,
+        Func<T, string> name,
+        string kind,
+        string @namespace,
+        ScreenplayDiagnostics diagnostics)
+    {
+        var taken = new HashSet<string>(StringComparer.Ordinal);
+        var kept = new List<T>();
+
+        foreach (var artifact in declared)
+        {
+            if (taken.Add(name(artifact)))
+            {
+                kept.Add(artifact);
+
+                continue;
+            }
+
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.RepeatedDeclarationAcrossProjects,
+                $"'{name(artifact)}' is a {kind} a second project of the application declares in this slice, and a slice describes one of a name, so it was left out",
+                @namespace);
+        }
+
+        return [.. kept.OrderBy(name, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Keeps the single projection a slice may declare, reporting any beyond the first.
+    /// </summary>
+    /// <param name="parts">The parts, in the order the projects declaring them were read.</param>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The projection, or <see langword="null"/> when no part declares one.</returns>
+    static ProjectionModel? OneProjection(
+        IReadOnlyList<SliceModel> parts,
+        string @namespace,
+        ScreenplayDiagnostics diagnostics)
+    {
+        ProjectionModel? kept = null;
+
+        foreach (var projection in parts.Select(_ => _.Projection).OfType<ProjectionModel>())
+        {
+            if (kept is null)
+            {
+                kept = projection;
+
+                continue;
+            }
+
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                $"'{projection.Identifier}' is a second projection in one slice, and a slice may declare at most one, so it was left out",
+                @namespace);
+        }
+
+        return kept;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
+++ b/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
@@ -40,14 +40,27 @@ public class SourcePaths(string root)
     /// nobody committed a line to.
     /// </para>
     /// </remarks>
-    public static SourcePaths For(Compilation compilation, ArtifactCatalog catalog)
+    public static SourcePaths For(Compilation compilation, ArtifactCatalog catalog) => new(RootOf(compilation, catalog));
+
+    /// <summary>
+    /// Resolves the directory the source of one project sits under.
+    /// </summary>
+    /// <param name="compilation">The compilation to read.</param>
+    /// <param name="catalog">The catalogue of everything the compilation declares.</param>
+    /// <returns>The directory, empty when there is none to write anything relative to.</returns>
+    /// <remarks>
+    /// This is what <see cref="For(Compilation, ArtifactCatalog)"/> resolves, said as a directory rather than as the
+    /// paths built from it, because an application written as several projects has one of these per project and a
+    /// single directory to write all of them relative to is worked out from them together.
+    /// </remarks>
+    public static string RootOf(Compilation compilation, ArtifactCatalog catalog)
     {
         var declared = DirectoriesOf(GeneratedSource.Excluded(catalog.Types.Select(_ => _.SourceFilePath())));
         var anchor = DeepestSharedBy(declared);
         var project = Rooted(declared, anchor);
         var root = Rooted(DirectoriesOf(compilation.SyntaxTrees.Select(_ => _.FilePath)), project);
 
-        return new(IsFileSystemRoot(root) ? string.Empty : root);
+        return Directories.IsFileSystemRoot(root) ? string.Empty : root;
     }
 
     /// <summary>
@@ -62,7 +75,7 @@ public class SourcePaths(string root)
             return null;
         }
 
-        var normalized = Normalize(path);
+        var normalized = Directories.Normalize(path);
 
         return root.Length > 0 && normalized.StartsWith(root, StringComparison.Ordinal)
             ? normalized[root.Length..]
@@ -111,7 +124,7 @@ public class SourcePaths(string root)
     {
         var onThePath = directories.Where(_ => OnTheSamePath(_, anchor)).ToList();
 
-        return onThePath.Count == 0 ? string.Empty : CommonPrefix(onThePath);
+        return Directories.SharedPrefixOf(onThePath);
     }
 
     /// <summary>
@@ -123,7 +136,7 @@ public class SourcePaths(string root)
     [
         .. paths
             .Where(_ => !string.IsNullOrWhiteSpace(_))
-            .Select(_ => Normalize(_!))
+            .Select(_ => Directories.Normalize(_!))
             .Select(_ => _[..(_.LastIndexOf('/') + 1)])
             .Distinct(StringComparer.Ordinal)
             .Order(StringComparer.Ordinal)
@@ -139,48 +152,4 @@ public class SourcePaths(string root)
         project.Length == 0 ||
         directory.StartsWith(project, StringComparison.Ordinal) ||
         project.StartsWith(directory, StringComparison.Ordinal);
-
-    /// <summary>
-    /// Determines whether a directory is the root of a file system rather than a directory within one.
-    /// </summary>
-    /// <param name="directory">The directory to check.</param>
-    /// <returns>True when it is a file system root.</returns>
-    /// <remarks>
-    /// Writing a path relative to <c>/</c> is not writing it relative to anything - it removes one character and
-    /// leaves the machine's own layout behind, looking like a relative path while being nothing of the sort.
-    /// </remarks>
-    static bool IsFileSystemRoot(string directory) =>
-        string.Equals(directory, "/", StringComparison.Ordinal) || (directory.Length == 3 && directory[1] == ':' && directory[2] == '/');
-
-    /// <summary>
-    /// Normalizes a path onto forward slashes.
-    /// </summary>
-    /// <param name="path">The path to normalize.</param>
-    /// <returns>The normalized path.</returns>
-    static string Normalize(string path) => path.Replace('\\', '/');
-
-    /// <summary>
-    /// Finds the longest directory prefix every path shares.
-    /// </summary>
-    /// <param name="directories">The directories to compare.</param>
-    /// <returns>The shared prefix, ending in a separator.</returns>
-    static string CommonPrefix(List<string> directories)
-    {
-        var prefix = directories[0];
-
-        foreach (var directory in directories.Skip(1))
-        {
-            var length = 0;
-            while (length < prefix.Length && length < directory.Length && prefix[length] == directory[length])
-            {
-                length++;
-            }
-
-            prefix = prefix[..length];
-        }
-
-        var separator = prefix.LastIndexOf('/');
-
-        return separator < 0 ? string.Empty : prefix[..(separator + 1)];
-    }
 }

--- a/Source/DotNET/Screenplay/Analysis/SourceRoots.cs
+++ b/Source/DotNET/Screenplay/Analysis/SourceRoots.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Resolves the directory every path in a document is written relative to, across the projects of an application.
+/// </summary>
+/// <remarks>
+/// One project answers this on its own - the directory its own source sits under. Several projects each answer it for
+/// themselves, and writing each project's paths relative to its own root would leave a document where <c>Ordering.cs</c>
+/// is the path of two files in two projects and nothing says which. The directory the projects are all written under
+/// is the one that keeps a path both relative and unambiguous, so that is what is used and every path in the document
+/// then opens with the project it belongs to.
+/// <para>
+/// It is not always there. Projects checked out beside each other in unrelated places share nothing but the root of
+/// the file system, and writing a path relative to that leaves the machine's own layout behind while looking like a
+/// relative path. Each project's own root is used instead, which is the ambiguity above rather than a document nobody
+/// can commit, and it is reported so that the ambiguity is one the reader knows about.
+/// </para>
+/// </remarks>
+public static class SourceRoots
+{
+    /// <summary>
+    /// Resolves what the paths of each compilation are written relative to.
+    /// </summary>
+    /// <param name="compilations">The compilations being analyzed, ordered.</param>
+    /// <param name="catalogs">What each of them declares, in the same order.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <param name="location">Where to report against.</param>
+    /// <returns>The <see cref="SourcePaths"/> of each compilation, in the same order.</returns>
+    public static IReadOnlyList<SourcePaths> Across(
+        IReadOnlyList<Compilation> compilations,
+        IReadOnlyList<ArtifactCatalog> catalogs,
+        ScreenplayDiagnostics diagnostics,
+        string? location)
+    {
+        var roots = compilations.Select((compilation, index) => SourcePaths.RootOf(compilation, catalogs[index])).ToList();
+        if (SharedBy(roots) is { } shared)
+        {
+            return [.. roots.Select(_ => new SourcePaths(shared))];
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.ProjectsWithoutASharedRoot,
+            $"The {roots.Count} projects of the application are written in directories that share none, so every path is written relative to the root of the project it belongs to and says nothing about which project that is",
+            location);
+
+        return [.. roots.Select(_ => new SourcePaths(_))];
+    }
+
+    /// <summary>
+    /// Gets the directory the source of every project sits under.
+    /// </summary>
+    /// <param name="roots">The root of each project.</param>
+    /// <returns>The directory, or <see langword="null"/> when the projects share none.</returns>
+    /// <remarks>
+    /// A single project is its own answer whatever that answer is, including the empty one it gives when there is
+    /// nothing to write its paths relative to - that is one project's situation rather than several projects failing
+    /// to agree, and it is what a document of one project has always said.
+    /// </remarks>
+    static string? SharedBy(List<string> roots)
+    {
+        if (roots.Count <= 1)
+        {
+            return roots.Count == 0 ? string.Empty : roots[0];
+        }
+
+        var shared = Directories.SharedPrefixOf(roots);
+
+        return shared.Length == 0 || Directories.IsFileSystemRoot(shared) ? null : shared;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/TypesTheDocumentCannotName.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/TypesTheDocumentCannotName.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Reports every type the document had to refer to by a name that does not say what it is.
+/// </summary>
+/// <remarks>
+/// A Screenplay type reference is a single identifier, so a type the grammar cannot hold is written as whatever of its
+/// name survives - and the property then claims a type nothing declares. Saying which types those were is the
+/// difference between a document with a known gap and a document that is quietly wrong.
+/// </remarks>
+public static class TypesTheDocumentCannotName
+{
+    /// <summary>
+    /// Reports everything the registry collected that the document could not say properly.
+    /// </summary>
+    /// <param name="types">The registry holding the types encountered.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <param name="location">Where to report against.</param>
+    /// <remarks>
+    /// These are reported against the application rather than against the project a type was reached from. One
+    /// registry holds the concepts of every project, because a concept is declared once and referred to by name from
+    /// there on, so which project first reached a type is an accident of the order the projects are read in and would
+    /// be a misleading thing to point at.
+    /// </remarks>
+    public static void Report(TypeRegistry types, ScreenplayDiagnostics diagnostics, string? location)
+    {
+        foreach (var type in types.Unmappable)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableTypeReference,
+                $"'{type}' has no Screenplay counterpart, so it is referred to by a name the document never declares",
+                location);
+        }
+
+        foreach (var type in types.Ambiguous)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.AmbiguousConceptName,
+                $"'{type}' shares its simple name with a concept the document already declares, so what it is is described by the first one instead",
+                location);
+        }
+
+        foreach (var shape in types.Shapes)
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.UndeclarableShape,
+                $"'{shape}' is a record an artifact carries, and there is no way to declare what a record holds, so the document names it without saying what is in it - the concepts it carries are declared, the shape itself is not",
+                location);
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/WholeApplication.cs
+++ b/Source/DotNET/Screenplay/Analysis/WholeApplication.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Aggregates;
+using Cratis.Arc.Screenplay.Analysis.Screens;
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Holds everything an analysis keeps for the whole application rather than for one of its projects.
+/// </summary>
+/// <param name="Compilations">The compilations the application is analyzed from, ordered.</param>
+/// <param name="Diagnostics">The <see cref="ScreenplayDiagnostics"/> everything is reported to.</param>
+/// <remarks>
+/// An application written as one project made this distinction invisible: everything a compilation was read into was
+/// the application, because the compilation was. With several, each of these has to be one thing across all of them
+/// or the document says something twice or misses it entirely. A concept is declared once and referred to by name
+/// from there on; an aggregate root one project declares is handed its work by a command another project holds; a
+/// screen imports the query of a slice that may live in a different project; a body reached from a handler may be
+/// written in the project below it; and diagnostics are one sequence in one order.
+/// <para>
+/// Everything not here is per project, because it reads a declaration the project itself catalogued and a symbol
+/// belongs to the compilation it came from.
+/// </para>
+/// </remarks>
+public record WholeApplication(IReadOnlyList<Compilation> Compilations, ScreenplayDiagnostics Diagnostics)
+{
+    /// <summary>
+    /// Gets the <see cref="IUserInterfaceFiles"/> the screens of a slice are found through.
+    /// </summary>
+    public IUserInterfaceFiles Files { get; init; } = new UserInterfaceFiles();
+
+    /// <summary>
+    /// Gets the models every syntax tree of the application is read through.
+    /// </summary>
+    public SemanticModels Models { get; } = new(Compilations);
+
+    /// <summary>
+    /// Gets the registry collecting every concept the application refers to.
+    /// </summary>
+    public TypeRegistry Types { get; } = new();
+
+    /// <summary>
+    /// Gets the aggregate roots the application declares, and which of them a command reaches.
+    /// </summary>
+    public AggregateRootCatalog AggregateRoots { get; } = new();
+
+    /// <summary>
+    /// Gets the queries screens read through that a slice other than their own declares.
+    /// </summary>
+    public CrossSliceQueries Elsewhere { get; } = new();
+
+    /// <summary>
+    /// Creates what an application of a single project holds.
+    /// </summary>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> everything is reported to.</param>
+    /// <returns>The <see cref="WholeApplication"/>.</returns>
+    public static WholeApplication Of(Compilation compilation, ScreenplayDiagnostics diagnostics) =>
+        new([compilation], diagnostics);
+}

--- a/Source/DotNET/Screenplay/IScreenplayGenerator.cs
+++ b/Source/DotNET/Screenplay/IScreenplayGenerator.cs
@@ -22,4 +22,24 @@ public interface IScreenplayGenerator
     /// <param name="options">The options to generate with.</param>
     /// <returns>The <see cref="ScreenplayGenerationResult"/>.</returns>
     ScreenplayGenerationResult Generate(Compilation compilation, ScreenplayOptions options);
+
+    /// <summary>
+    /// Generates the Screenplay document describing an application written as several projects.
+    /// </summary>
+    /// <param name="compilations">The compilations to generate from.</param>
+    /// <param name="options">The options to generate with.</param>
+    /// <returns>The <see cref="ScreenplayGenerationResult"/>.</returns>
+    /// <remarks>
+    /// A layered application - domain, application and api, or a host beside the bounded contexts it serves - is not
+    /// described by any one of its projects. Each compilation contributes what its own assembly declares and the
+    /// document holds all of it: a namespace two projects declare into is one slice, a concept referred to from three
+    /// of them is declared once, and an event a sibling project declares is one the application has rather than one
+    /// it imports.
+    /// <para>
+    /// The order the list arrives in does not reach the document. Nothing decides what order a host enumerates the
+    /// projects of a solution in, so they are put into assembly name order before anything is read and the same
+    /// projects always print the same bytes.
+    /// </para>
+    /// </remarks>
+    ScreenplayGenerationResult Generate(IReadOnlyList<Compilation> compilations, ScreenplayOptions options);
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -285,4 +285,34 @@ public static class ScreenplayDiagnosticCodes
     /// the binding the document is missing, and what turns it into one the moment a reference can carry the slice.
     /// </remarks>
     public const string CrossSliceQueryBinding = "SP0036";
+
+    /// <summary>
+    /// Two projects of one application declare an artifact of the same name in the same slice.
+    /// </summary>
+    /// <remarks>
+    /// A slice is recovered from a namespace, and a namespace an application declares from two projects is one slice
+    /// written in two places - the contracts of a bounded context sitting beside the handlers acting on them is the
+    /// ordinary case. Everything both projects contribute belongs to that one slice, and everything within a slice is
+    /// named once: a document declaring two commands called <c>PlaceOrder</c> in one slice says the same word twice
+    /// and means it differently. The first is kept, because the projects are read in assembly name order and no other
+    /// order is available to prefer by, and the second is reported rather than dropped where nobody would see it.
+    /// </remarks>
+    public const string RepeatedDeclarationAcrossProjects = "SP0037";
+
+    /// <summary>
+    /// The projects of an application are written in directories that share none above the root of the file system.
+    /// </summary>
+    /// <remarks>
+    /// Every path in a document is written relative to a directory, because a document carrying the absolute layout of
+    /// the machine that generated it is one nobody can commit or diff. With several projects that directory is the one
+    /// they are all written under - a <c>Source</c> folder holding a project each - and a path relative to it says
+    /// which project a file belongs to as well as where it sits within that project.
+    /// <para>
+    /// Projects checked out beside each other in unrelated places share nothing but the root of the file system, which
+    /// is not a directory to write anything relative to. Each project's paths are therefore written relative to its own
+    /// root, which keeps every one of them relative and still says where a file sits within its project - and says
+    /// nothing about which project that is, so two files can come out as the same path. That is what this reports.
+    /// </para>
+    /// </remarks>
+    public const string ProjectsWithoutASharedRoot = "SP0038";
 }

--- a/Source/DotNET/Screenplay/ScreenplayGenerator.cs
+++ b/Source/DotNET/Screenplay/ScreenplayGenerator.cs
@@ -37,16 +37,21 @@ public class ScreenplayGenerator(IApplicationModelAnalyzer analyzer, IScreenplay
     }
 
     /// <inheritdoc/>
-    public ScreenplayGenerationResult Generate(Compilation compilation, ScreenplayOptions options)
+    public ScreenplayGenerationResult Generate(Compilation compilation, ScreenplayOptions options) =>
+        Generate([compilation], options);
+
+    /// <inheritdoc/>
+    public ScreenplayGenerationResult Generate(IReadOnlyList<Compilation> compilations, ScreenplayOptions options)
     {
-        var resolved = options.WithDefaults(compilation.AssemblyName);
-        var analysis = analyzer.Analyze(compilation, resolved);
+        var ordered = AnalyzedCompilations.Ordered(compilations);
+        var resolved = options.WithDefaults(AnalyzedCompilations.NameOf(ordered));
+        var analysis = analyzer.Analyze(ordered, resolved);
         var emission = emitter.Emit(analysis.Model, resolved);
 
         var diagnostics = new ScreenplayDiagnostics();
         diagnostics.AddRange(analysis.Diagnostics);
         diagnostics.AddRange(emission.Diagnostics);
-        ReportDocumentThatDoesNotCompile(emission.Source, analysis.Diagnostics, diagnostics, compilation.AssemblyName);
+        ReportDocumentThatDoesNotCompile(emission.Source, analysis.Diagnostics, diagnostics, resolved.Domain);
 
         return new(emission.Source, analysis.Model, diagnostics.All);
     }


### PR DESCRIPTION
## Added

- An application split across several projects is described as one document: a namespace two projects declare into is one slice, a concept is declared once however many projects refer to it, and an event a sibling project declares is declared rather than imported (#2399)

## Fixed

- A command handing work to an aggregate root declared in another project is read instead of failing (#2399)
