### PR TITLE
Recover the specifications a slice carries into the document

### DIFF
--- a/Source/DotNET/Screenplay.Specs/IntegrationTesting.cs
+++ b/Source/DotNET/Screenplay.Specs/IntegrationTesting.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay;
+
+/// <summary>
+/// Declares the testing surface a Chronicle integration specification is written against, as source.
+/// </summary>
+/// <remarks>
+/// The generator recognizes these by the fully qualified name of the type declaring each member, which is exactly
+/// what lets it read a specification without the testing packages being referenced. Declaring them here rather than
+/// referencing them keeps every specification about reading them hermetic, and asks the recognition the only
+/// question worth asking of it - whether the names alone are enough.
+/// </remarks>
+public static class IntegrationTesting
+{
+    /// <summary>
+    /// The path the surface is compiled as.
+    /// </summary>
+    public const string Path = "Library/Testing/IntegrationTesting.cs";
+
+    /// <summary>
+    /// The source of the surface.
+    /// </summary>
+    public const string Source = """
+        using System.Net.Http;
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.EventSequences;
+
+        namespace Cratis.Arc.Testing.Commands
+        {
+            public class CommandScenario<TCommand>
+            {
+                public Cratis.Arc.Chronicle.Testing.Commands.CommandScenarioChronicleGivenBuilder<TCommand> Given => new();
+
+                public IEventSequence EventSequence => null!;
+
+                public Task<Result> Execute(TCommand command) => Task.FromResult(new Result());
+
+                public Task<Result> Validate(TCommand command) => Task.FromResult(new Result());
+            }
+
+            public class Result
+            {
+                public bool IsSuccess => true;
+            }
+        }
+
+        namespace Cratis.Arc.Chronicle.Testing.Commands
+        {
+            public class CommandScenarioChronicleGivenBuilder<TCommand>
+            {
+                public CommandScenarioSourceGivenBuilder<TCommand> ForEventSource(EventSourceId eventSourceId) => new();
+            }
+
+            public class CommandScenarioSourceGivenBuilder<TCommand>
+            {
+                public void Events(params object[] events)
+                {
+                }
+
+                public void ReadModel<TReadModel>(TReadModel readModel)
+                    where TReadModel : class
+                {
+                }
+            }
+        }
+
+        namespace Cratis.Chronicle.XUnit.Integration
+        {
+            public static class HttpClientExtensions
+            {
+                public static Task<Cratis.Arc.Testing.Commands.Result> ExecuteCommand<TCommand>(
+                    this HttpClient client,
+                    string requestUri,
+                    TCommand command) => Task.FromResult(new Cratis.Arc.Testing.Commands.Result());
+            }
+        }
+
+        namespace Cratis.Chronicle.Testing.EventSequences
+        {
+            public static class EventSequenceShouldExtensions
+            {
+                public static void ShouldHaveAppendedEvent<TEvent>(this IEventSequence sequence, EventSourceId eventSourceId)
+                {
+                }
+
+                public static void ShouldHaveTailSequenceNumber(this IEventSequence sequence, int expected)
+                {
+                }
+
+                public static void ShouldBeSuccessful(this Cratis.Arc.Testing.Commands.Result result)
+                {
+                }
+
+                public static void ShouldNotBeSuccessful(this Cratis.Arc.Testing.Commands.Result result)
+                {
+                }
+
+                public static void ShouldHaveConstraintViolationFor(this Cratis.Arc.Testing.Commands.Result result, string constraintName)
+                {
+                }
+
+                public static void ShouldBeFalse(this bool value)
+                {
+                }
+            }
+        }
+        """;
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_against_a_running_host.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_against_a_running_host.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The other shape Arc documents drives a running host rather than the pipeline in process: what the event log
+/// already held is appended to it directly, the command goes over HTTP, and the steps live on a nested context with
+/// only the assertions left outside. It says the same thing as the in-process shape and has to read as the same
+/// thing, or a document would describe an application differently depending on how it was specified.
+/// </summary>
+public class a_specification_against_a_running_host : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Net.Http;
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.EventSequences;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Cratis.Chronicle.XUnit.Integration;
+        using Library.Authors.Registration;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_registering;
+
+        public class and_the_name_is_already_taken
+        {
+            public class context
+            {
+                public const string AuthorName = "Jane Austen";
+
+                protected IEventLog EventLog = null!;
+                protected HttpClient Client = null!;
+
+                async Task Establish() => await EventLog.Append("author", new AuthorRegistered(AuthorName));
+
+                async Task Because() => await Client.ExecuteCommand("/api/authors/register", new RegisterAuthor(AuthorName));
+            }
+
+            readonly IEventSequence _sequence = null!;
+
+            [Fact] void should_register_the_author() => _sequence.ShouldHaveAppendedEvent<AuthorRegistered>("author");
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Slice),
+        ("Library/Authors/Registration/when_registering/and_the_name_is_already_taken.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    SpecificationModel _specification;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _specification = _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_read_the_steps_written_on_the_nested_context() => _specification.Given.Single().Name.ShouldEqual("AuthorRegistered");
+    [Fact] void should_state_the_value_appended_to_the_log() => _specification.Given.Single().Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Jane Austen"))]);
+    [Fact] void should_issue_the_command_sent_over_http() => _specification.When.Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_state_the_values_the_command_was_sent_with() => _specification.When.Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Jane Austen"))]);
+    [Fact] void should_read_the_assertions_left_outside_the_context() => _specification.Then.Single().Name.ShouldEqual("AuthorRegistered");
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_expecting_a_rejection.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_expecting_a_rejection.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A command being turned down is half of what a slice is specified for, and the language says it as a rejection
+/// with a reason. A source naming the reason - the constraint that held - has it carried across; a source saying
+/// only that the command did not go through has no reason to carry, and a made up sentence would describe an
+/// application nobody wrote. The scenario is named after the words the source uses for it, so the reason is already
+/// said there.
+/// </summary>
+public class a_specification_expecting_a_rejection : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Library.Authors.Registration;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_registering;
+
+        public class and_the_name_is_taken
+        {
+            public const string UniqueAuthorName = "unique-author-name";
+
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterAuthor("Jane Austen"));
+
+            [Fact] void should_not_register_the_author() => _result.ShouldHaveConstraintViolationFor(UniqueAuthorName);
+        }
+
+        public class and_nothing_was_given
+        {
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterAuthor("Jane Austen"));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+            [Fact] void should_say_so_on_the_result() => _result.IsSuccess.ShouldBeFalse();
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Slice),
+        ("Library/Authors/Registration/when_registering/and_the_name_is_taken.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    SpecificationModel _named;
+    SpecificationModel _unnamed;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        var specifications = _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.ToList();
+        _named = specifications.Single(_ => _.Name.EndsWith("and_the_name_is_taken", StringComparison.Ordinal));
+        _unnamed = specifications.Single(_ => _.Name.EndsWith("and_nothing_was_given", StringComparison.Ordinal));
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_read_both_scenarios_written_in_one_file() => _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.Count().ShouldEqual(2);
+    [Fact] void should_carry_across_the_reason_the_source_names() => _named.Errors.ShouldContainOnly(["unique-author-name"]);
+    [Fact] void should_expect_no_event_alongside_a_rejection() => _named.Then.ShouldBeEmpty();
+    [Fact] void should_state_a_rejection_the_source_names_no_reason_for() => _unnamed.Errors.ShouldContainOnly([string.Empty]);
+    [Fact] void should_state_two_ways_of_saying_the_same_rejection_once() => _unnamed.Errors.Count().ShouldEqual(1);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_collaborator.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_collaborator.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Most of the specifications an application carries stand a collaborator up behind a substitute and say what it was
+/// asked to do. That is a statement about the inside of a slice rather than about its behavior, so the language has
+/// nowhere to put it - and reporting each one would say a gap exists where none does. They are passed over entirely,
+/// which is only safe because what is read is decided by what a specification touches rather than by where it sits.
+/// </summary>
+public class a_specification_of_a_collaborator : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_registering;
+
+        public interface INameFormatter
+        {
+            string Format(string name);
+        }
+
+        public class and_the_name_is_formatted
+        {
+            string _result = string.Empty;
+
+            void Because() => _result = new Formatter().Format("jane austen");
+
+            [Fact] void should_capitalize_the_name() => _result.ShouldEqualTheExpected("Jane Austen");
+        }
+
+        public class Formatter : INameFormatter
+        {
+            public string Format(string name) => name;
+        }
+
+        public static class Assertions
+        {
+            public static void ShouldEqualTheExpected(this string actual, string expected)
+            {
+            }
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Slice),
+        ("Library/Authors/Registration/when_registering/and_the_name_is_formatted.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_specify_the_slice_by_nothing() => _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.ShouldBeEmpty();
+    [Fact] void should_report_no_scenario_left_out() => _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.UnreadableSpecification).ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_slice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_slice.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// The scenarios a slice is specified by sit in a folder beneath it, which is a namespace beneath its own, and are
+/// written to a convention rigid enough to read: what had happened is stated against the scenario, the command is
+/// issued through it, and each assertion says one thing about what followed. Reading them is what turns a document
+/// stating what a slice does into one carrying the examples proving it.
+/// </summary>
+public class a_specification_of_a_slice : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [ReadModel]
+        public record Author(string Id, string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name, int Age)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Library.Authors.Registration;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_registering;
+
+        public class and_the_author_is_new
+        {
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+
+            void Establish()
+            {
+                _scenario.Given.ForEventSource("author").Events(new AuthorRegistered("Jane Austen"));
+                _scenario.Given.ForEventSource("author").ReadModel(new Author("author", "Jane Austen"));
+            }
+
+            async Task Because() => await _scenario.Execute(new RegisterAuthor("Mary Shelley", 42));
+
+            [Fact] void should_register_the_author() => _scenario.EventSequence.ShouldHaveAppendedEvent<AuthorRegistered>("author");
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Slice),
+        ("Library/Authors/Registration/when_registering/and_the_author_is_new.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    SpecificationModel _specification;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _specification = _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_put_it_under_the_slice_it_specifies() => _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.Count().ShouldEqual(1);
+    [Fact] void should_name_it_after_every_word_between_the_slice_and_itself() => _specification.Name.ShouldEqual("when_registering_and_the_author_is_new");
+    [Fact] void should_start_from_the_event_that_had_happened() => _specification.Given.First().Name.ShouldEqual("AuthorRegistered");
+    [Fact] void should_know_the_event_it_starts_from_is_an_event() => _specification.Given.First().Kind.ShouldEqual(SpecificationStateKind.Event);
+    [Fact] void should_state_the_values_of_the_event_it_starts_from() => _specification.Given.First().Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Jane Austen"))]);
+    [Fact] void should_start_from_the_read_model_that_was_pinned() => _specification.Given.Last().Kind.ShouldEqual(SpecificationStateKind.ReadModel);
+    [Fact] void should_state_the_values_of_the_read_model() => _specification.Given.Last().Values.Select(_ => _.Property).ShouldContainOnly(["Id", "Name"]);
+    [Fact] void should_issue_the_command() => _specification.When.Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_state_the_values_the_command_was_issued_with() => _specification.When.Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Mary Shelley")), new PropertyMappingModel("Age", new LiteralSource(42))]);
+    [Fact] void should_expect_the_event_the_assertion_names() => _specification.Then.Single().Name.ShouldEqual("AuthorRegistered");
+    [Fact] void should_expect_no_rejection() => _specification.Errors.ShouldBeEmpty();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_stating_a_value_that_is_code.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_stating_a_value_that_is_code.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A scenario written in the host language routinely rests an identity on a value made at run time, which is exactly
+/// what a document stating values has no way to name. Unlike a step, a value stands on its own: leaving one out
+/// leaves the rest of the scenario saying what the source says, so it is left out and said rather than taking the
+/// scenario with it.
+/// </summary>
+public class a_specification_stating_a_value_that_is_code : Specification
+{
+    const string Slice = """
+        using System;
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(Guid Id, string Name, int Age)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System;
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Library.Authors.Registration;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_registering;
+
+        public class and_the_identity_is_made_at_run_time
+        {
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+            readonly Guid _id = Guid.NewGuid();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterAuthor(_id, "Jane Austen", 41));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Slice),
+        ("Library/Authors/Registration/when_registering/and_the_identity_is_made_at_run_time.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    SpecificationModel _specification;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _specification = _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.Single();
+    }
+
+    ScreenplayDiagnostic LeftOut() =>
+        _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.UnreadableSpecificationValue);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_keep_the_scenario() => _specification.When.Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_state_every_value_it_can_read() => _specification.When.Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Jane Austen")), new PropertyMappingModel("Age", new LiteralSource(41))]);
+    [Fact] void should_leave_out_the_one_it_cannot() => _specification.When.Values.Select(_ => _.Property).ShouldNotContain("Id");
+    [Fact] void should_say_which_value_it_left_out() => LeftOut().Message.ShouldEqual("The value 'when_registering_and_the_identity_is_made_at_run_time' states for 'RegisterAuthor.Id' is code rather than a constant, so the scenario states everything but that value");
+    [Fact] void should_say_where_it_left_it_out() => LeftOut().Location.ShouldEqual("Library.Authors.Registration.when_registering.and_the_identity_is_made_at_run_time");
+    [Fact] void should_report_it_as_information() => LeftOut().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Information);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_whose_steps_cannot_be_read.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_whose_steps_cannot_be_read.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A scenario is one example, and an example missing the state it started from, the command it issued or the outcome
+/// it expects is a different example from the one the source states. Each of the three is left out whole and said
+/// so, which is the difference between a document with a known gap and one that is quietly wrong about what an
+/// application was specified against.
+/// </summary>
+public class a_specification_whose_steps_cannot_be_read : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Library.Authors.Registration;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_registering;
+
+        public class and_the_command_is_held_in_a_field
+        {
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+            RegisterAuthor _command = null!;
+            Result _result = null!;
+
+            void Establish() => _command = new RegisterAuthor("Jane Austen");
+
+            async Task Because() => _result = await _scenario.Execute(_command);
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+
+        public class and_what_it_starts_from_depends_on_a_condition
+        {
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+            Result _result = null!;
+
+            protected virtual bool AuthorAlreadyRegistered => true;
+
+            void Establish()
+            {
+                if (AuthorAlreadyRegistered)
+                {
+                    _scenario.Given.ForEventSource("author").Events(new AuthorRegistered("Jane Austen"));
+                }
+            }
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterAuthor("Mary Shelley"));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+
+        public class and_nothing_it_expects_has_a_place_in_the_language
+        {
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterAuthor("Mary Shelley"));
+
+            [Fact] void should_succeed() => _result.ShouldBeSuccessful();
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Slice),
+        ("Library/Authors/Registration/when_registering/and_the_command_is_held_in_a_field.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    IEnumerable<ScreenplayDiagnostic> LeftOut() =>
+        _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.UnreadableSpecification);
+
+    bool SaidOf(string scenario, string reason) =>
+        LeftOut().Any(_ => _.Message.Contains(scenario, StringComparison.Ordinal) && _.Message.Contains(reason, StringComparison.Ordinal));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_leave_out_every_scenario_it_cannot_read() => _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.ShouldBeEmpty();
+    [Fact] void should_report_each_of_them() => LeftOut().Count().ShouldEqual(3);
+    [Fact] void should_say_a_command_put_together_elsewhere_cannot_be_read() => SaidOf("and_the_command_is_held_in_a_field", "the command it issues is put together somewhere this cannot read").ShouldBeTrue();
+    [Fact] void should_say_a_starting_point_under_a_condition_cannot_be_read() => SaidOf("and_what_it_starts_from_depends_on_a_condition", "only happens under a condition").ShouldBeTrue();
+    [Fact] void should_say_an_outcome_the_language_cannot_hold_cannot_be_read() => SaidOf("and_nothing_it_expects_has_a_place_in_the_language", "it expects no event and no rejection").ShouldBeTrue();
+    [Fact] void should_say_where_each_of_them_lives() => LeftOut().Select(_ => _.Location).ShouldContain("Library.Authors.Registration.when_registering.and_the_command_is_held_in_a_field");
+    [Fact] void should_report_them_as_warnings() => LeftOut().Select(_ => _.Severity).ShouldContainOnly([ScreenplayDiagnosticSeverity.Warning, ScreenplayDiagnosticSeverity.Warning, ScreenplayDiagnosticSeverity.Warning]);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_carrying_the_specifications_of_a_slice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_source_carrying_the_specifications_of_a_slice.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating;
+
+/// <summary>
+/// A scenario recovered from source has to survive being written down: the name it is declared under, the events it
+/// starts from, the command it issues and the rejection it expects are each a line the language reads back, and a
+/// scenario is the one construct where the value of a property and the name of a step sit one indentation apart.
+/// This asks the whole way through, from source to printed text and back again through the compiler.
+/// </summary>
+public class from_source_carrying_the_specifications_of_a_slice : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Invoicing.Issuing;
+
+        [EventType]
+        public record InvoiceIssued(string Number, int Lines);
+
+        [ReadModel]
+        public record Invoice(string Id, string Number);
+
+        [Command]
+        public record IssueInvoice(string Number, int Lines)
+        {
+            public InvoiceIssued Handle() => new(Number, Lines);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Library.Invoicing.Issuing;
+        using Xunit;
+
+        namespace Library.Invoicing.Issuing.when_issuing;
+
+        public class and_the_invoice_has_no_lines
+        {
+            public const string OneInvoicePerNumber = "one-invoice-per-number";
+
+            readonly CommandScenario<IssueInvoice> _scenario = new();
+            Result _result = null!;
+
+            void Establish()
+            {
+                _scenario.Given.ForEventSource("invoice").Events(new InvoiceIssued("2026-1", 3));
+                _scenario.Given.ForEventSource("invoice").ReadModel(new Invoice("invoice", "2026-1"));
+            }
+
+            async Task Because() => _result = await _scenario.Execute(new IssueInvoice("2026-2", 0));
+
+            [Fact] void should_not_issue_the_invoice() => _result.ShouldHaveConstraintViolationFor(OneInvoicePerNumber);
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Invoicing/Issuing/Issuing.cs", Slice),
+        ("Library/Invoicing/Issuing/when_issuing/and_the_invoice_has_no_lines.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ScreenplayGenerationResult _result;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled;
+    string _reprinted;
+
+    void Because()
+    {
+        _result = new ScreenplayGenerator().Generate(Analyzed.Compile(_sources), new ScreenplayOptions());
+        _compiled = new ScreenplayCompiler().Compile(_result.Source);
+        _reprinted = _compiled.Value is null ? string.Empty : new Cratis.Screenplay.Printing.ScreenplayPrinter().Print(_compiled.Value);
+    }
+
+    bool Says(string text) => _result.Source.Contains(text, StringComparison.Ordinal);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
+    [Fact] void should_declare_the_scenario_under_the_words_the_source_wrote() => Says("specification WhenIssuingAndTheInvoiceHasNoLines").ShouldBeTrue();
+    [Fact] void should_state_the_event_it_starts_from() => Says("given InvoiceIssued").ShouldBeTrue();
+    [Fact] void should_state_the_read_model_it_starts_from() => Says("given readmodel Invoice").ShouldBeTrue();
+    [Fact] void should_state_the_values_it_starts_from() => Says("number = \"2026-1\"").ShouldBeTrue();
+    [Fact] void should_state_the_command_it_issues() => Says("when IssueInvoice").ShouldBeTrue();
+    [Fact] void should_state_the_values_the_command_carries() => Says("lines = 0").ShouldBeTrue();
+    [Fact] void should_state_the_rejection_and_the_reason_named_for_it() => Says("then error \"one-invoice-per-number\"").ShouldBeTrue();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -5,6 +5,7 @@ using Cratis.Arc.Screenplay.Analysis.Events;
 using Cratis.Arc.Screenplay.Analysis.Policies;
 using Cratis.Arc.Screenplay.Analysis.Screens;
 using Cratis.Arc.Screenplay.Analysis.Slices;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
 using Cratis.Arc.Screenplay.Model;
 using Microsoft.CodeAnalysis;
 
@@ -56,6 +57,8 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
             .OfType<SliceModel>()
             .ToList();
 
+        slices = Specified(compilation, catalog, slices, diagnostics);
+
         ConceptValidations.Link(catalog, readers);
         readers.AggregateRoots.Report(diagnostics);
         elsewhere.Report(diagnostics);
@@ -89,6 +92,25 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
                 Imports = imports
             },
             diagnostics.All);
+    }
+
+    /// <summary>
+    /// Puts every scenario the application specifies its slices by under the slice it belongs to.
+    /// </summary>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="catalog">The catalogue of everything the compilation declares.</param>
+    /// <param name="slices">The slices recovered so far.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The slices, each carrying the scenarios it is specified by.</returns>
+    static List<SliceModel> Specified(
+        Compilation compilation,
+        ArtifactCatalog catalog,
+        List<SliceModel> slices,
+        ScreenplayDiagnostics diagnostics)
+    {
+        var specifications = SpecificationCatalog.Read(compilation, catalog, slices.Select(_ => _.Namespace), diagnostics);
+
+        return [.. slices.Select(slice => slice with { Specifications = [.. specifications.For(slice.Namespace)] })];
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Specifications/CallArguments.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/CallArguments.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Gets the expressions a call gives to one of its parameters.
+/// </summary>
+/// <remarks>
+/// What a specification states sits in one argument of a call, and which one it is has to be resolved by name rather
+/// than by position - the calls carrying it declare everything after it as optional, take it through a parameter
+/// array, or are extension methods whose first parameter is the receiver. A parameter array and a parameter taking a
+/// collection are both flattened, so that stating three events in one call and stating them in three reads the same
+/// way.
+/// </remarks>
+public static class CallArguments
+{
+    /// <summary>
+    /// Gets the expressions a call gives to a parameter.
+    /// </summary>
+    /// <param name="invocation">The call to read.</param>
+    /// <param name="method">The method being called.</param>
+    /// <param name="parameter">The name of the parameter to read.</param>
+    /// <returns>The expressions, in the order the call declares them.</returns>
+    public static IEnumerable<ExpressionSyntax> For(InvocationExpressionSyntax invocation, IMethodSymbol method, string parameter)
+    {
+        var arguments = invocation.ArgumentList.Arguments;
+        var given = new List<ExpressionSyntax>();
+
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            if (string.Equals(NameOf(arguments[index], method, index), parameter, StringComparison.Ordinal))
+            {
+                given.AddRange(Flatten(arguments[index].Expression));
+            }
+        }
+
+        return given;
+    }
+
+    /// <summary>
+    /// Gets the name of the parameter an argument fills in.
+    /// </summary>
+    /// <param name="argument">The argument to name.</param>
+    /// <param name="method">The method being called.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The parameter name, or <see langword="null"/> when it cannot be resolved.</returns>
+    static string? NameOf(ArgumentSyntax argument, IMethodSymbol method, int index)
+    {
+        if (argument.NameColon is { } named)
+        {
+            return named.Name.Identifier.ValueText;
+        }
+
+        if (index < method.Parameters.Length)
+        {
+            return method.Parameters[index].Name;
+        }
+
+        return method.Parameters is [.., { IsParams: true } last] ? last.Name : null;
+    }
+
+    /// <summary>
+    /// Opens up an expression that holds several values into the values it holds.
+    /// </summary>
+    /// <param name="expression">The expression to open up.</param>
+    /// <returns>The values, or the expression itself when it holds one.</returns>
+    static IEnumerable<ExpressionSyntax> Flatten(ExpressionSyntax expression) => expression switch
+    {
+        CollectionExpressionSyntax collection => collection.Elements.Select(ValueOf),
+        ImplicitArrayCreationExpressionSyntax implicitly => implicitly.Initializer.Expressions,
+        ArrayCreationExpressionSyntax array when array.Initializer is { } initializer => initializer.Expressions,
+        _ => [expression]
+    };
+
+    /// <summary>
+    /// Gets the expression one element of a collection stands for.
+    /// </summary>
+    /// <param name="element">The element to read.</param>
+    /// <returns>The expression.</returns>
+    /// <remarks>
+    /// An element spreading another collection into this one stands for however many values that collection holds,
+    /// which is not something a source text says. The expression being spread is returned as it is, so that whoever
+    /// asked for the values finds one it cannot read rather than a list quietly missing them.
+    /// </remarks>
+    static ExpressionSyntax ValueOf(CollectionElementSyntax element) => element switch
+    {
+        ExpressionElementSyntax value => value.Expression,
+        SpreadElementSyntax spread => spread.Expression,
+        _ => SyntaxFactory.IdentifierName(element.ToString())
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationAssertions.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationAssertions.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Recognizes what an assertion of a specification says the outcome was.
+/// </summary>
+/// <remarks>
+/// Assertions are matched on the name of the helper alone. The same helper is declared several times over across the
+/// testing packages - once for the result of a command, once for the result of an append, once for the scenario
+/// itself - and a specification calls whichever of them its own shape reaches, so matching the declaring type would
+/// recognize the same sentence in one specification and not in the next.
+/// <para>
+/// Only the two outcomes Screenplay can hold are recognized: an event was appended, and the command was rejected.
+/// Everything else a specification asserts - how far the sequence got, that no exception was thrown, that the result
+/// was valid - says nothing the language has a place for and is passed over rather than reported, in the same way a
+/// unit level specification is.
+/// </para>
+/// </remarks>
+public static class SpecificationAssertions
+{
+    /// <summary>The assertion naming an event the command appended.</summary>
+    public const string AppendedEventAssertion = "ShouldHaveAppendedEvent";
+
+    /// <summary>The assertion saying a value is false, which is a rejection when the value is the success of a result.</summary>
+    public const string FalseAssertion = "ShouldBeFalse";
+
+    /// <summary>The value of a result saying whether the command was carried out.</summary>
+    public const string SuccessProperty = "IsSuccess";
+
+    /// <summary>The assertions saying the command was rejected, without naming why.</summary>
+    public static readonly string[] Rejections =
+    [
+        "ShouldHaveExceptions",
+        "ShouldHaveValidationErrors",
+        "ShouldNotBeAuthorized",
+        "ShouldNotBeSuccessful"
+    ];
+
+    /// <summary>The assertions saying the command was rejected and naming the reason.</summary>
+    public static readonly string[] NamedRejections =
+    [
+        "ShouldHaveConstraintViolation",
+        "ShouldHaveConstraintViolationFor",
+        "ShouldHaveValidationErrorFor"
+    ];
+
+    /// <summary>
+    /// Gets the event an assertion says was appended.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <returns>The event type, or <see langword="null"/> when the assertion is about something else.</returns>
+    /// <remarks>
+    /// The event is the last type argument rather than the only one, because the helper taking the scenario also
+    /// takes the command it is a scenario for, which has to be named ahead of it.
+    /// </remarks>
+    public static ITypeSymbol? AppendedEventOf(IMethodSymbol method) =>
+        string.Equals(method.Name, AppendedEventAssertion, StringComparison.Ordinal)
+            ? method.TypeArguments.LastOrDefault()
+            : null;
+
+    /// <summary>
+    /// Determines whether an assertion says the command was rejected.
+    /// </summary>
+    /// <param name="invocation">The assertion to read.</param>
+    /// <param name="method">The method being called.</param>
+    /// <returns>True when the assertion is a rejection.</returns>
+    public static bool IsRejection(InvocationExpressionSyntax invocation, IMethodSymbol method) =>
+        Array.Exists(Rejections, _ => string.Equals(_, method.Name, StringComparison.Ordinal)) ||
+        IsNamedRejection(method) ||
+        IsUnsuccessful(invocation, method);
+
+    /// <summary>
+    /// Determines whether an assertion names the reason the command was rejected.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <returns>True when the assertion names a reason.</returns>
+    public static bool IsNamedRejection(IMethodSymbol method) =>
+        Array.Exists(NamedRejections, _ => string.Equals(_, method.Name, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Determines whether an assertion says the result of the command was not a success.
+    /// </summary>
+    /// <param name="invocation">The assertion to read.</param>
+    /// <param name="method">The method being called.</param>
+    /// <returns>True when the assertion is about the success of a result.</returns>
+    static bool IsUnsuccessful(InvocationExpressionSyntax invocation, IMethodSymbol method) =>
+        string.Equals(method.Name, FalseAssertion, StringComparison.Ordinal) &&
+        invocation.Expression is MemberAccessExpressionSyntax { Expression: MemberAccessExpressionSyntax subject } &&
+        string.Equals(subject.Name.Identifier.ValueText, SuccessProperty, StringComparison.Ordinal);
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCalls.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCalls.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Recognizes the calls a Chronicle integration specification is written with.
+/// </summary>
+/// <remarks>
+/// Two ways of writing one are recognized, because Arc documents both. A specification driving the command pipeline
+/// in process states what had happened through the scenario it holds and issues the command through the same
+/// scenario; one driving a running host states it against the event log and issues the command over HTTP. Everything
+/// is matched on the fully qualified metadata name of the type declaring the method, so neither testing package has
+/// to be referenced for either to be read.
+/// </remarks>
+public static class SpecificationCalls
+{
+    /// <summary>The method appending one event to a sequence.</summary>
+    public const string AppendMethod = "Append";
+
+    /// <summary>The method appending several events to a sequence as one transaction.</summary>
+    public const string AppendManyMethod = "AppendMany";
+
+    /// <summary>The method stating the events that had happened for one event source.</summary>
+    public const string EventsMethod = "Events";
+
+    /// <summary>The method pinning the read model one event source resolves to.</summary>
+    public const string ReadModelMethod = "ReadModel";
+
+    /// <summary>The method issuing a command through the in-process pipeline.</summary>
+    public const string ExecuteMethod = "Execute";
+
+    /// <summary>The method taking a command as far as the pipeline validates it.</summary>
+    public const string ValidateMethod = "Validate";
+
+    /// <summary>The method issuing a command over HTTP.</summary>
+    public const string ExecuteCommandMethod = "ExecuteCommand";
+
+    /// <summary>The parameter carrying the single event an append is given.</summary>
+    public const string EventParameter = "event";
+
+    /// <summary>The parameter carrying the events an append or a scenario is given.</summary>
+    public const string EventsParameter = "events";
+
+    /// <summary>The parameter carrying the read model a scenario is pinned with.</summary>
+    public const string ReadModelParameter = "readModel";
+
+    /// <summary>The parameter carrying the command issued over HTTP.</summary>
+    public const string CommandParameter = "command";
+
+    /// <summary>
+    /// Determines whether a call states the events a specification starts from.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <returns>True when the call states events.</returns>
+    public static bool IsGivenEvents(IMethodSymbol method) =>
+        (IsOn(method, WellKnownTypeNames.EventSequence) && (Named(method, AppendMethod) || Named(method, AppendManyMethod))) ||
+        (IsOn(method, WellKnownTypeNames.CommandScenarioSourceGivenBuilder) && Named(method, EventsMethod));
+
+    /// <summary>
+    /// Determines whether a call pins the read model a specification starts from.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <returns>True when the call pins a read model.</returns>
+    public static bool IsGivenReadModel(IMethodSymbol method) =>
+        IsOn(method, WellKnownTypeNames.CommandScenarioSourceGivenBuilder) && Named(method, ReadModelMethod);
+
+    /// <summary>
+    /// Determines whether a call issues the command a specification is about.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <returns>True when the call issues a command.</returns>
+    public static bool IsExecution(IMethodSymbol method) =>
+        (IsOn(method, WellKnownTypeNames.CommandScenario) && (Named(method, ExecuteMethod) || Named(method, ValidateMethod))) ||
+        (IsOn(method, WellKnownTypeNames.HttpClientExtensions) && Named(method, ExecuteCommandMethod));
+
+    /// <summary>
+    /// Gets the name of the parameter carrying what a recognized call is given.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <returns>The parameter name, or <see langword="null"/> when the call carries nothing this reads.</returns>
+    public static string? PayloadParameterOf(IMethodSymbol method)
+    {
+        if (IsGivenReadModel(method))
+        {
+            return ReadModelParameter;
+        }
+
+        if (IsExecution(method))
+        {
+            return Named(method, ExecuteCommandMethod) ? CommandParameter : method.Parameters.FirstOrDefault()?.Name;
+        }
+
+        if (!IsGivenEvents(method))
+        {
+            return null;
+        }
+
+        return Named(method, AppendMethod) ? EventParameter : EventsParameter;
+    }
+
+    /// <summary>
+    /// Determines whether a method carries a name.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <param name="name">The name to match.</param>
+    /// <returns>True when the names are the same.</returns>
+    static bool Named(IMethodSymbol method, string name) => string.Equals(method.Name, name, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Determines whether a method belongs to a named type, following the type it was reduced from.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the declaring type.</param>
+    /// <returns>True when the method belongs to that type.</returns>
+    /// <remarks>
+    /// A specialization of an interface inherits its members without redeclaring them, so the interface a member is
+    /// declared on is matched as well as the one it is reached through - appending to the event log is appending to a
+    /// sequence, whichever of the two the call site names.
+    /// </remarks>
+    static bool IsOn(IMethodSymbol method, string fullMetadataName)
+    {
+        var declaring = (method.ReducedFrom ?? method).ContainingType;
+
+        return declaring.Is(fullMetadataName) || declaring.FindInterface(fullMetadataName) is not null;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCatalog.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Holds every scenario the application specifies its slices by, arranged under the slice each belongs to.
+/// </summary>
+/// <remarks>
+/// Specifications are read once the slices are in, because which slice a scenario belongs to is answered by which
+/// namespaces turned out to declare one. Reading them alongside would mean deciding that against namespaces still
+/// being read, and a scenario would land under a different slice depending on the order the compilation was walked.
+/// </remarks>
+public class SpecificationCatalog
+{
+    readonly Dictionary<string, List<SpecificationModel>> _bySlice;
+
+    SpecificationCatalog(Dictionary<string, List<SpecificationModel>> bySlice) => _bySlice = bySlice;
+
+    /// <summary>
+    /// Reads every specification the compilation declares.
+    /// </summary>
+    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="catalog">The catalogue of everything the compilation declares.</param>
+    /// <param name="slices">The namespaces a slice was recovered from.</param>
+    /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unreadable is reported to.</param>
+    /// <returns>The <see cref="SpecificationCatalog"/>.</returns>
+    public static SpecificationCatalog Read(
+        Compilation compilation,
+        ArtifactCatalog catalog,
+        IEnumerable<string> slices,
+        ScreenplayDiagnostics diagnostics)
+    {
+        var reader = new SpecificationReader(compilation, diagnostics);
+        var placement = new SpecificationPlacement(slices);
+        var bySlice = new Dictionary<string, List<SpecificationModel>>(StringComparer.Ordinal);
+
+        foreach (var type in catalog.Types.Where(reader.IsSpecification))
+        {
+            if (placement.SliceOf(type) is not { } slice)
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UnreadableSpecification,
+                    $"The scenario '{type.Name}' was left out because no namespace above it declares a slice for it to specify",
+                    type.ToDisplayString());
+
+                continue;
+            }
+
+            if (reader.Read(type, SpecificationPlacement.NameOf(type, slice)) is { } specification)
+            {
+                Add(bySlice, slice, specification);
+            }
+        }
+
+        return new(bySlice);
+    }
+
+    /// <summary>
+    /// Gets the specifications belonging to a slice.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <returns>The specifications, ordered by name.</returns>
+    public IEnumerable<SpecificationModel> For(string @namespace) =>
+        _bySlice.TryGetValue(@namespace, out var specifications)
+            ? specifications.OrderBy(_ => _.Name, StringComparer.Ordinal)
+            : [];
+
+    /// <summary>
+    /// Adds a specification under the slice it belongs to.
+    /// </summary>
+    /// <param name="bySlice">The specifications collected so far.</param>
+    /// <param name="slice">The namespace of the slice.</param>
+    /// <param name="specification">The specification to add.</param>
+    static void Add(Dictionary<string, List<SpecificationModel>> bySlice, string slice, SpecificationModel specification)
+    {
+        if (!bySlice.TryGetValue(slice, out var specifications))
+        {
+            specifications = [];
+            bySlice[slice] = specifications;
+        }
+
+        specifications.Add(specification);
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationDraft.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationDraft.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Collects a specification while the type declaring it is being read.
+/// </summary>
+/// <remarks>
+/// A scenario is one example, so the first step of it that cannot be read decides the outcome for all of them. The
+/// reason is kept rather than the fact, because what made a scenario unreadable is the only part of it worth
+/// reporting - and the first reason is kept rather than the last, since every reason after it is read from a
+/// scenario already known to be incomplete.
+/// </remarks>
+public class SpecificationDraft
+{
+    /// <summary>
+    /// Gets what had already happened when the command was issued.
+    /// </summary>
+    public IList<SpecificationStateModel> Given { get; } = [];
+
+    /// <summary>
+    /// Gets the events and read model states that followed.
+    /// </summary>
+    public IList<SpecificationStateModel> Then { get; } = [];
+
+    /// <summary>
+    /// Gets the rejections that followed, each named by the reason the source gives for it.
+    /// </summary>
+    public IList<string> Errors { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the command that was issued.
+    /// </summary>
+    public SpecificationStateModel? When { get; set; }
+
+    /// <summary>
+    /// Gets why the scenario could not be read, or <see langword="null"/> while all of it still can be.
+    /// </summary>
+    public string? Unreadable { get; private set; }
+
+    /// <summary>
+    /// Records why the scenario cannot be read.
+    /// </summary>
+    /// <param name="reason">What made it unreadable.</param>
+    public void CannotRead(string reason) => Unreadable ??= reason;
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Finds the parts of a specification within the chain of types it is written across.
+/// </summary>
+/// <remarks>
+/// A specification inherits the world it starts from. Every type in the chain may set part of it up, and the
+/// specification framework calls each of those in turn from the base down, so the chain is walked in that same order
+/// and what it states comes out in the order it really happens in.
+/// <para>
+/// Where the steps are written differs between the two shapes Arc documents. A specification driving the pipeline in
+/// process writes them on itself; one driving a running host writes them on a nested type the fixture is handed to,
+/// and keeps only its assertions outside. Which of the two a specification is follows from where the steps are, not
+/// from what it derives from, so a chain no package declares reads exactly the same way.
+/// </para>
+/// </remarks>
+public static class SpecificationMembers
+{
+    /// <summary>The method setting up the world a specification starts from.</summary>
+    public const string EstablishMethod = "Establish";
+
+    /// <summary>The method performing the single action a specification is about.</summary>
+    public const string BecauseMethod = "Because";
+
+    /// <summary>The nested type the steps of a specification against a running host are written on.</summary>
+    public const string ContextType = "context";
+
+    /// <summary>
+    /// Gets the type the steps of a specification are written on.
+    /// </summary>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <returns>The nested context when the specification has one, otherwise the type itself.</returns>
+    public static INamedTypeSymbol StepsOf(INamedTypeSymbol type) =>
+        type.GetTypeMembers(ContextType).FirstOrDefault(_ => Declares(_, BecauseMethod) || Declares(_, EstablishMethod)) ?? type;
+
+    /// <summary>
+    /// Gets the chain of types a type is written across, from the base down.
+    /// </summary>
+    /// <param name="type">The type to walk.</param>
+    /// <returns>The chain, base first.</returns>
+    public static IEnumerable<INamedTypeSymbol> ChainOf(INamedTypeSymbol type)
+    {
+        var chain = new List<INamedTypeSymbol>();
+        for (var current = type; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+        {
+            chain.Insert(0, current);
+        }
+
+        return chain;
+    }
+
+    /// <summary>
+    /// Gets every declaration of a method in a chain of types.
+    /// </summary>
+    /// <param name="type">The type to walk from.</param>
+    /// <param name="name">The name of the method.</param>
+    /// <returns>The methods, from the base down.</returns>
+    public static IEnumerable<IMethodSymbol> MethodsIn(INamedTypeSymbol type, string name) =>
+        ChainOf(type).SelectMany(_ => _.GetMembers(name)).OfType<IMethodSymbol>().Where(_ => _.MethodKind == MethodKind.Ordinary);
+
+    /// <summary>
+    /// Gets every assertion a specification makes.
+    /// </summary>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <returns>The assertions, ordered by name so that the same source always reads the same way.</returns>
+    public static IEnumerable<IMethodSymbol> AssertionsIn(INamedTypeSymbol type) =>
+        ChainOf(type)
+            .SelectMany(_ => _.GetMembers())
+            .OfType<IMethodSymbol>()
+            .Where(_ => _.HasAttribute(WellKnownTypeNames.FactAttribute))
+            .OrderBy(_ => _.Name, StringComparer.Ordinal)
+            .ThenBy(_ => _.ToDisplayString(), StringComparer.Ordinal);
+
+    /// <summary>
+    /// Determines whether a type holds a scenario the command pipeline is driven through.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type or one of its bases holds a scenario.</returns>
+    /// <remarks>
+    /// Holding one is what makes a specification an integration specification of the slice rather than a unit level
+    /// one about a collaborator, and it holds whether or not the command is issued somewhere this can read. That is
+    /// exactly why it is asked: a specification that holds a scenario and issues its command through a helper is one
+    /// this cannot read, and saying so is the difference between a known gap and a silent one.
+    /// </remarks>
+    public static bool HoldsAScenario(INamedTypeSymbol type) =>
+        ChainOf(type)
+            .SelectMany(_ => _.GetMembers())
+            .Any(member => TypeOf(member).Is(WellKnownTypeNames.CommandScenario));
+
+    /// <summary>
+    /// Determines whether a type declares a method itself.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="name">The name of the method.</param>
+    /// <returns>True when the type declares it.</returns>
+    static bool Declares(INamedTypeSymbol type, string name) => type.GetMembers(name).OfType<IMethodSymbol>().Any();
+
+    /// <summary>
+    /// Gets the type a member holds a value of.
+    /// </summary>
+    /// <param name="member">The member to read.</param>
+    /// <returns>The type, or <see langword="null"/> when the member holds no value.</returns>
+    static ITypeSymbol? TypeOf(ISymbol member) => member switch
+    {
+        IFieldSymbol field => field.Type,
+        IPropertySymbol property => property.Type,
+        _ => null
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Reads what a specification says followed from the command it issued.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unreadable is reported to.</param>
+/// <remarks>
+/// Each assertion is one sentence about the outcome, and several of them routinely say the same sentence about a
+/// different part of the same event - once for each value it carries. Screenplay says an event followed once, so a
+/// sentence already said is passed over rather than repeated.
+/// </remarks>
+public class SpecificationOutcomeReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Reads what a specification says followed.
+    /// </summary>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    /// <param name="name">The name of the specification.</param>
+    /// <param name="location">Where the specification lives, for use in diagnostics.</param>
+    public void Read(INamedTypeSymbol type, SpecificationDraft draft, string name, string location)
+    {
+        foreach (var assertion in SpecificationMembers.AssertionsIn(type))
+        {
+            foreach (var body in HandlerBodies.Of(assertion))
+            {
+                ReadBody(body, compilation.GetSemanticModel(body.SyntaxTree), draft, name, location);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds an event a specification says followed, or records that it cannot be read.
+    /// </summary>
+    /// <param name="appended">The type the assertion names.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    static void AddEvent(ITypeSymbol appended, SpecificationDraft draft)
+    {
+        if (!EventReader.IsEvent(appended))
+        {
+            draft.CannotRead($"it expects '{appended.Name}' to follow, which is not declared as an event");
+            return;
+        }
+
+        if (!draft.Then.Any(_ => string.Equals(_.Name, appended.Name, StringComparison.Ordinal)))
+        {
+            draft.Then.Add(new(appended.Name, SpecificationStateKind.Event, []));
+        }
+    }
+
+    /// <summary>
+    /// Reads what one assertion says followed.
+    /// </summary>
+    /// <param name="body">The body of the assertion.</param>
+    /// <param name="semanticModel">The semantic model of the tree the body lives in.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    /// <param name="name">The name of the specification.</param>
+    /// <param name="location">Where the specification lives.</param>
+    void ReadBody(SyntaxNode body, SemanticModel semanticModel, SpecificationDraft draft, string name, string location)
+    {
+        foreach (var invocation in body.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method)
+            {
+                continue;
+            }
+
+            var appended = SpecificationAssertions.AppendedEventOf(method);
+            var rejection = SpecificationAssertions.IsRejection(invocation, method);
+            if (appended is null && !rejection)
+            {
+                continue;
+            }
+
+            if (!StepsTaken.Always(invocation, body))
+            {
+                draft.CannotRead("what it expects to follow is only expected under a condition, and a scenario says what followed");
+                return;
+            }
+
+            if (appended is not null)
+            {
+                AddEvent(appended, draft);
+                continue;
+            }
+
+            AddError(invocation, method, semanticModel, draft, name, location);
+        }
+    }
+
+    /// <summary>
+    /// Adds a rejection a specification says followed, named by the reason the source gives for it.
+    /// </summary>
+    /// <param name="invocation">The assertion to read.</param>
+    /// <param name="method">The method being called.</param>
+    /// <param name="semanticModel">The semantic model of the tree the assertion lives in.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    /// <param name="name">The name of the specification.</param>
+    /// <param name="location">Where the specification lives.</param>
+    void AddError(
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method,
+        SemanticModel semanticModel,
+        SpecificationDraft draft,
+        string name,
+        string location)
+    {
+        var reason = SpecificationAssertions.IsNamedRejection(method)
+            ? ReasonOf(invocation, semanticModel, name, location)
+            : string.Empty;
+
+        if (!draft.Errors.Contains(reason, StringComparer.Ordinal))
+        {
+            draft.Errors.Add(reason);
+        }
+    }
+
+    /// <summary>
+    /// Gets the reason an assertion names for a rejection.
+    /// </summary>
+    /// <param name="invocation">The assertion to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the assertion lives in.</param>
+    /// <param name="name">The name of the specification.</param>
+    /// <param name="location">Where the specification lives.</param>
+    /// <returns>The reason, empty when the source names one this cannot read.</returns>
+    string ReasonOf(InvocationExpressionSyntax invocation, SemanticModel semanticModel, string name, string location)
+    {
+        var named = invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression;
+        if (named is not null && semanticModel.GetConstantValue(named) is { HasValue: true, Value: { } value })
+        {
+            return value.ToString() ?? string.Empty;
+        }
+
+        diagnostics.Information(
+            ScreenplayDiagnosticCodes.UnreadableSpecificationValue,
+            $"The reason '{name}' gives for a rejection is code rather than a constant, so the rejection is stated without one",
+            location);
+
+        return string.Empty;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationPlacement.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationPlacement.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Decides which slice a specification belongs to and what it is called there.
+/// </summary>
+/// <param name="slices">The namespaces a slice was recovered from.</param>
+/// <remarks>
+/// A specification sits in a folder beneath the slice it is about, which is a namespace beneath the slice's own. The
+/// slice it belongs to is therefore the nearest namespace above it that declares one - nearest rather than any,
+/// because a slice within a slice is exactly what a feature holding both a behavior and the behaviors beneath it
+/// looks like.
+/// <para>
+/// The name is every word between the slice and the specification, in the order the source wrote them. That is what
+/// the convention was built to read as - a folder saying when something happens and a file saying what else was true
+/// at the time - so keeping all of it is what makes the specification say in the document what it says in the source.
+/// </para>
+/// </remarks>
+public class SpecificationPlacement(IEnumerable<string> slices)
+{
+    /// <summary>The namespace segment holding the world several specifications share.</summary>
+    public const string SharedContextSegment = "given";
+
+    readonly HashSet<string> _slices = [.. slices];
+
+    /// <summary>
+    /// Gets the name a specification is declared under.
+    /// </summary>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <param name="slice">The namespace of the slice it belongs to.</param>
+    /// <returns>The name, as the words the source wrote joined together.</returns>
+    public static string NameOf(INamedTypeSymbol type, string slice)
+    {
+        var below = Segments(type)[SegmentsIn(slice)..];
+
+        return string.Join(
+            '_',
+            below.Where(_ => !string.Equals(_, SharedContextSegment, StringComparison.Ordinal)).Append(type.Name));
+    }
+
+    /// <summary>
+    /// Gets the namespace of the slice a specification belongs to.
+    /// </summary>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <returns>The namespace, or <see langword="null"/> when no slice above it declares anything.</returns>
+    public string? SliceOf(INamedTypeSymbol type)
+    {
+        var segments = Segments(type);
+
+        for (var depth = segments.Length - 1; depth > 0; depth--)
+        {
+            var candidate = string.Join('.', segments[..depth]);
+            if (_slices.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the segments of the namespace a type lives in, with the type left out.
+    /// </summary>
+    /// <param name="type">The type to read.</param>
+    /// <returns>The segments.</returns>
+    static string[] Segments(INamedTypeSymbol type) => type.Namespace().Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+    /// <summary>
+    /// Counts the segments of a namespace.
+    /// </summary>
+    /// <param name="namespace">The namespace to count.</param>
+    /// <returns>The number of segments.</returns>
+    static int SegmentsIn(string @namespace) => @namespace.Split('.', StringSplitOptions.RemoveEmptyEntries).Length;
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Reads the scenario one type specifies a slice by.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unreadable is reported to.</param>
+/// <remarks>
+/// Only a specification driving a command through the real pipeline is read. A unit level one stands a collaborator
+/// up behind a substitute and says what that collaborator was asked to do, which is a statement about the inside of
+/// the slice rather than about its behavior, and Screenplay has nowhere to put it. Whether a specification is one or
+/// the other is decided by what it touches: holding a scenario the pipeline runs in, or reaching the event log, is
+/// what an integration specification does and nothing else does.
+/// </remarks>
+public class SpecificationReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Determines whether a type specifies a slice by driving a command through the pipeline.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a specification of the kind this reads.</returns>
+    public bool IsSpecification(INamedTypeSymbol type)
+    {
+        if (type is not { TypeKind: TypeKind.Class, IsAbstract: false, ContainingType: null })
+        {
+            return false;
+        }
+
+        var steps = SpecificationMembers.StepsOf(type);
+
+        return SpecificationMembers.MethodsIn(steps, SpecificationMembers.BecauseMethod).Any() &&
+            (SpecificationMembers.HoldsAScenario(steps) || DrivesASlice(steps));
+    }
+
+    /// <summary>
+    /// Reads the scenario a type specifies a slice by.
+    /// </summary>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <param name="name">The name the specification is declared under.</param>
+    /// <returns>The <see cref="SpecificationModel"/>, or <see langword="null"/> when the scenario cannot be read.</returns>
+    /// <remarks>
+    /// What was left out of a scenario is held back until the scenario is known to survive. Saying that a value was
+    /// left out of a scenario that was itself left out describes a document that says something it does not say, and
+    /// there are far more values than scenarios - so the noise would be the loudest thing in the report.
+    /// </remarks>
+    public SpecificationModel? Read(INamedTypeSymbol type, string name)
+    {
+        var location = type.ToDisplayString();
+        var steps = SpecificationMembers.StepsOf(type);
+        var draft = new SpecificationDraft();
+        var stated = new ScreenplayDiagnostics();
+
+        var reader = new SpecificationStepReader(compilation, new(stated));
+        reader.ReadGiven(steps, draft, name, location);
+        reader.ReadWhen(steps, draft, name, location);
+        new SpecificationOutcomeReader(compilation, stated).Read(type, draft, name, location);
+
+        if (draft.When is null)
+        {
+            draft.CannotRead("the command it issues is put together somewhere this cannot read");
+        }
+        else if (draft.Then.Count == 0 && draft.Errors.Count == 0)
+        {
+            draft.CannotRead("it expects no event and no rejection, and those are the outcomes the language holds");
+        }
+
+        if (draft.Unreadable is not null)
+        {
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnreadableSpecification,
+                $"The scenario '{name}' was left out because {draft.Unreadable}",
+                location);
+
+            return null;
+        }
+
+        diagnostics.AddRange(stated.All);
+
+        return new(name, [.. draft.Given], draft.When, [.. draft.Then], [.. draft.Errors]);
+    }
+
+    /// <summary>
+    /// Determines whether the steps of a specification drive a slice rather than exercise a part of one.
+    /// </summary>
+    /// <param name="steps">The type the steps are written on.</param>
+    /// <returns>True when the specification issues a command, or says what the event store already held.</returns>
+    /// <remarks>
+    /// A specification against a running host holds no scenario of its own - the host is the scenario - so what makes
+    /// it one is that it hands a command to the host, or says what the event log already held before doing so.
+    /// <para>
+    /// Where the two are looked for differs, and deliberately. Issuing a command is what a slice does, wherever it is
+    /// written. Appending to a sequence is only the world a scenario starts in when it happens before the action, and
+    /// a specification appending as its action is one about the event store itself - a constraint holding, an append
+    /// being rejected - which is a part of a slice rather than the behavior of one.
+    /// </para>
+    /// </remarks>
+    bool DrivesASlice(INamedTypeSymbol steps) =>
+        Calls(steps, SpecificationMembers.EstablishMethod)
+            .Any(_ => SpecificationCalls.IsGivenEvents(_) || SpecificationCalls.IsGivenReadModel(_) || SpecificationCalls.IsExecution(_)) ||
+        Calls(steps, SpecificationMembers.BecauseMethod).Any(SpecificationCalls.IsExecution);
+
+    /// <summary>
+    /// Gets every call a method of a chain resolves to.
+    /// </summary>
+    /// <param name="steps">The type the steps are written on.</param>
+    /// <param name="method">The name of the method to read.</param>
+    /// <returns>The methods called.</returns>
+    IEnumerable<IMethodSymbol> Calls(INamedTypeSymbol steps, string method) =>
+        SpecificationMembers.MethodsIn(steps, method).SelectMany(HandlerBodies.Of).SelectMany(CallsIn);
+
+    /// <summary>
+    /// Gets every call a body resolves to.
+    /// </summary>
+    /// <param name="body">The body to walk.</param>
+    /// <returns>The methods called.</returns>
+    IEnumerable<IMethodSymbol> CallsIn(SyntaxNode body)
+    {
+        var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
+
+        return body.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .Select(invocation => semanticModel.GetSymbolInfo(invocation).Symbol)
+            .OfType<IMethodSymbol>();
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Analysis.Events;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Reads what a specification starts from and the command it issues, from the bodies stating them.
+/// </summary>
+/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="values">The <see cref="SpecificationValues"/> reading the values each step states.</param>
+public class SpecificationStepReader(Compilation compilation, SpecificationValues values)
+{
+    /// <summary>
+    /// Reads what a specification had already seen when it issued its command.
+    /// </summary>
+    /// <param name="steps">The type the steps are written on.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    /// <param name="name">The name of the specification.</param>
+    /// <param name="location">Where the specification lives, for use in diagnostics.</param>
+    public void ReadGiven(INamedTypeSymbol steps, SpecificationDraft draft, string name, string location)
+    {
+        foreach (var (invocation, method, semanticModel, always) in CallsIn(steps, SpecificationMembers.EstablishMethod))
+        {
+            if (!SpecificationCalls.IsGivenEvents(method) && !SpecificationCalls.IsGivenReadModel(method))
+            {
+                continue;
+            }
+
+            if (!always)
+            {
+                draft.CannotRead("what it starts from only happens under a condition, and a scenario says what happened");
+                return;
+            }
+
+            var kind = SpecificationCalls.IsGivenReadModel(method) ? SpecificationStateKind.ReadModel : SpecificationStateKind.Event;
+
+            foreach (var stated in CallArguments.For(invocation, method, SpecificationCalls.PayloadParameterOf(method) ?? string.Empty))
+            {
+                Add(draft.Given, stated, kind, semanticModel, draft, name, location);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the command a specification issues.
+    /// </summary>
+    /// <param name="steps">The type the steps are written on.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    /// <param name="name">The name of the specification.</param>
+    /// <param name="location">Where the specification lives, for use in diagnostics.</param>
+    public void ReadWhen(INamedTypeSymbol steps, SpecificationDraft draft, string name, string location)
+    {
+        foreach (var (invocation, method, semanticModel, always) in CallsIn(steps, SpecificationMembers.BecauseMethod))
+        {
+            if (!SpecificationCalls.IsExecution(method))
+            {
+                continue;
+            }
+
+            if (!always)
+            {
+                draft.CannotRead("the command it issues is only issued under a condition, and a scenario says what happened");
+                return;
+            }
+
+            if (draft.When is not null)
+            {
+                draft.CannotRead("it issues more than one command, and a scenario is about one");
+                return;
+            }
+
+            var stated = CallArguments.For(invocation, method, SpecificationCalls.PayloadParameterOf(method) ?? string.Empty).ToList();
+            if (stated is not [BaseObjectCreationExpressionSyntax creation] ||
+                semanticModel.GetTypeInfo(creation).Type is not INamedTypeSymbol command)
+            {
+                draft.CannotRead("the command it issues is put together somewhere this cannot read");
+                return;
+            }
+
+            if (!CommandReader.IsCommand(command))
+            {
+                draft.CannotRead($"'{command.Name}' is not a command the document declares");
+                return;
+            }
+
+            draft.When = new(command.Name, SpecificationStateKind.Command, values.Read(creation, semanticModel, command, name, location));
+        }
+    }
+
+    /// <summary>
+    /// Gets every call a body makes that resolves to a method.
+    /// </summary>
+    /// <param name="body">The body to walk.</param>
+    /// <param name="semanticModel">The semantic model of the tree the body lives in.</param>
+    /// <returns>The calls, in the order the body makes them.</returns>
+    static IEnumerable<Step> Calls(SyntaxNode body, SemanticModel semanticModel) =>
+        body.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .Select(invocation => (invocation, Method: semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol, semanticModel, body))
+            .Where(call => call.Method is not null)
+            .Select(call => new Step(call.invocation, call.Method!, call.semanticModel, StepsTaken.Always(call.invocation, call.body)));
+
+    /// <summary>
+    /// Gets every call a method of a chain makes, with the model the tree it lives in is read through.
+    /// </summary>
+    /// <param name="type">The type to walk from.</param>
+    /// <param name="method">The name of the method to read.</param>
+    /// <returns>The calls, from the base down and in the order each body makes them.</returns>
+    IEnumerable<Step> CallsIn(INamedTypeSymbol type, string method) =>
+        SpecificationMembers.MethodsIn(type, method)
+            .SelectMany(HandlerBodies.Of)
+            .SelectMany(body => Calls(body, compilation.GetSemanticModel(body.SyntaxTree)));
+
+    /// <summary>
+    /// Adds one state a specification starts from, or records that it cannot be read.
+    /// </summary>
+    /// <param name="states">The states collected so far.</param>
+    /// <param name="stated">The expression stating it.</param>
+    /// <param name="kind">What the state is.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    /// <param name="name">The name of the specification.</param>
+    /// <param name="location">Where the specification lives.</param>
+    void Add(
+        IList<SpecificationStateModel> states,
+        ExpressionSyntax stated,
+        SpecificationStateKind kind,
+        SemanticModel semanticModel,
+        SpecificationDraft draft,
+        string name,
+        string location)
+    {
+        if (stated is not BaseObjectCreationExpressionSyntax creation ||
+            semanticModel.GetTypeInfo(creation).Type is not INamedTypeSymbol type)
+        {
+            draft.CannotRead("what it starts from is put together somewhere this cannot read");
+            return;
+        }
+
+        if (kind == SpecificationStateKind.Event && !EventReader.IsEvent(type))
+        {
+            draft.CannotRead($"it starts from '{type.Name}', which is not declared as an event");
+            return;
+        }
+
+        states.Add(new(type.Name, kind, values.Read(creation, semanticModel, type, name, location)));
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationValues.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationValues.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Reads the values a specification states for one artifact, from the construction stating them.
+/// </summary>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unreadable is reported to.</param>
+/// <remarks>
+/// A specification is closed - it refers to nothing outside itself - so a constant is the only source of a value
+/// there is. That is the same discipline a produces mapping is read with, one source shorter: a produces mapping may
+/// also name the input of the command being handled, and a scenario has no input to name.
+/// </remarks>
+public class SpecificationValues(ScreenplayDiagnostics diagnostics)
+{
+    readonly MappingSourceReader _sources = new(diagnostics);
+
+    /// <summary>
+    /// Reads the values one construction states.
+    /// </summary>
+    /// <param name="creation">The construction to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the construction lives in.</param>
+    /// <param name="type">The type being constructed.</param>
+    /// <param name="specification">The name of the specification, for use in diagnostics.</param>
+    /// <param name="location">Where the specification lives, for use in diagnostics.</param>
+    /// <returns>The values, in the order the source declares them.</returns>
+    public IEnumerable<PropertyMappingModel> Read(
+        BaseObjectCreationExpressionSyntax creation,
+        SemanticModel semanticModel,
+        ITypeSymbol type,
+        string specification,
+        string location)
+    {
+        var values = new List<PropertyMappingModel>();
+        var constructor = semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol;
+
+        foreach (var (name, expression) in Stated(creation, constructor))
+        {
+            Add(values, PropertyOf(type, name), expression, semanticModel, type, specification, location);
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Gets every value a construction states, from its arguments and from its initializer.
+    /// </summary>
+    /// <param name="creation">The construction to read.</param>
+    /// <param name="constructor">The constructor being called.</param>
+    /// <returns>The values, each with the name it fills in, in the order the source declares them.</returns>
+    static IEnumerable<(string Name, ExpressionSyntax Expression)> Stated(
+        BaseObjectCreationExpressionSyntax creation,
+        IMethodSymbol? constructor)
+    {
+        var arguments = creation.ArgumentList?.Arguments ?? [];
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            if (NameOf(arguments[index], constructor, index) is { } name)
+            {
+                yield return (name, arguments[index].Expression);
+            }
+        }
+
+        foreach (var assignment in creation.Initializer?.Expressions.OfType<AssignmentExpressionSyntax>() ?? [])
+        {
+            if (assignment.Left is IdentifierNameSyntax identifier)
+            {
+                yield return (identifier.Identifier.ValueText, assignment.Right);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the name of the property an argument fills in.
+    /// </summary>
+    /// <param name="argument">The argument to name.</param>
+    /// <param name="constructor">The constructor being called.</param>
+    /// <param name="index">The position of the argument.</param>
+    /// <returns>The parameter name, or <see langword="null"/> when it cannot be resolved.</returns>
+    static string? NameOf(ArgumentSyntax argument, IMethodSymbol? constructor, int index)
+    {
+        if (argument.NameColon is { } named)
+        {
+            return named.Name.Identifier.ValueText;
+        }
+
+        return constructor is not null && index < constructor.Parameters.Length ? constructor.Parameters[index].Name : null;
+    }
+
+    /// <summary>
+    /// Resolves the declared casing of a property from the name an argument used.
+    /// </summary>
+    /// <param name="type">The type being constructed.</param>
+    /// <param name="name">The name to resolve.</param>
+    /// <returns>The property name.</returns>
+    static string PropertyOf(ITypeSymbol type, string name) =>
+        type.DeclaredProperties().FirstOrDefault(_ => string.Equals(_.Name, name, StringComparison.OrdinalIgnoreCase))?.Name ?? name;
+
+    /// <summary>
+    /// Adds a value, reporting one that is code rather than stating it as something it is not.
+    /// </summary>
+    /// <param name="values">The values collected so far.</param>
+    /// <param name="property">The property being filled in.</param>
+    /// <param name="expression">The expression filling it in.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="type">The type being constructed.</param>
+    /// <param name="specification">The name of the specification.</param>
+    /// <param name="location">Where the specification lives.</param>
+    void Add(
+        List<PropertyMappingModel> values,
+        string property,
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol type,
+        string specification,
+        string location)
+    {
+        if (_sources.Read(expression, semanticModel, type, location) is LiteralSource literal)
+        {
+            values.Add(new(property, literal));
+            return;
+        }
+
+        diagnostics.Information(
+            ScreenplayDiagnosticCodes.UnreadableSpecificationValue,
+            $"The value '{specification}' states for '{type.Name}.{property}' is code rather than a constant, so the scenario states everything but that value",
+            location);
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/Step.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/Step.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Represents one call a specification makes, with everything needed to read what it says.
+/// </summary>
+/// <param name="Invocation">The call as it is written.</param>
+/// <param name="Method">The method it resolves to.</param>
+/// <param name="SemanticModel">The semantic model of the tree it lives in.</param>
+/// <param name="Always">Whether the body it is written in always makes the call, exactly once.</param>
+public record Step(
+    InvocationExpressionSyntax Invocation,
+    IMethodSymbol Method,
+    SemanticModel SemanticModel,
+    bool Always);

--- a/Source/DotNET/Screenplay/Analysis/Specifications/StepsTaken.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/StepsTaken.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Answers whether a step written in a body is one the body always takes.
+/// </summary>
+/// <remarks>
+/// A scenario says what happened, once, in order. A step written inside a branch happened in some runs of the
+/// specification and not in others, and one written inside a loop happened as many times as the loop went round -
+/// neither of which the source text says. Reading such a step as if it always happened states a world the
+/// application was never specified against, which is worse than saying nothing: it is the one failure mode a reader
+/// has no way of catching.
+/// <para>
+/// Which condition a branch stood on is routinely knowable to the compiler - a virtual property a derived
+/// specification overrides with a constant is the usual shape - but knowing it means following values through
+/// dispatch rather than reading what was written, which is a different discipline from the one everything else here
+/// keeps to. So a conditional step is left unread and said so, and a scenario that has one is left out whole.
+/// </para>
+/// </remarks>
+public static class StepsTaken
+{
+    /// <summary>
+    /// Determines whether a body always takes a step, exactly once.
+    /// </summary>
+    /// <param name="call">The call the step is written as.</param>
+    /// <param name="body">The body the step is written in.</param>
+    /// <returns>True when nothing between the two makes the step conditional or repeated.</returns>
+    public static bool Always(SyntaxNode call, SyntaxNode body)
+    {
+        for (var current = call.Parent; current is not null && current != body; current = current.Parent)
+        {
+            if (IsConditional(current))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether a construct makes what is written inside it conditional, repeated or deferred.
+    /// </summary>
+    /// <param name="node">The construct to check.</param>
+    /// <returns>True when it does.</returns>
+    static bool IsConditional(SyntaxNode node) => node switch
+    {
+        IfStatementSyntax or SwitchStatementSyntax or SwitchExpressionSyntax => true,
+        ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax => true,
+        ConditionalExpressionSyntax or ConditionalAccessExpressionSyntax => true,
+        CatchClauseSyntax or FinallyClauseSyntax => true,
+        AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax => true,
+        BinaryExpressionSyntax binary => binary.IsKind(SyntaxKind.LogicalAndExpression) ||
+            binary.IsKind(SyntaxKind.LogicalOrExpression) ||
+            binary.IsKind(SyntaxKind.CoalesceExpression),
+        _ => false
+    };
+}

--- a/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
@@ -123,6 +123,21 @@ public static class WellKnownTypeNames
     /// <summary>The everything a query is performed with, which the host fills in.</summary>
     public const string QueryContext = "Cratis.Arc.Queries.QueryContext";
 
+    /// <summary>The sequence a specification appends the events it starts from to.</summary>
+    public const string EventSequence = "Cratis.Chronicle.EventSequences.IEventSequence";
+
+    /// <summary>The scenario a specification issues a command through in process.</summary>
+    public const string CommandScenario = "Cratis.Arc.Testing.Commands.CommandScenario`1";
+
+    /// <summary>The builder a specification states the state of one event source with.</summary>
+    public const string CommandScenarioSourceGivenBuilder = "Cratis.Arc.Chronicle.Testing.Commands.CommandScenarioSourceGivenBuilder`1";
+
+    /// <summary>The extensions a specification issues a command through over HTTP.</summary>
+    public const string HttpClientExtensions = "Cratis.Chronicle.XUnit.Integration.HttpClientExtensions";
+
+    /// <summary>The attribute marking a method as one assertion of a specification.</summary>
+    public const string FactAttribute = "Xunit.FactAttribute";
+
     /// <summary>The page of a result a query is performed for, which the host fills in from the request.</summary>
     public const string Paging = "Cratis.Arc.Queries.Paging";
 

--- a/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
@@ -12,6 +12,7 @@ using Cratis.Arc.Screenplay.Emission.Queries;
 using Cratis.Arc.Screenplay.Emission.Reactors;
 using Cratis.Arc.Screenplay.Emission.Screens;
 using Cratis.Arc.Screenplay.Emission.Slices;
+using Cratis.Arc.Screenplay.Emission.Specifications;
 using Cratis.Arc.Screenplay.Emission.Types;
 using Cratis.Arc.Screenplay.Emission.Validation;
 using Cratis.Arc.Screenplay.Model;
@@ -145,7 +146,8 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
             new ConstraintSyntaxBuilder(naming),
             new ReactorSyntaxBuilder(naming, diagnostics),
             new ProjectionSyntaxBuilder(naming, diagnostics, _names),
-            new ScreenSyntaxBuilder(naming, _types));
+            new ScreenSyntaxBuilder(naming, _types),
+            new SpecificationSyntaxBuilder(naming));
 
     /// <summary>
     /// Sanitizes a document level name, falling back when it yields nothing usable.

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
@@ -9,6 +9,7 @@ using Cratis.Arc.Screenplay.Emission.Projections;
 using Cratis.Arc.Screenplay.Emission.Queries;
 using Cratis.Arc.Screenplay.Emission.Reactors;
 using Cratis.Arc.Screenplay.Emission.Screens;
+using Cratis.Arc.Screenplay.Emission.Specifications;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Diagnostics;
 using Cratis.Screenplay.Syntax;
@@ -27,6 +28,7 @@ namespace Cratis.Arc.Screenplay.Emission.Slices;
 /// <param name="reactors">The <see cref="ReactorSyntaxBuilder"/> for the reactors of the slice.</param>
 /// <param name="projections">The <see cref="ProjectionSyntaxBuilder"/> for the projection of the slice.</param>
 /// <param name="screens">The <see cref="ScreenSyntaxBuilder"/> for the screens of the slice.</param>
+/// <param name="specifications">The <see cref="SpecificationSyntaxBuilder"/> for the scenarios the slice is specified by.</param>
 public class SliceSyntaxBuilder(
     IScreenplayNaming naming,
     CommandSyntaxBuilder commands,
@@ -35,7 +37,8 @@ public class SliceSyntaxBuilder(
     ConstraintSyntaxBuilder constraints,
     ReactorSyntaxBuilder reactors,
     ProjectionSyntaxBuilder projections,
-    ScreenSyntaxBuilder screens)
+    ScreenSyntaxBuilder screens,
+    SpecificationSyntaxBuilder specifications)
 {
     /// <summary>
     /// The name given to a slice whose own name yields nothing usable.
@@ -73,7 +76,7 @@ public class SliceSyntaxBuilder(
                     .Select(_ => constraints.Build(_, slice.Namespace))
                     .OrderBy(_ => _.Name, StringComparer.Ordinal)
             ],
-            [],
+            [.. specifications.Build(slice.Specifications)],
             SourceLocation.Start,
             naming.ToStringLiteral(slice.Description));
 

--- a/Source/DotNET/Screenplay/Emission/Specifications/SpecificationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Specifications/SpecificationSyntaxBuilder.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Expressions;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+using Cratis.Screenplay.Syntax.Specifications;
+
+namespace Cratis.Arc.Screenplay.Emission.Specifications;
+
+/// <summary>
+/// Builds the Screenplay <c>specification</c> blocks of a slice.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <remarks>
+/// Nothing a step states is ever left out over its name. Every other block decides what a line is from its first
+/// word, so a property called after a directive collides with it; the values of a step are written one level deeper
+/// than the step itself and the step takes every line beneath it as a value, whatever its first word says.
+/// </remarks>
+public class SpecificationSyntaxBuilder(IScreenplayNaming naming)
+{
+    readonly MappingSourceConverter _sources = new(naming);
+
+    /// <summary>
+    /// Builds the specifications of a slice.
+    /// </summary>
+    /// <param name="specifications">The scenarios the slice is specified by.</param>
+    /// <returns>The specifications, ordered by name.</returns>
+    public IEnumerable<SpecificationSyntax> Build(IEnumerable<SpecificationModel> specifications) =>
+    [
+        .. specifications
+            .Select(Build)
+            .OrderBy(_ => _.Name, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Builds one specification.
+    /// </summary>
+    /// <param name="specification">The scenario to build for.</param>
+    /// <returns>The <see cref="SpecificationSyntax"/>.</returns>
+    SpecificationSyntax Build(SpecificationModel specification) =>
+        new(
+            naming.ToDeclarationName(specification.Name),
+            [.. Events(specification.Given)],
+            new SpecificationCommandSyntax(
+                naming.ToDeclarationName(specification.When.Name),
+                [.. Values(specification.When)],
+                SourceLocation.Start),
+            [.. Events(specification.Then)],
+            [.. specification.Errors.Select(_ => new SpecificationErrorSyntax(naming.ToStringLiteral(_) ?? string.Empty, SourceLocation.Start))],
+            SourceLocation.Start,
+            [.. ReadModels(specification.Given)],
+            [.. ReadModels(specification.Then)]);
+
+    /// <summary>
+    /// Builds the states of a step that name an event.
+    /// </summary>
+    /// <param name="states">The states to build from.</param>
+    /// <returns>The events.</returns>
+    IEnumerable<SpecificationEventSyntax> Events(IEnumerable<SpecificationStateModel> states) =>
+        states
+            .Where(_ => _.Kind == SpecificationStateKind.Event)
+            .Select(_ => new SpecificationEventSyntax(naming.ToDeclarationName(_.Name), [.. Values(_)], SourceLocation.Start));
+
+    /// <summary>
+    /// Builds the states of a step that name a read model.
+    /// </summary>
+    /// <param name="states">The states to build from.</param>
+    /// <returns>The read models.</returns>
+    IEnumerable<SpecificationReadModelSyntax> ReadModels(IEnumerable<SpecificationStateModel> states) =>
+        states
+            .Where(_ => _.Kind == SpecificationStateKind.ReadModel)
+            .Select(_ => new SpecificationReadModelSyntax(naming.ToDeclarationName(_.Name), [.. Values(_)], SourceLocation.Start));
+
+    /// <summary>
+    /// Builds the values a step states.
+    /// </summary>
+    /// <param name="state">The state to build from.</param>
+    /// <returns>The values.</returns>
+    IEnumerable<PropertyMappingSyntax> Values(SpecificationStateModel state) =>
+        state.Values.Select(_ => new PropertyMappingSyntax(naming.ToPropertyName(_.Property), _sources.Convert(_.Source), SourceLocation.Start));
+}

--- a/Source/DotNET/Screenplay/Model/SliceModel.cs
+++ b/Source/DotNET/Screenplay/Model/SliceModel.cs
@@ -38,6 +38,16 @@ public record SliceModel(
     public IEnumerable<ScreenModel> Screens { get; init; } = [];
 
     /// <summary>
+    /// Gets the scenarios the slice is specified by.
+    /// </summary>
+    /// <remarks>
+    /// A scenario is recovered from a namespace beneath the slice's own rather than from the slice's, so it arrives
+    /// once every namespace has been read and which of them declare a slice is known - which is after the slice
+    /// itself exists.
+    /// </remarks>
+    public IEnumerable<SpecificationModel> Specifications { get; init; } = [];
+
+    /// <summary>
     /// Creates a slice that declares nothing, for use as a starting point.
     /// </summary>
     /// <param name="namespace">The full namespace the slice lives in.</param>

--- a/Source/DotNET/Screenplay/Model/SpecificationModel.cs
+++ b/Source/DotNET/Screenplay/Model/SpecificationModel.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents one scenario a slice is specified by - what had happened, the command that was issued and what
+/// followed.
+/// </summary>
+/// <param name="Name">The name of the specification.</param>
+/// <param name="Given">What had already happened when the command was issued.</param>
+/// <param name="When">The command that was issued.</param>
+/// <param name="Then">The events and read model states that followed.</param>
+/// <param name="Errors">The rejections that followed, each named by the reason the source gives for it.</param>
+/// <remarks>
+/// A rejection the source names no reason for carries an empty one. The scenario is named after the words the
+/// source itself uses for it, so what the rejection was about is already said by the name and inventing a sentence
+/// to repeat it would be describing an application nobody wrote.
+/// </remarks>
+public record SpecificationModel(
+    string Name,
+    IEnumerable<SpecificationStateModel> Given,
+    SpecificationStateModel When,
+    IEnumerable<SpecificationStateModel> Then,
+    IEnumerable<string> Errors);

--- a/Source/DotNET/Screenplay/Model/SpecificationStateKind.cs
+++ b/Source/DotNET/Screenplay/Model/SpecificationStateKind.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents what a state a specification names actually is.
+/// </summary>
+public enum SpecificationStateKind
+{
+    /// <summary>
+    /// An event, which is what a <c>given</c> and a <c>then</c> name by default.
+    /// </summary>
+    Event = 0,
+
+    /// <summary>
+    /// A read model, which a <c>given</c> and a <c>then</c> name behind the <c>readmodel</c> keyword.
+    /// </summary>
+    ReadModel = 1,
+
+    /// <summary>
+    /// A command, which is what the single <c>when</c> of a specification names.
+    /// </summary>
+    Command = 2
+}

--- a/Source/DotNET/Screenplay/Model/SpecificationStateModel.cs
+++ b/Source/DotNET/Screenplay/Model/SpecificationStateModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents one artifact a specification names, together with the values it states for it.
+/// </summary>
+/// <param name="Name">The name of the event, read model or command being named.</param>
+/// <param name="Kind">What the named artifact is.</param>
+/// <param name="Values">The values the specification states, in the order the source declares them.</param>
+/// <remarks>
+/// A <c>given</c>, a <c>when</c> and a <c>then</c> are the same shape - a name and a list of values - so one model
+/// covers all three and the step it belongs to says which of them it is.
+/// </remarks>
+public record SpecificationStateModel(string Name, SpecificationStateKind Kind, IEnumerable<PropertyMappingModel> Values);

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -285,4 +285,30 @@ public static class ScreenplayDiagnosticCodes
     /// the binding the document is missing, and what turns it into one the moment a reference can carry the slice.
     /// </remarks>
     public const string CrossSliceQueryBinding = "SP0036";
+
+    /// <summary>
+    /// A scenario a slice is specified by states a step that could not be read, so the whole scenario was left out.
+    /// </summary>
+    /// <remarks>
+    /// A specification is one concrete example, and an example missing the command it issues, the state it started
+    /// from or the outcome it expects is not that example - it is a different one nobody wrote. So unlike a mapping,
+    /// which stands on its own and can be left out while the rest of the block still says something true, a step that
+    /// cannot be read takes the scenario with it. What made it unreadable is said, because the difference between a
+    /// scenario resting on a value computed at run time and one resting on a helper the reader could inline is the
+    /// difference between a gap that will always be there and one an afternoon closes.
+    /// </remarks>
+    public const string UnreadableSpecification = "SP0037";
+
+    /// <summary>
+    /// A value a scenario states is code rather than a constant, so the scenario states everything but that value.
+    /// </summary>
+    /// <remarks>
+    /// A scenario is written in the host language, where the identity two steps agree on is routinely a fresh
+    /// identifier held in a field rather than something written down twice. Screenplay states values and has no way
+    /// to name one, so such a value is left out and the rest of the scenario stands: which events had happened, which
+    /// command was issued and what followed are all still exactly what the source says. This is reported per value
+    /// rather than per scenario for the same reason a produces mapping is - a reader counting what a scenario states
+    /// against what the source states otherwise has no way of knowing which of the two it is looking at.
+    /// </remarks>
+    public const string UnreadableSpecificationValue = "SP0038";
 }


### PR DESCRIPTION
## Added

- The integration specifications a slice carries are recovered into `specification` blocks, so a document states what the application is specified to do rather than only what it declares; a scenario with a step that cannot be read statically is reported rather than guessed at (#2404)
