### PR TITLE
Read roles declared with the Roles constructor form

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authorization;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions;
+
+public class RoleSecuredTypes
+{
+    [Roles("Librarian")]
+    public void SingleRoleFromConstructor() { }
+
+    [Roles("Librarian", "Admin")]
+    public void MultipleRolesFromConstructor() { }
+
+    [Authorize(Roles = "Librarian")]
+    public void RoleFromNamedArgument() { }
+
+    [Roles("Librarian")]
+    [Authorize(Roles = "Librarian")]
+    public void RoleFromBothForms() { }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
@@ -2,10 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Authorization;
-using Microsoft.AspNetCore.Authorization;
 
 namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions;
 
+/// <summary>
+/// Holds the shapes roles can be declared in, for reading them back.
+/// </summary>
+/// <remarks>
+/// Both <c>Cratis.Arc.Authorization</c> and <c>Microsoft.AspNetCore.Authorization</c> declare an
+/// <c>Authorize</c> attribute, so the ASP.NET Core one is written out in full where the named-argument form is needed.
+/// </remarks>
 public class RoleSecuredTypes
 {
     [Roles("Librarian")]
@@ -14,10 +20,10 @@ public class RoleSecuredTypes
     [Roles("Librarian", "Admin")]
     public void MultipleRolesFromConstructor() { }
 
-    [Authorize(Roles = "Librarian")]
+    [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Librarian")]
     public void RoleFromNamedArgument() { }
 
     [Roles("Librarian")]
-    [Authorize(Roles = "Librarian")]
+    [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Librarian")]
     public void RoleFromBothForms() { }
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_both_forms_combined.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_both_forms_combined.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_both_forms_combined : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.RoleFromBothForms));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_deduplicate_the_roles() => _result.ShouldContainOnly(["Librarian"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_multiple_roles.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_multiple_roles.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_constructor_form_with_multiple_roles : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.MultipleRolesFromConstructor));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_yield_all_roles() => _result.ShouldContainOnly(["Librarian", "Admin"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_single_role.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_single_role.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_constructor_form_with_single_role : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.SingleRoleFromConstructor));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_yield_the_role() => _result.ShouldContainOnly(["Librarian"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_named_argument_form.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_named_argument_form.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_named_argument_form : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.RoleFromNamedArgument));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_yield_the_role() => _result.ShouldContainOnly(["Librarian"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
@@ -105,12 +105,23 @@ public static class MethodInfoExtensions
                 continue;
             }
 
+            // Named-argument form, e.g. [Authorize(Roles = "Librarian")].
             var rolesArg = attr.NamedArguments.FirstOrDefault(a => a.MemberName == "Roles");
             if (rolesArg != default && rolesArg.TypedValue.Value is string rolesStr && !string.IsNullOrEmpty(rolesStr))
             {
                 foreach (var role in rolesStr.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                 {
                     yield return role;
+                }
+            }
+
+            // Constructor form, e.g. [Roles("Librarian", "Admin")] where the attribute takes a params string[].
+            if (attr.ConstructorArguments.Count > 0 &&
+                attr.ConstructorArguments[0].Value is IReadOnlyCollection<CustomAttributeTypedArgument> roleArgs)
+            {
+                foreach (var role in roleArgs.Select(a => a.Value as string).Where(r => !string.IsNullOrEmpty(r)))
+                {
+                    yield return role!;
                 }
             }
         }


### PR DESCRIPTION
## Fixed

- Roles declared with the `[Roles("...")]` constructor form are read by the proxy generator, not only the named-argument form (#2381)
