### PR TITLE
Align tenancy docs with the actual default tenant header

### DIFF
--- a/Documentation/backend/asp-net-core/configuration.md
+++ b/Documentation/backend/asp-net-core/configuration.md
@@ -126,7 +126,7 @@ builder.AddCratisArc(options =>
     options.CorrelationId.HttpHeader = "X-My-Correlation-ID";
 
     // Configure tenancy
-    options.Tenancy.HttpHeader = "X-Tenant-ID";
+    options.Tenancy.HttpHeader = "X-Custom-Tenant";
 
     // Configure generated APIs
     options.GeneratedApis.RoutePrefix = "myapi";

--- a/Documentation/backend/core/getting-started.md
+++ b/Documentation/backend/core/getting-started.md
@@ -195,7 +195,7 @@ Arc.Core supports standard .NET configuration:
         "HttpHeader": "X-Correlation-ID"
       },
       "Tenancy": {
-        "HttpHeader": "X-Tenant-ID"
+        "HttpHeader": "X-Custom-Tenant"
       }
     }
   },

--- a/Documentation/backend/tenancy/configuration.md
+++ b/Documentation/backend/tenancy/configuration.md
@@ -23,7 +23,7 @@ builder.AddCratisArcCore(options =>
     "Arc": {
       "Tenancy": {
         "ResolverType": "Header",
-        "HttpHeader": "X-Tenant-ID"
+        "HttpHeader": "X-Custom-Tenant"
       }
     }
   }

--- a/Documentation/backend/tenancy/resolvers.md
+++ b/Documentation/backend/tenancy/resolvers.md
@@ -11,7 +11,7 @@ Resolves the tenant ID from an HTTP header.
 ```csharp
 builder.AddCratisArcCore(options =>
 {
-    options.UseHeaderTenancy("X-Tenant-ID");
+    options.UseHeaderTenancy("X-Custom-Tenant");
 });
 ```
 
@@ -50,11 +50,11 @@ Resolves the tenant ID from the first segment of the request hostname. When the 
 ```csharp
 builder.AddCratisArcCore(options =>
 {
-    options.UseSubdomainTenancy("X-Tenant-ID");
+    options.UseSubdomainTenancy("X-Custom-Tenant");
 });
 ```
 
-A request to `acme.myapp.com` resolves the tenant as `acme`. A request to `myapp.com` falls back to the `X-Tenant-ID` header. This pattern is useful for SaaS applications where each tenant is routed through its own subdomain.
+A request to `acme.myapp.com` resolves the tenant as `acme`. A request to `myapp.com` falls back to the `X-Custom-Tenant` header. This pattern is useful for SaaS applications where each tenant is routed through its own subdomain.
 
 Default fallback header: `x-cratis-tenant-id`
 


### PR DESCRIPTION
## Fixed

- Tenancy documentation no longer presents `X-Tenant-ID` as the tenant header; the header-override samples now use a clearly-custom placeholder so they no longer contradict the actual default `x-cratis-tenant-id` (#2351)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1mrPcRT2GYjRxrx4T1p8N)_