### PR TITLE
Report what an application says about how it is served

### DIFF
--- a/Documentation/generating-a-screenplay.md
+++ b/Documentation/generating-a-screenplay.md
@@ -240,7 +240,7 @@ These are part of the language, but nothing in C# says them, so a generated docu
 
 ### Detail Screenplay cannot represent
 
-These exist in your application and do not reach the document — most of them because the language has no counterpart. Almost all are reported as a diagnostic when encountered, so the document tells you it is silent about them. The two rows naming no code are the exception: nothing is reported for those.
+These exist in your application and do not reach the document, because the language has no counterpart. Each is reported as a diagnostic when encountered, so the document tells you it is silent about them.
 
 | In Arc or Chronicle | Why it is not in the document |
 |---|---|
@@ -251,8 +251,8 @@ These exist in your application and do not reach the document — most of them b
 | Inline `policy` code and requirements built in code | `RequireAssertion(…)` and a policy registered from an `AuthorizationPolicy` built elsewhere are code. `RequireAuthenticatedUser`, `RequireRole`, and `RequireClaim` given the values it accepts are recovered; the rest is reported as `SP0026` — including a `RequireClaim` naming only a claim type, which a policy condition has no way to state. |
 | The event source id from a `(TKey, TEvent)` handler | The event is recovered; the identifier saying *which* event source it goes to has no counterpart. `SP0013`. |
 | Emptying a scope with `[ClearWith]`; removing a child with `[RemovedWith]` on the property holding it | Nothing in the model a projection is built from carries a scope being emptied again, so `[ClearWith]` has nowhere to go (`SP0015`). A removal does have somewhere — but it is read from the type of the child, alongside the events filling that child in, so the same removal written beside the collection is reported as `SP0007` instead. |
-| Read model tags | A read model has no declaration of its own — it appears as the type a query returns — so there is nowhere to hang a tag. Tags on *events* are recovered and written out. |
-| Query paging and sorting, custom routes | These say how a model is served rather than what it is. The parameters the host fills in are left out, and a route template has no counterpart. |
+| Read model tags | A read model has no declaration of its own — it appears as the type a query returns — so there is nowhere to hang a tag. Tags on *events* are recovered and written out. `SP0042`. |
+| Query paging and sorting, custom routes | These say how a model is served rather than what it is. The parameters the host fills in are left out, and a route template — `[Path]`, `[Route]`, or a template on an HTTP verb — has no counterpart. `SP0041`. |
 
 If a generated `.play` is missing something you expected, the diagnostics are the first place to look — the omission is almost always reported.
 

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_controller_served_at_a_route_of_its_own.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_controller_served_at_a_route_of_its_own.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A controller says where it answers twice over - once for the controller and once for each verb that carries a
+/// template. The document describes neither, and says so for each, so a reader can tell a route that was passed over
+/// from an application that leaves the convention alone.
+/// </summary>
+/// <remarks>
+/// The web framework is declared alongside the application rather than referenced, the same way the other controller
+/// specifications do it, because the recognizer matches on names rather than on the assembly they came from.
+/// </remarks>
+public class a_controller_served_at_a_route_of_its_own : Specification
+{
+    const string WebFramework = """
+        using System;
+
+        namespace Microsoft.AspNetCore.Mvc;
+
+        public abstract class ControllerBase;
+
+        [AttributeUsage(AttributeTargets.Class)]
+        public sealed class RouteAttribute(string template) : Attribute
+        {
+            public string Template { get; } = template;
+        }
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class HttpPostAttribute(string template = "") : Attribute
+        {
+            public string Template { get; } = template;
+        }
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class HttpGetAttribute(string template = "") : Attribute
+        {
+            public string Template { get; } = template;
+        }
+
+        [AttributeUsage(AttributeTargets.Parameter)]
+        public sealed class FromBodyAttribute : Attribute;
+        """;
+
+    const string Source = """
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Microsoft.AspNetCore.Mvc;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        public record RegisterAuthor(string Name);
+
+        public record Author(string Id, string Name);
+
+        [Route("catalog/authors")]
+        public class AuthorsController : ControllerBase
+        {
+            [HttpPost("register-author")]
+            public Task<AuthorRegistered> Register([FromBody] RegisterAuthor command) =>
+                Task.FromResult(new AuthorRegistered(command.Name));
+
+            [HttpGet]
+            public IEnumerable<Author> All() => [];
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(
+        ("Framework.cs", WebFramework),
+        ("Library/Authors/Registration/Registration.cs", Source));
+
+    [Fact] void should_still_recover_the_command() => _analysis.Slice().Commands.Single().Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_name_the_command_the_way_the_document_does() => _analysis.Diagnostics.Single(_ => _.Message.Contains("register-author'", StringComparison.Ordinal)).Message.ShouldContain("'RegisterAuthor'");
+    [Fact] void should_still_recover_the_query() => _analysis.Slice().Queries.Single().Name.ShouldEqual("All");
+    [Fact] void should_say_where_the_controller_answers() => _analysis.Diagnostics.Count(_ => _.Message.Contains("catalog/authors'", StringComparison.Ordinal)).ShouldEqual(1);
+    [Fact] void should_say_where_the_command_answers() => _analysis.Diagnostics.Count(_ => _.Message.Contains("register-author'", StringComparison.Ordinal)).ShouldEqual(1);
+    [Fact] void should_say_nothing_about_the_verb_that_leaves_the_convention_alone() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.ServingConcernWithoutCounterpart).ShouldEqual(2);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_served_at_a_route_of_its_own.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_served_at_a_route_of_its_own.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An application can serve a read model or a single query somewhere other than where the convention would put it.
+/// Where it answers is not something a Screenplay says, so the route is left out - but a route declared and never
+/// mentioned reads exactly like an application that declared none.
+/// </summary>
+public class a_query_served_at_a_route_of_its_own : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        [Path("/catalog/authors")]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            [Path("/catalog/authors/by-name")]
+            public static IEnumerable<Author> AuthorsByName(string name) => [];
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(("Library/Authors/Listing/Listing.cs", Source));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Listing/Listing.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_recover_the_query() => _analysis.Slice().Queries.Single().Name.ShouldEqual("AuthorsByName");
+    [Fact] void should_say_where_the_read_model_is_served() => _analysis.Diagnostics.Count(_ => _.Message.Contains("/catalog/authors'", StringComparison.Ordinal)).ShouldEqual(1);
+    [Fact] void should_say_where_the_query_is_served() => _analysis.Diagnostics.Count(_ => _.Message.Contains("/catalog/authors/by-name'", StringComparison.Ordinal)).ShouldEqual(1);
+    [Fact] void should_report_both_as_a_serving_concern() => _analysis.Diagnostics.All(_ => _.Code == ScreenplayDiagnosticCodes.ServingConcernWithoutCounterpart).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_the_host_hands_more_than_arguments.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_the_host_hands_more_than_arguments.cs
@@ -48,5 +48,7 @@ public class a_query_the_host_hands_more_than_arguments : Specification
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Listing/Listing.cs", Source)).ShouldBeEmpty();
     [Fact] void should_key_the_query_by_what_the_caller_sends() => _query.By!.Name.ShouldEqual("name");
     [Fact] void should_leave_out_everything_the_host_fills_in() => _query.Filters.ShouldBeEmpty();
-    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_say_the_query_is_paged() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.ServingConcernWithoutCounterpart && _.Message.Contains("paging", StringComparison.Ordinal)).ShouldEqual(1);
+    [Fact] void should_say_the_query_is_sorted() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.ServingConcernWithoutCounterpart && _.Message.Contains("sorting", StringComparison.Ordinal)).ShouldEqual(1);
+    [Fact] void should_say_nothing_about_the_plumbing_the_host_fills_in_of_its_own() => _analysis.Diagnostics.Count.ShouldEqual(2);
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_read_model_carrying_tags.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_read_model_carrying_tags.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Chronicle tags read models as readily as it tags events, and only the event has somewhere in the document to carry
+/// them - a read model is named there only as what a query answers with. Passing the tags over without a word would
+/// leave a reader who sees tags throughout the events concluding that the read models carry none.
+/// </summary>
+public class a_read_model_carrying_tags : Specification
+{
+    const string Source = """
+        using System.Collections.Generic;
+        using Cratis.Chronicle;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        [Tag("audit")]
+        [Tags("authors")]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public static IEnumerable<Author> AllAuthors() => [];
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(("Library/Authors/Listing/Listing.cs", Source));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Listing/Listing.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_still_recover_the_query() => _analysis.Slice().Queries.Single().Name.ShouldEqual("AllAuthors");
+    [Fact] void should_say_the_tags_have_nowhere_to_go() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.ReadModelFeatureWithoutCounterpart).ShouldEqual(1);
+    [Fact] void should_name_every_tag_it_could_not_carry() => _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.ReadModelFeatureWithoutCounterpart).Message.ShouldContain("'audit', 'authors'");
+    [Fact] void should_report_it_once_for_the_read_model_rather_than_once_per_tag() => _analysis.Diagnostics.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Screenplay/Analysis/Controllers/ControllerRoutes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Controllers/ControllerRoutes.cs
@@ -50,6 +50,22 @@ public static class ControllerRoutes
     public static bool IsQuery(IMethodSymbol method) => Carries(method, "HttpGetAttribute");
 
     /// <summary>
+    /// Gets the route a controller or one of its methods is served at.
+    /// </summary>
+    /// <param name="symbol">The controller or method to read.</param>
+    /// <returns>The route template, or <see langword="null"/> when the conventional route is used.</returns>
+    /// <remarks>
+    /// A template appears either as the argument of the verb attribute or as a route attribute of its own, and both
+    /// say the same thing. Neither has a counterpart in a Screenplay, which says what an application is rather than
+    /// where it answers.
+    /// </remarks>
+    public static string? RouteOf(ISymbol symbol) =>
+        symbol.GetAttributes()
+            .Where(_ => IsRouting(_.AttributeClass))
+            .Select(_ => _.GetArgument(0) as string)
+            .FirstOrDefault(_ => !string.IsNullOrWhiteSpace(_));
+
+    /// <summary>
     /// Gets the routable methods a controller declares.
     /// </summary>
     /// <param name="type">The controller to read.</param>
@@ -68,4 +84,13 @@ public static class ControllerRoutes
     /// <returns>True when the attribute is applied.</returns>
     static bool Carries(IMethodSymbol method, string attributeName) =>
         method.HasAttribute($"{MvcNamespace}.{attributeName}");
+
+    /// <summary>
+    /// Determines whether an attribute is one that says where something is served.
+    /// </summary>
+    /// <param name="attribute">The attribute to check.</param>
+    /// <returns>True when the attribute carries a route template.</returns>
+    static bool IsRouting(INamedTypeSymbol? attribute) =>
+        attribute?.ContainingNamespace?.ToDisplayString() == MvcNamespace &&
+        (attribute.Name == "RouteAttribute" || attribute.Name == "HttpGetAttribute" || Array.Exists(_mutating, verb => verb == attribute.Name));
 }

--- a/Source/DotNET/Screenplay/Analysis/Events/EventReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Events/EventReader.cs
@@ -40,25 +40,8 @@ public class EventReader(PropertyReader properties, ScreenplayDiagnostics diagno
     {
         ReportWhatIsLost(type, location);
 
-        return new(type.Name, properties.Read(type), Tags(type));
+        return new(type.Name, properties.Read(type), Tags.Of(type));
     }
-
-    /// <summary>
-    /// Gets the tags an event is classified by.
-    /// </summary>
-    /// <param name="type">The type declaring the event.</param>
-    /// <returns>The tags, ordered.</returns>
-    static IEnumerable<string> Tags(ISymbol type) =>
-    [
-        .. type.GetAttributes()
-            .Where(_ => _.AttributeClass.Is(WellKnownTypeNames.TagAttribute) || _.AttributeClass.Is(WellKnownTypeNames.TagsAttribute))
-            .SelectMany(_ => _.ConstructorArguments)
-            .SelectMany(_ => _.Kind == TypedConstantKind.Array ? _.Values.Select(value => value.Value) : [_.Value])
-            .OfType<string>()
-            .Where(_ => _.Length > 0)
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-    ];
 
     /// <summary>
     /// Reports everything an event declares that the document cannot say.

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
@@ -70,6 +70,8 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
             return null;
         }
 
+        ReportHowItIsServed(method, location);
+
         var parameters = method.Parameters.Where(IsInput).ToList();
         var required = parameters.Find(_ => !_.HasExplicitDefaultValue);
 
@@ -108,6 +110,39 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
         var collection = false;
 
         return SymbolEqualityComparer.Default.Equals(QueryReturnTypes.Unwrap(method.ReturnType, ref collection), readModel);
+    }
+
+    /// <summary>
+    /// Reports what a query says about how it is served, which the document does not describe.
+    /// </summary>
+    /// <param name="method">The method exposing the query.</param>
+    /// <param name="location">Where the query lives.</param>
+    /// <remarks>
+    /// Paging and sorting are left out of the query's shape because no caller sends them as arguments, and that is
+    /// the right reading - but a query that pages is a real thing the application does, and a document that says
+    /// nothing at all reads exactly like a query that does not page.
+    /// </remarks>
+    void ReportHowItIsServed(IMethodSymbol method, string location)
+    {
+        foreach (var served in method.Parameters
+            .Where(_ => _.Type.Is(WellKnownTypeNames.Paging) || _.Type.Is(WellKnownTypeNames.Sorting))
+            .Select(_ => _.Type.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal))
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.ServingConcernWithoutCounterpart,
+                $"The query '{method.Name}' is served with {served.ToLowerInvariant()}, which says how the result is asked for rather than what it is, and Screenplay has no counterpart for it",
+                location);
+        }
+
+        if (method.GetAttribute(WellKnownTypeNames.PathAttribute)?.GetArgument(0) is string path && path.Length > 0)
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.ServingConcernWithoutCounterpart,
+                $"The query '{method.Name}' is served at '{path}' rather than the conventional route, which Screenplay has no counterpart for",
+                location);
+        }
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
@@ -66,6 +66,7 @@ public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics 
 
         if (QueryReader.IsReadModel(type))
         {
+            ReportWhatTheReadModelCannotSay(type, @namespace);
             AddQueries(content, type, QueryReader.MethodsOf(type), @namespace);
             Assign(content, readers.ModelBoundProjections.Read(type, @namespace), @namespace);
         }
@@ -112,17 +113,65 @@ public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics 
             return;
         }
 
+        ReportRoute(ControllerRoutes.RouteOf(type), $"The controller '{type.Name}'", @namespace);
+
         foreach (var method in ControllerRoutes.MethodsOf(type))
         {
             if (ControllerRoutes.IsCommand(method))
             {
-                content.Commands.Add(readers.ControllerCommands.Read(type, method, @namespace));
+                var command = readers.ControllerCommands.Read(type, method, @namespace);
+                content.Commands.Add(command);
+                ReportRoute(ControllerRoutes.RouteOf(method), $"The command '{command.Name}'", @namespace);
             }
             else if (ControllerRoutes.IsQuery(method))
             {
                 AddQueries(content, type, [method], @namespace);
+                ReportRoute(ControllerRoutes.RouteOf(method), $"The query '{method.Name}'", @namespace);
             }
         }
+    }
+
+    /// <summary>
+    /// Reports everything a read model declares that the document has nowhere to hold.
+    /// </summary>
+    /// <param name="type">The read model.</param>
+    /// <param name="location">Where it lives.</param>
+    /// <remarks>
+    /// A read model appears in the document only as the type a query answers with, so a tag on one has nowhere to go
+    /// - while a tag on an event is printed. Saying so is what keeps a reader from taking the difference for the
+    /// application's own.
+    /// </remarks>
+    void ReportWhatTheReadModelCannotSay(INamedTypeSymbol type, string location)
+    {
+        var tags = Tags.Of(type).ToArray();
+        if (tags.Length > 0)
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.ReadModelFeatureWithoutCounterpart,
+                $"The read model '{type.Name}' is tagged {string.Join(", ", tags.Select(tag => $"'{tag}'"))}, and a read model is named in the document only as what a query answers with, so it has nowhere to carry them",
+                location);
+        }
+
+        ReportRoute(type.GetAttribute(WellKnownTypeNames.PathAttribute)?.GetArgument(0) as string, $"The read model '{type.Name}'", location);
+    }
+
+    /// <summary>
+    /// Reports a route the application serves an artifact at.
+    /// </summary>
+    /// <param name="route">The route, when one was declared.</param>
+    /// <param name="what">What declares it, as it reads at the start of the message.</param>
+    /// <param name="location">Where it lives.</param>
+    void ReportRoute(string? route, string what, string location)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+        {
+            return;
+        }
+
+        diagnostics.Information(
+            ScreenplayDiagnosticCodes.ServingConcernWithoutCounterpart,
+            $"{what} is served at '{route}' rather than the conventional route, which Screenplay has no counterpart for",
+            location);
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Tags.cs
+++ b/Source/DotNET/Screenplay/Analysis/Tags.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Reads the tags a declaration classifies itself by.
+/// </summary>
+/// <remarks>
+/// Chronicle tags observers, read models and event types alike, and only an event has somewhere in a Screenplay to
+/// carry them. Reading them in one place is what lets the rest be reported rather than passed over.
+/// </remarks>
+public static class Tags
+{
+    /// <summary>
+    /// Gets the tags a declaration carries.
+    /// </summary>
+    /// <param name="symbol">The declaration to read.</param>
+    /// <returns>The tags, ordered, without duplicates.</returns>
+    public static IEnumerable<string> Of(ISymbol symbol) =>
+    [
+        .. symbol.GetAttributes()
+            .Where(_ => _.AttributeClass.Is(WellKnownTypeNames.TagAttribute) || _.AttributeClass.Is(WellKnownTypeNames.TagsAttribute))
+            .SelectMany(_ => _.ConstructorArguments)
+            .SelectMany(_ => _.Kind == TypedConstantKind.Array ? _.Values.Select(value => value.Value) : [_.Value])
+            .OfType<string>()
+            .Where(_ => _.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+    ];
+}

--- a/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
@@ -143,4 +143,7 @@ public static class WellKnownTypeNames
 
     /// <summary>The order a result is returned in, which the host fills in from the request.</summary>
     public const string Sorting = "Cratis.Arc.Queries.Sorting";
+
+    /// <summary>The attribute giving a read model or a query a route of its own rather than the conventional one.</summary>
+    public const string PathAttribute = "Cratis.Arc.Queries.ModelBound.PathAttribute";
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -375,4 +375,31 @@ public static class ScreenplayDiagnosticCodes
     /// </para>
     /// </remarks>
     public const string UnreadableSpecificationValue = "SP0040";
+
+    /// <summary>
+    /// The application says how an artifact is served, which a Screenplay does not describe.
+    /// </summary>
+    /// <remarks>
+    /// A Screenplay says what an application is, never how a caller reaches it. Paging, sorting and a route template
+    /// are all real declarations about the running application, and all three concern the request rather than the
+    /// model - so there is nothing in the document they could be written into, and nothing to gain from inventing
+    /// somewhere. What is worth having is the reader knowing the question was asked at all: a document silent about
+    /// paging reads exactly like an application that does not page. The three share one code because they share one
+    /// reason, and a reader who does not want to hear about how the application is served suppresses all of it at
+    /// once.
+    /// </remarks>
+    public const string ServingConcernWithoutCounterpart = "SP0041";
+
+    /// <summary>
+    /// A read model declares something the document has nowhere to hold.
+    /// </summary>
+    /// <remarks>
+    /// A read model is never declared in a Screenplay in its own right - it appears only as the type a query answers
+    /// with - so anything it carries beyond its shape has nowhere to go. Tags are the case that matters, and they
+    /// matter because an event's tags <em>are</em> printed: a reader seeing tags throughout the events and none on
+    /// the read models would reasonably conclude that the read models carry none. This is separate from
+    /// <see cref="ServingConcernWithoutCounterpart"/> because the reason is different - the declaration says nothing
+    /// about the request, it is a declaration the document does not make at all.
+    /// </remarks>
+    public const string ReadModelFeatureWithoutCounterpart = "SP0042";
 }


### PR DESCRIPTION
## Added

- `SP0041` reports a query the host pages or sorts, and a route template declared with `[Path]`, `[Route]` or on an HTTP verb — all previously dropped without a word (#2415)
- `SP0042` reports the tags a read model carries, which the document has nowhere to hold while an event's tags are printed (#2415)
