### PR TITLE
Forward-port fix for unbounded recursion deserializing polymorphic read models

### DIFF
--- a/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/AbstractBaseType.cs
+++ b/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/AbstractBaseType.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.MongoDB.for_DerivedTypeDiscriminatorConvention;
+
+public abstract class AbstractBaseType;

--- a/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/PolymorphicReadModel.cs
+++ b/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/PolymorphicReadModel.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_DerivedTypeDiscriminatorConvention;
+
+#pragma warning disable SA1402, SA1649 // Fixture types for the polymorphic read-model specs live together deliberately.
+
+/// <summary>
+/// Fixture hierarchy mirroring the shape that crashed in production: a read model embedding a polymorphic
+/// element tree (marker interface → abstract base chain → [DerivedType] concrete leaves) and an
+/// interface-typed rules list, both discriminated by "_derivedTypeId".
+/// </summary>
+public interface IVisual;
+
+public abstract class VisualObject
+{
+    public string Id { get; set; } = string.Empty;
+
+    public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+}
+
+public abstract class Visual : VisualObject, IVisual
+{
+    public bool IsEnabled { get; set; } = true;
+
+    public double Opacity { get; set; } = 1;
+
+    public double? Width { get; set; }
+
+    public double? Height { get; set; }
+}
+
+public abstract class FrameworkVisual : Visual
+{
+    public string? Name { get; set; }
+
+    public double MinWidth { get; set; }
+
+    public double MaxWidth { get; set; } = double.MaxValue;
+}
+
+[DerivedType("Test.Button", typeof(IVisual))]
+public class ButtonVisual : FrameworkVisual
+{
+    public bool Rounded { get; set; }
+
+    public int Severity { get; set; }
+}
+
+[DerivedType("Test.Knob", typeof(IVisual))]
+public class KnobVisual : FrameworkVisual
+{
+    public int Size { get; set; }
+}
+
+public interface IPropertyRule
+{
+    string? ErrorMessage { get; }
+}
+
+[DerivedType("notEmpty", typeof(IPropertyRule))]
+public record NotEmptyRule(string? ErrorMessage = null) : IPropertyRule;
+
+public record RulesForProperty(string PropertyName, IReadOnlyList<IPropertyRule> Rules);
+
+public record CommandElement(string Id, string Name, IReadOnlyList<RulesForProperty>? Rules = null);
+
+public record ActorElement(string Id, IReadOnlyList<Visual> Elements);
+
+public record SliceElement(string Id, string Name, IReadOnlyList<ActorElement> Actors, CommandElement? Command = null);
+
+public record FeatureElement(string Id, string Name, IReadOnlyList<SliceElement> Slices);
+
+public record ModuleReadModel(string Id, string Name, IReadOnlyList<FeatureElement> Features);
+
+#pragma warning restore SA1402, SA1649

--- a/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_deserializing_a_polymorphic_read_model.cs
+++ b/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_deserializing_a_polymorphic_read_model.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Cratis.Arc.MongoDB.for_DerivedTypeDiscriminatorConvention;
+
+/// <summary>
+/// Round-trips a read model embedding a polymorphic element tree the way MongoDBDefaults wires it in a real
+/// application: camel-cased element names, extra elements ignored, and DerivedTypeDiscriminatorConvention
+/// registered for every type with derivatives. This is the exact shape that overflowed the stack in
+/// production when the discriminator could not resolve a concrete type.
+/// </summary>
+public class when_deserializing_a_polymorphic_read_model : Specification
+{
+    static bool _registered;
+
+    ModuleReadModel _original;
+    ModuleReadModel _deserialized;
+
+    void Establish()
+    {
+        if (!_registered)
+        {
+            _registered = true;
+
+            var types = Substitute.For<ITypes>();
+            types.All.Returns(
+            [
+                typeof(ButtonVisual),
+                typeof(KnobVisual),
+                typeof(NotEmptyRule)
+            ]);
+            var derivedTypes = new DerivedTypes(types);
+
+            var convention = new DerivedTypeDiscriminatorConvention(derivedTypes);
+            foreach (var type in derivedTypes.TypesWithDerivatives)
+            {
+                BsonSerializer.RegisterDiscriminatorConvention(type, convention);
+            }
+
+            var derivedTypePack = new ConventionPack { new DerivedTypeClassMapConvention(derivedTypes, convention) };
+            ConventionRegistry.Register("polymorphic read model derived types", derivedTypePack, _ => true);
+
+            var pack = new ConventionPack
+            {
+                new CamelCaseElementNameConvention(),
+                new IgnoreExtraElementsConvention(true)
+            };
+            ConventionRegistry.Register(
+                "polymorphic read model specs",
+                pack,
+                type => type.Namespace == typeof(when_deserializing_a_polymorphic_read_model).Namespace);
+        }
+
+        _original = new ModuleReadModel(
+            "m1",
+            "My First Module",
+            [
+                new FeatureElement(
+                    "f1",
+                    "My First Feature",
+                    [
+                        new SliceElement(
+                            "s1",
+                            "Register",
+                            [
+                                new ActorElement(
+                                    "a1",
+                                    [
+                                        new ButtonVisual
+                                        {
+                                            Name = "Button",
+                                            Rounded = true,
+                                            Severity = 2,
+                                            Width = 120,
+                                            Height = 42,
+                                            Properties = new Dictionary<string, string> { ["tabIndex"] = "0" }
+                                        },
+                                        new KnobVisual { Name = "Knob", Size = 100 }
+                                    ])
+                            ],
+                            new CommandElement(
+                                "c1",
+                                "Register",
+                                [new RulesForProperty("name", [new NotEmptyRule()])]))
+                    ])
+            ]);
+    }
+
+    void Because()
+    {
+        var document = _original.ToBsonDocument();
+        _deserialized = BsonSerializer.Deserialize<ModuleReadModel>(document);
+    }
+
+    [Fact] void should_round_trip_the_module_name() => _deserialized.Name.ShouldEqual(_original.Name);
+    [Fact] void should_round_trip_the_element_count() => _deserialized.Features[0].Slices[0].Actors[0].Elements.Count.ShouldEqual(2);
+    [Fact] void should_resolve_the_button_to_its_concrete_type() => _deserialized.Features[0].Slices[0].Actors[0].Elements[0].ShouldBeOfExactType<ButtonVisual>();
+    [Fact] void should_resolve_the_knob_to_its_concrete_type() => _deserialized.Features[0].Slices[0].Actors[0].Elements[1].ShouldBeOfExactType<KnobVisual>();
+    [Fact] void should_round_trip_button_state() => ((ButtonVisual)_deserialized.Features[0].Slices[0].Actors[0].Elements[0]).Rounded.ShouldBeTrue();
+    [Fact] void should_resolve_the_rule_to_its_concrete_type() => _deserialized.Features[0].Slices[0].Command!.Rules![0].Rules[0].ShouldBeOfExactType<NotEmptyRule>();
+}

--- a/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_getting_actual_type_for_a_non_instantiable_type_without_derivatives.cs
+++ b/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_getting_actual_type_for_a_non_instantiable_type_without_derivatives.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+
+namespace Cratis.Arc.MongoDB.for_DerivedTypeDiscriminatorConvention;
+
+public class when_getting_actual_type_for_a_non_instantiable_type_without_derivatives : given.a_derived_type_discriminator_convention
+{
+    Exception _result;
+
+    void Establish() => _derivedTypes.HasDerivatives(typeof(AbstractBaseType)).Returns(false);
+
+    void Because() => _result = Catch.Exception(() =>
+    {
+        var document = new BsonDocument { { DerivedTypeDiscriminatorConvention.PropertyName, _derivedTypeIdentifier } };
+        using var reader = new BsonDocumentReader(document);
+        _convention.GetActualType(reader, typeof(AbstractBaseType));
+    });
+
+    [Fact] void should_fail_loudly_instead_of_returning_a_type_that_recurses() => _result.ShouldBeOfExactType<CannotResolveConcreteDerivedType>();
+}

--- a/Source/DotNET/MongoDB/CannotResolveConcreteDerivedType.cs
+++ b/Source/DotNET/MongoDB/CannotResolveConcreteDerivedType.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.MongoDB;
+
+/// <summary>
+/// Exception that gets thrown when a polymorphic value cannot be resolved to a concrete (instantiable) derived type
+/// during BSON deserialization.
+/// </summary>
+/// <remarks>
+/// Returning a non-instantiable nominal type (an interface or abstract class) from the discriminator convention
+/// makes MongoDB's <c>DiscriminatedInterfaceSerializer</c> look the same serializer up again and re-enter
+/// resolution on the same bytes — an unbounded recursion that overflows the stack and terminates the process.
+/// Failing loudly and catchably instead keeps the failure contained to the query that hit it.
+/// </remarks>
+/// <param name="nominalType">The nominal type being deserialized.</param>
+/// <param name="discriminator">The discriminator value read from the document, if any.</param>
+public class CannotResolveConcreteDerivedType(Type nominalType, string? discriminator)
+    : Exception($"Cannot resolve a concrete derived type for '{nominalType.FullName}' from discriminator '{discriminator ?? "<none>"}'. Returning the non-instantiable nominal type would cause the discriminated serializer to recurse indefinitely.");

--- a/Source/DotNET/MongoDB/DerivedTypeClassMapConvention.cs
+++ b/Source/DotNET/MongoDB/DerivedTypeClassMapConvention.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Cratis.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Cratis.Arc.MongoDB;
+
+/// <summary>
+/// Class map convention that registers the derived-type discriminator convention for every concrete
+/// [DerivedType] as its class map is created.
+/// </summary>
+/// <remarks>
+/// The target types (interfaces and base classes) get the convention registered up front, but the driver
+/// resolves the discriminator convention per CLASS MAP when delegating from a discriminated interface
+/// serializer to the concrete type's serializer — and it passes the original (interface) nominal type along.
+/// Without this registration the concrete type's class map falls back to the driver's default "_t"
+/// convention, which cannot see the "_derivedTypeId" element and answers with the interface nominal type,
+/// bouncing deserialization back to the discriminated interface serializer in an unbounded loop that
+/// overflows the stack. Registering the same convention for the concrete types keeps both sides symmetric:
+/// writes emit "_derivedTypeId" and the re-check resolves to the type itself, terminating the delegation.
+/// </remarks>
+/// <param name="derivedTypes">The <see cref="IDerivedTypes"/> system for knowing which types are derived types.</param>
+/// <param name="discriminatorConvention">The <see cref="IDiscriminatorConvention"/> to register for derived types.</param>
+public class DerivedTypeClassMapConvention(IDerivedTypes derivedTypes, IDiscriminatorConvention discriminatorConvention) : ConventionBase, IClassMapConvention
+{
+    readonly ConcurrentDictionary<Type, bool> _registered = new();
+
+    /// <inheritdoc/>
+    public void Apply(BsonClassMap classMap)
+    {
+        var type = classMap.ClassType;
+
+        // Types that also have derivatives of their own (an intermediate that is both a [DerivedType] and a
+        // base of other [DerivedType]s) already got the convention registered up front as target types —
+        // registering again would throw. Only the leaf derived types need the class-map-time registration.
+        if (derivedTypes.IsDerivedType(type) && !derivedTypes.HasDerivatives(type) && _registered.TryAdd(type, true))
+        {
+            try
+            {
+                BsonSerializer.RegisterDiscriminatorConvention(type, discriminatorConvention);
+            }
+            catch (BsonSerializationException)
+            {
+                // The driver memoizes discriminator conventions per type as it walks class hierarchies during
+                // lookups, and can have registered one for this type before its class map was created. That
+                // memoized convention was inherited from a base type that carries ours, so the registration is
+                // already correct — a duplicate here is fine to leave in place.
+            }
+        }
+    }
+}

--- a/Source/DotNET/MongoDB/DerivedTypeDiscriminatorConvention.cs
+++ b/Source/DotNET/MongoDB/DerivedTypeDiscriminatorConvention.cs
@@ -44,9 +44,21 @@ public class DerivedTypeDiscriminatorConvention(IDerivedTypes derivedTypes) : ID
         // a leaf derived type being deserialized after its discriminator was resolved one level up). The
         // discriminator element may still be present on the document, so only resolve a derived type when
         // the nominal type actually has derivatives to avoid throwing for an unknown target type.
-        return type is null || !derivedTypes.HasDerivatives(nominalType)
+        var actualType = type is null || !derivedTypes.HasDerivatives(nominalType)
             ? nominalType
             : derivedTypes.GetDerivedTypeFor(nominalType, type);
+
+        // Guard against handing back a non-instantiable type. MongoDB constructs a DiscriminatedInterfaceSerializer
+        // for interface (and abstract) nominal types; if GetActualType returns that same non-instantiable type, the
+        // driver looks the discriminated serializer up again and calls GetActualType on the identical bytes, looping
+        // until the stack overflows and the process is killed (SIGSEGV). A polymorphic value that reaches here without
+        // resolving to a concrete type is malformed or unregistered — surface it as a catchable exception instead.
+        if (actualType.IsInterface || actualType.IsAbstract)
+        {
+            throw new CannotResolveConcreteDerivedType(nominalType, type);
+        }
+
+        return actualType;
     }
 
     /// <inheritdoc/>

--- a/Source/DotNET/MongoDB/MongoDBDefaults.cs
+++ b/Source/DotNET/MongoDB/MongoDBDefaults.cs
@@ -93,6 +93,14 @@ public static class MongoDBDefaults
         {
             BsonSerializer.RegisterDiscriminatorConvention(type, convention);
         }
+
+        // The concrete derived types need the same convention on their own class maps — the driver resolves
+        // the discriminator per class map when delegating from an interface serializer, and the default "_t"
+        // convention answers with the interface nominal type, looping the delegation until the stack overflows.
+        // A class map convention registers them lazily as each class map is created, independent of when the
+        // derived types were discovered. Deliberately unfiltered: discriminator correctness is not optional.
+        var derivedTypePack = new ConventionPack { new DerivedTypeClassMapConvention(derivedTypes, convention) };
+        ConventionRegistry.Register("Derived type discriminator for derived types", derivedTypePack, _ => true);
     }
 
     static void RegisterConventionPacks(IMongoDBBuilder builder, IEnumerable<ICanFilterMongoDBConventionPacksForType> conventionPackFilters)


### PR DESCRIPTION
# Summary

Forward-ports the `release/20.62.x` hotfix (`94fc9178`) that never landed on main. Without it, every release from 20.63.0 on regressed the fix: deserializing a read model with an interface- or abstract-typed `[DerivedType]` member bounces between the discriminated interface serializer and the concrete class map's default `_t` convention until the stack overflows and the process dies with SIGSEGV. This took down Studio production today after it upgraded from 20.62.6 to 20.69.2.

## Fixed

- Deserializing a read model with a polymorphic (`[DerivedType]`) interface- or abstract-typed member no longer overflows the stack and kills the process — the derived-type discriminator convention is registered for concrete class maps as they are created, and an unresolvable discriminator now throws the catchable `CannotResolveConcreteDerivedType` instead of recursing

🤖 Generated with [Claude Code](https://claude.com/claude-code)