### PR TITLE
Require a version label only where a release can be cut

### DIFF
--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -14,8 +14,11 @@ concurrency:
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+    # Scoped to the same base branch Publish releases from. A pull request stacked onto another one's
+    # branch cannot cut a release, so demanding a version label of it would be asking which version a
+    # merge that publishes nothing should carry.
     branches:
-      - "**"
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
# Summary

Scopes the semantic version label check to pull requests into `main`, the only base branch Publish releases from.