### PR TITLE
Resolve Screenplay options once, at the entry point that sees them first

### DIFF
--- a/Source/DotNET/Screenplay/Emission/ScreenplayEmitter.cs
+++ b/Source/DotNET/Screenplay/Emission/ScreenplayEmitter.cs
@@ -24,10 +24,11 @@ public class ScreenplayEmitter(IScreenplayPrinter printer, IScreenplayNaming nam
 
     /// <inheritdoc/>
     /// <remarks>
-    /// This is where the options an emission runs with are resolved, and the only place. What a name falls back to
-    /// is a question only an entry point can answer - a host that emits a model it already holds has nothing to fall
-    /// back on but the domain of that model - so resolving deeper down meant resolving twice on the way through a
-    /// generation, against two answers that only happen to agree.
+    /// Emitting is an entry point of its own, so the options are resolved here for a host that hands over a model it
+    /// already holds - such a host has nothing to fall back on but the domain of that model. A generation is the
+    /// other entry point and has already resolved against the assembly it was reading, and options that are resolved
+    /// answer with themselves, so one generation still resolves exactly once and the fallback the analysis half used
+    /// is the fallback the document is named after.
     /// </remarks>
     public ScreenplayEmission Emit(ApplicationModel model, ScreenplayOptions options)
     {

--- a/Source/DotNET/Screenplay/ScreenplayGenerator.cs
+++ b/Source/DotNET/Screenplay/ScreenplayGenerator.cs
@@ -41,6 +41,12 @@ public class ScreenplayGenerator(IApplicationModelAnalyzer analyzer, IScreenplay
         Generate([compilation], options);
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// A generation is the entry point that knows what a name falls back to - the assembly being read, or nothing at
+    /// all when several projects are the application together - so the options resolve here and both halves run with
+    /// the same answer. Emitting resolves too, because a host can emit a model without ever generating, but options
+    /// that are resolved answer with themselves and nothing is resolved twice on the way through.
+    /// </remarks>
     public ScreenplayGenerationResult Generate(IReadOnlyList<Compilation> compilations, ScreenplayOptions options)
     {
         var ordered = AnalyzedCompilations.Ordered(compilations);

--- a/Source/DotNET/Screenplay/ScreenplayOptions.cs
+++ b/Source/DotNET/Screenplay/ScreenplayOptions.cs
@@ -49,20 +49,42 @@ public record ScreenplayOptions
     /// carry a name that belongs to nobody and would gather every project under it. The namespaces already say what
     /// the modules are. Naming a module still collapses the document into that one, which is the way to ask for it.
     /// <para>
-    /// Once resolved it stays resolved. Emission resolves a second time against the domain of the model, which by
-    /// then is known, and without this the module would quietly be filled in from it and the document would come
-    /// back as one module after all.
+    /// It is decided where the options resolve and carried from there, so the emission half reads the decision the
+    /// entry point made rather than working one out again from a module that is empty because of that decision -
+    /// which would fill the module in from the domain and hand back a document of one module after all.
     /// </para>
     /// </remarks>
     public bool ModulesFromNamespaceRoots { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether every value has been filled in already.
+    /// </summary>
+    /// <remarks>
+    /// Carried so that the options themselves say whether they have been resolved, rather than every reader working
+    /// it out from the values it happens to look at.
+    /// </remarks>
+    private bool Resolved { get; init; }
 
     /// <summary>
     /// Resolves the options with every value filled in.
     /// </summary>
     /// <param name="fallbackName">The name to use for the domain when none is configured.</param>
     /// <returns>The resolved options.</returns>
+    /// <remarks>
+    /// Options resolve once, at whichever entry point sees them first, and every later call answers with the same
+    /// options rather than resolving them again. What a name falls back to is a question only an entry point can
+    /// answer - the assembly being analyzed when a generation asked for the document, the domain of the model when a
+    /// host emitted one it already had - and a generation passes through both halves, so without this the emission
+    /// half would resolve a second time against a fallback the analysis half never saw. The two answers agree today,
+    /// which is the only reason nothing showed; agreeing is not something either half promises the other.
+    /// </remarks>
     public ScreenplayOptions WithDefaults(string? fallbackName)
     {
+        if (Resolved)
+        {
+            return this;
+        }
+
         var domain = Coalesce(Domain, Coalesce(fallbackName, DefaultName));
         var fromNamespaceRoots = ModulesFromNamespaceRoots ||
             (string.IsNullOrWhiteSpace(Module) && string.IsNullOrWhiteSpace(fallbackName));
@@ -72,7 +94,8 @@ public record ScreenplayOptions
             Domain = domain,
             Module = fromNamespaceRoots ? null : Coalesce(Module, domain),
             SegmentsToSkip = SegmentsToSkip ?? 0,
-            ModulesFromNamespaceRoots = fromNamespaceRoots
+            ModulesFromNamespaceRoots = fromNamespaceRoots,
+            Resolved = true
         };
     }
 


### PR DESCRIPTION
## Fixed

- Screenplay options are resolved once, at whichever entry point sees them first, so emitting a model directly and reaching the same model through a generation no longer resolve the domain name against two different fallbacks (#2401)
