### PR TITLE
Drop the empty assetsDir override from the TestApp Vite configs

### DIFF
--- a/TestApps/ArcCore/.frontend/vite.config.minified.ts
+++ b/TestApps/ArcCore/.frontend/vite.config.minified.ts
@@ -16,7 +16,6 @@ import baseConfig from './vite.config';
 export default mergeConfig(baseConfig, defineConfig({
     build: {
         outDir: 'dist-minified',
-        assetsDir: '',
         minify: 'esbuild',
     },
     esbuild: {

--- a/TestApps/ArcCore/.frontend/vite.config.ts
+++ b/TestApps/ArcCore/.frontend/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     root: fileURLToPath(new URL('../', import.meta.url)),
     build: {
         outDir: 'wwwroot',
-        assetsDir: '',
     },
     plugins: [react()],
     resolve: {

--- a/TestApps/AspNetCore/.frontend/vite.config.ts
+++ b/TestApps/AspNetCore/.frontend/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     root: fileURLToPath(new URL('../', import.meta.url)),
     build: {
         outDir: 'wwwroot',
-        assetsDir: '',
     },
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
# Summary

Internal test applications only — no user-facing change.