### PR TITLE
Materialize read model collections as empty rather than null

### DIFF
--- a/Documentation/backend/mongodb/convention-packs.md
+++ b/Documentation/backend/mongodb/convention-packs.md
@@ -41,6 +41,93 @@ RegisterConventionAsPack(
 );
 ```
 
+### Read Model Collections Never Null
+
+Materializes a `[ReadModel]`'s declared **non-nullable** collection members as empty collections instead of `null`:
+
+```csharp
+// Registered automatically with name: "Read model collections never null convention",
+// scoped to types marked with [ReadModel]
+RegisterConventionAsPack(
+    conventionPackFilters,
+    ConventionPacks.ReadModelCollectionsNeverNull,
+    new ReadModelCollectionsNeverNullConvention(),
+    type => type.IsReadModel()
+);
+```
+
+#### Why it exists — the driver is a separate boundary from Chronicle
+
+A read model that declares a child collection as a non-nullable `IEnumerable<T>` promises the type system that the
+value is there. The store is free to disagree. Chronicle's read model sink writes **no field at all** for a child
+collection that has never had an element, and can write an **explicit `null`** for one whose last element went away.
+Nullable reference analysis has already concluded the member can never be `null`, so nothing warns, and an unguarded
+`.Any()` / `.All()` / `.Select()` throws at runtime.
+
+Chronicle closes this for **its own reader** with a `JsonTypeInfo` modifier on its client's `JsonSerializerOptions`.
+That fix lives at Chronicle's serialization boundary and **does not reach the MongoDB driver**. Reading a read model
+through `IMongoCollection<T>` — the sanctioned way to query by anything other than the key, and what Arc's own
+server-side paging runs on — goes through the driver instead. This convention is the same guarantee, restated where
+the driver can honor it.
+
+#### What it covers
+
+Both shapes a store can leave behind, through two different mechanisms:
+
+| Stored shape | Mechanism | Result for a non-nullable member |
+|---|---|---|
+| The field is **absent** from the document | a default value on the member map | an empty collection |
+| The field is present and holds **`null`** | a serializer wrapping the member's own | an empty collection |
+
+Both halves are needed: the driver never invokes a member's serializer for an element that is not in the document, and
+a default value is never consulted for one that is.
+
+#### What it deliberately leaves alone
+
+- **Nullable collections.** A member declared `IEnumerable<T>?` keeps the distinction between "no collection" and "an
+  empty collection", because that model asked for it. Absent stays `null`; a stored `null` stays `null`.
+- **Dictionaries.** `IDictionary<TKey, TValue>`, `IReadOnlyDictionary<TKey, TValue>`, and `Dictionary<TKey, TValue>`
+  are untouched.
+- **`string`.** It is an `IEnumerable<char>`, and the classic trap here would be handing it an empty list.
+- **Types without `[ReadModel]`.** The scoping is what keeps this from redefining what `null` means for every BSON
+  type in the process.
+- **Writing.** Serialization is unchanged — a collection that is `null` in memory is still written as `null`.
+
+#### Supported collection shapes
+
+`IEnumerable<T>`, `ICollection<T>`, `IList<T>`, `IReadOnlyCollection<T>`, `IReadOnlyList<T>`, `List<T>`,
+`ISet<T>`, `IReadOnlySet<T>`, `HashSet<T>`, and single-dimension arrays `T[]`. Interface-typed members are filled with
+a `List<T>` (or a `HashSet<T>` for the set interfaces). Any other collection type is left as the driver would leave
+it — the empty value is assigned straight into the member, so a shape that cannot be constructed safely is not guessed
+at.
+
+#### Opting out
+
+Per type, through the standard mechanism:
+
+```csharp
+[IgnoreConventions(ConventionPacks.ReadModelCollectionsNeverNull)]
+[ReadModel]
+public record RawProjection(string Id, IEnumerable<Child> Children);
+```
+
+Per member, by stating the default the member wants — the convention skips any member carrying a
+`[BsonDefaultValue]`, for an absent element and a stored `null` alike:
+
+```csharp
+[ReadModel]
+public record Parent(string Id, [property: BsonDefaultValue(null)] IEnumerable<Child> Children);
+```
+
+#### Things to know
+
+- **The default replaces whatever a property initializer set.** A member written as
+  `public IEnumerable<Child> Children { get; set; } = [];` still comes back empty, but as a `List<Child>` rather than
+  the `Child[]` the collection expression produced. A member whose initializer sets a **meaningful non-empty** default
+  would be silently emptied — use one of the opt-outs above for that member.
+- **Registration order matters.** A class map freezes its conventions the first time it is built, so this is
+  registered during `AddCratisMongoDB`, before anything can deserialize.
+
 ## Creating Convention Pack Providers
 
 To provide your own convention packs, implement `ICanProvideMongoDBConventionPacks`:
@@ -256,6 +343,7 @@ The framework defines constants for well-known convention pack names:
 public static class ConventionPacks
 {
     public const string IgnoreExtraElements = "Ignore extra elements convention";
+    public const string ReadModelCollectionsNeverNull = "Read model collections never null convention";
 }
 
 public class NamingPolicyNameConvention

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/given/a_read_model_document.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/given/a_read_model_document.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+
+/// <summary>
+/// Provides a fully populated document for <see cref="ReadModelWithEveryCollectionShape"/> for a spec to take away
+/// from, so what each one asserts about is only what it removed or nulled.
+/// </summary>
+public class a_read_model_document : a_registered_convention_pack
+{
+    protected BsonDocument _document;
+
+    void Establish() => _document = FullyPopulated().ToBsonDocument();
+
+    protected static ReadModelWithEveryCollectionShape FullyPopulated() =>
+        new(
+            "p1",
+            [new Child("enumerable")],
+            [new Child("optional")],
+            [new Child("list")],
+            [new Child("ordered")],
+            [new Child("collection")],
+            [new Child("array")],
+            ["tag"],
+            new HashSet<string> { "set" },
+            new Dictionary<string, Child> { ["key"] = new("mapped") },
+            "a label");
+}

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/given/a_registered_convention_pack.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/given/a_registered_convention_pack.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries.ModelBound;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+
+/// <summary>
+/// Registers the convention the way <see cref="MongoDBDefaults"/> does — scoped to <c>[ReadModel]</c> types — narrowed
+/// to this namespace so the rest of the assembly is unaffected by the process-wide convention registry.
+/// </summary>
+/// <remarks>
+/// A class map freezes its conventions the first time it is built, so the registration has to happen before anything
+/// touches these types and exactly once for the whole run.
+/// </remarks>
+public class a_registered_convention_pack : Specification
+{
+    static bool _registered;
+
+    void Establish()
+    {
+        if (_registered)
+        {
+            return;
+        }
+
+        _registered = true;
+
+        var pack = new ConventionPack { new ReadModelCollectionsNeverNullConvention() };
+        ConventionRegistry.Register(
+            ConventionPacks.ReadModelCollectionsNeverNull,
+            pack,
+            type => type.IsReadModel() && type.Namespace == typeof(Child).Namespace);
+    }
+
+    /// <summary>
+    /// Resolves the element name a member is stored under.
+    /// </summary>
+    /// <param name="memberName">Name of the member.</param>
+    /// <returns>The element name from the class map.</returns>
+    /// <remarks>
+    /// Documents are built through the class map rather than by hand, because other specs in this assembly register
+    /// naming conventions process-wide and a hard-coded <c>"Children"</c> would stop matching the moment one applied.
+    /// </remarks>
+    protected static string ElementNameFor(string memberName) =>
+        BsonClassMap.LookupClassMap(typeof(ReadModelWithEveryCollectionShape)).GetMemberMap(memberName).ElementName;
+}

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/read_models.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/read_models.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries.ModelBound;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention;
+
+#pragma warning disable SA1402, SA1649, CA1819, RCS1181
+
+// Spec fixtures: several small types in one file, an array-typed collection member because that is one of the shapes
+// the convention has to get right, and plain comments rather than XML docs on records with many positional members.
+[IgnoreConventions(NamingPolicyNameConvention.ConventionName)]
+public record Child(string Name);
+
+// One member per collection shape the convention claims to support, plus the shapes it must leave alone —
+// a nullable collection, a dictionary, and a string.
+//
+// The naming policy is process-wide state (DatabaseExtensions.SetNamingPolicy) and other specs in this assembly
+// replace it with a bare substitute that answers null for every name. Once any spec has called AddCratisMongoDB,
+// NamingPolicyNameConvention is registered for every type, and a class map built after both of those would have
+// every element renamed to null and fail to freeze. Opting out of that one pack — through the very mechanism a
+// consumer would use — keeps these fixtures independent of the order the assembly happens to run in.
+[IgnoreConventions(NamingPolicyNameConvention.ConventionName)]
+[ReadModel]
+public record ReadModelWithEveryCollectionShape(
+    string Id,
+    IEnumerable<Child> Children,
+    IEnumerable<Child>? OptionalChildren,
+    List<Child> ChildList,
+    IReadOnlyList<Child> OrderedChildren,
+    ICollection<Child> ChildCollection,
+    Child[] ChildArray,
+    HashSet<string> Tags,
+    ISet<string> TagSet,
+    IDictionary<string, Child> ChildrenByName,
+    string Label);
+
+[IgnoreConventions(NamingPolicyNameConvention.ConventionName)]
+[ReadModel]
+public record ReadModelWithOwnDefault(string Id, [property: BsonDefaultValue(null)] IEnumerable<Child> Children);
+
+[IgnoreConventions(NamingPolicyNameConvention.ConventionName)]
+public record NotAReadModel(string Id, IEnumerable<Child> Children);
+
+#pragma warning restore SA1402, SA1649, CA1819, RCS1181

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/with_a_member_declaring_its_own_default.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/with_a_member_declaring_its_own_default.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.when_deserializing_a_read_model;
+
+/// <summary>
+/// The per-member escape hatch: a member that states its own default has said what it wants, and the convention leaves
+/// it alone for an absent element and a stored null alike.
+/// </summary>
+public class with_a_member_declaring_its_own_default : a_registered_convention_pack
+{
+    BsonDocument _absent;
+    BsonDocument _explicitlyNull;
+    ReadModelWithOwnDefault _fromAbsent;
+    ReadModelWithOwnDefault _fromExplicitNull;
+
+    void Establish()
+    {
+        var elementName = BsonClassMap
+            .LookupClassMap(typeof(ReadModelWithOwnDefault))
+            .GetMemberMap(nameof(ReadModelWithOwnDefault.Children))
+            .ElementName;
+
+        _absent = new ReadModelWithOwnDefault("p1", [new Child("child")]).ToBsonDocument();
+        _absent.Remove(elementName);
+
+        _explicitlyNull = new ReadModelWithOwnDefault("p1", [new Child("child")]).ToBsonDocument();
+        _explicitlyNull[elementName] = BsonNull.Value;
+    }
+
+    void Because()
+    {
+        _fromAbsent = BsonSerializer.Deserialize<ReadModelWithOwnDefault>(_absent);
+        _fromExplicitNull = BsonSerializer.Deserialize<ReadModelWithOwnDefault>(_explicitlyNull);
+    }
+
+    [Fact] void should_leave_an_absent_element_null() => _fromAbsent.Children.ShouldBeNull();
+    [Fact] void should_leave_a_stored_null_null() => _fromExplicitNull.Children.ShouldBeNull();
+}

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/with_null_collection_elements.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/with_null_collection_elements.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.when_deserializing_a_read_model;
+
+/// <summary>
+/// The other shape a store can leave behind — the field is there and holds null. A default value alone never covers
+/// this, because the driver goes through the member's serializer for an element that is present.
+/// </summary>
+public class with_null_collection_elements : a_read_model_document
+{
+    ReadModelWithEveryCollectionShape _result;
+
+    void Establish()
+    {
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Children))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.OptionalChildren))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildList))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.OrderedChildren))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildCollection))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildArray))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Tags))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.TagSet))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildrenByName))] = BsonNull.Value;
+        _document[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Label))] = BsonNull.Value;
+    }
+
+    void Because() => _result = BsonSerializer.Deserialize<ReadModelWithEveryCollectionShape>(_document);
+
+    [Fact] void should_materialize_the_enumerable_as_empty() => _result.Children.ShouldBeEmpty();
+    [Fact] void should_materialize_the_list_as_empty() => _result.ChildList.ShouldBeEmpty();
+    [Fact] void should_materialize_the_read_only_list_as_empty() => _result.OrderedChildren.ShouldBeEmpty();
+    [Fact] void should_materialize_the_collection_as_empty() => _result.ChildCollection.ShouldBeEmpty();
+    [Fact] void should_materialize_the_array_as_empty() => _result.ChildArray.ShouldBeEmpty();
+    [Fact] void should_materialize_the_hash_set_as_empty() => _result.Tags.ShouldBeEmpty();
+    [Fact] void should_materialize_the_set_as_empty() => _result.TagSet.ShouldBeEmpty();
+    [Fact] void should_leave_the_nullable_collection_null() => _result.OptionalChildren.ShouldBeNull();
+    [Fact] void should_leave_the_dictionary_null() => _result.ChildrenByName.ShouldBeNull();
+    [Fact] void should_leave_the_string_null() => _result.Label.ShouldBeNull();
+}

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/with_the_collection_elements_present.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/with_the_collection_elements_present.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.when_deserializing_a_read_model;
+
+/// <summary>
+/// A stored value must survive the convention untouched — the guarantee is about absence, not about the content.
+/// </summary>
+public class with_the_collection_elements_present : a_read_model_document
+{
+    ReadModelWithEveryCollectionShape _result;
+
+    void Because() => _result = BsonSerializer.Deserialize<ReadModelWithEveryCollectionShape>(_document);
+
+    [Fact] void should_keep_the_enumerable_value() => _result.Children.Single().Name.ShouldEqual("enumerable");
+    [Fact] void should_keep_the_list_value() => _result.ChildList.Single().Name.ShouldEqual("list");
+    [Fact] void should_keep_the_read_only_list_value() => _result.OrderedChildren.Single().Name.ShouldEqual("ordered");
+    [Fact] void should_keep_the_collection_value() => _result.ChildCollection.Single().Name.ShouldEqual("collection");
+    [Fact] void should_keep_the_array_value() => _result.ChildArray.Single().Name.ShouldEqual("array");
+    [Fact] void should_keep_the_hash_set_value() => _result.Tags.Single().ShouldEqual("tag");
+    [Fact] void should_keep_the_set_value() => _result.TagSet.Single().ShouldEqual("set");
+    [Fact] void should_keep_the_nullable_collection_value() => _result.OptionalChildren!.Single().Name.ShouldEqual("optional");
+    [Fact] void should_keep_the_dictionary_value() => _result.ChildrenByName["key"].Name.ShouldEqual("mapped");
+    [Fact] void should_keep_the_string_value() => _result.Label.ShouldEqual("a label");
+}

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/without_the_collection_elements.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_read_model/without_the_collection_elements.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.when_deserializing_a_read_model;
+
+/// <summary>
+/// The shape Chronicle's read model sink writes for a child collection that has never had an element — no field at all.
+/// </summary>
+public class without_the_collection_elements : a_read_model_document
+{
+    ReadModelWithEveryCollectionShape _result;
+
+    void Establish()
+    {
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Children)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.OptionalChildren)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildList)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.OrderedChildren)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildCollection)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildArray)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Tags)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.TagSet)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildrenByName)));
+        _document.Remove(ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Label)));
+    }
+
+    void Because() => _result = BsonSerializer.Deserialize<ReadModelWithEveryCollectionShape>(_document);
+
+    [Fact] void should_materialize_the_enumerable_as_empty() => _result.Children.ShouldBeEmpty();
+    [Fact] void should_materialize_the_list_as_empty() => _result.ChildList.ShouldBeEmpty();
+    [Fact] void should_materialize_the_read_only_list_as_empty() => _result.OrderedChildren.ShouldBeEmpty();
+    [Fact] void should_materialize_the_collection_as_empty() => _result.ChildCollection.ShouldBeEmpty();
+    [Fact] void should_materialize_the_array_as_empty() => _result.ChildArray.ShouldBeEmpty();
+    [Fact] void should_materialize_the_hash_set_as_empty() => _result.Tags.ShouldBeEmpty();
+    [Fact] void should_materialize_the_set_as_empty() => _result.TagSet.ShouldBeEmpty();
+    [Fact] void should_leave_the_nullable_collection_null() => _result.OptionalChildren.ShouldBeNull();
+    [Fact] void should_leave_the_dictionary_null() => _result.ChildrenByName.ShouldBeNull();
+    [Fact] void should_leave_the_string_null() => _result.Label.ShouldBeNull();
+}

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_type_that_is_not_a_read_model.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_deserializing_a_type_that_is_not_a_read_model.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention;
+
+/// <summary>
+/// The scoping to <c>[ReadModel]</c> is what keeps this from redefining what null means for every BSON type in the
+/// process, so a type without the attribute must come back exactly as the driver would have left it.
+/// </summary>
+public class when_deserializing_a_type_that_is_not_a_read_model : a_registered_convention_pack
+{
+    BsonDocument _document;
+    NotAReadModel _result;
+
+    void Establish()
+    {
+        _document = new NotAReadModel("p1", [new Child("child")]).ToBsonDocument();
+        _document.Remove(
+            BsonClassMap
+                .LookupClassMap(typeof(NotAReadModel))
+                .GetMemberMap(nameof(NotAReadModel.Children))
+                .ElementName);
+    }
+
+    void Because() => _result = BsonSerializer.Deserialize<NotAReadModel>(_document);
+
+    [Fact] void should_leave_the_collection_null() => _result.Children.ShouldBeNull();
+}

--- a/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_serializing_a_read_model.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ReadModelCollectionsNeverNullConvention/when_serializing_a_read_model.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention.given;
+using MongoDB.Bson;
+
+namespace Cratis.Arc.MongoDB.for_ReadModelCollectionsNeverNullConvention;
+
+/// <summary>
+/// The convention only adjusts the read direction. Writing has to stay byte-for-byte what it was, or every document
+/// already in a collection would start disagreeing with the ones written after the upgrade.
+/// </summary>
+public class when_serializing_a_read_model : a_registered_convention_pack
+{
+    BsonDocument _result;
+
+    void Because() => _result = new ReadModelWithEveryCollectionShape(
+        "p1",
+        [new Child("enumerable")],
+        null,
+        [],
+        [],
+        [],
+        [],
+        [],
+        new HashSet<string>(),
+        new Dictionary<string, Child>(),
+        "a label").ToBsonDocument();
+
+    [Fact] void should_write_a_populated_collection_as_an_array() => _result[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Children))].AsBsonArray.Count.ShouldEqual(1);
+    [Fact] void should_write_an_empty_collection_as_an_empty_array() => _result[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.ChildList))].AsBsonArray.ShouldBeEmpty();
+    [Fact] void should_write_a_null_collection_as_null() => _result[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.OptionalChildren))].IsBsonNull.ShouldBeTrue();
+    [Fact] void should_write_the_string_unchanged() => _result[ElementNameFor(nameof(ReadModelWithEveryCollectionShape.Label))].AsString.ShouldEqual("a label");
+}

--- a/Source/DotNET/MongoDB/ConventionPacks.cs
+++ b/Source/DotNET/MongoDB/ConventionPacks.cs
@@ -12,4 +12,9 @@ public static class ConventionPacks
     /// Gets the ignore extra elements convention pack name.
     /// </summary>
     public const string IgnoreExtraElements = "Ignore extra elements convention";
+
+    /// <summary>
+    /// Gets the read model collections never null convention pack name.
+    /// </summary>
+    public const string ReadModelCollectionsNeverNull = "Read model collections never null convention";
 }

--- a/Source/DotNET/MongoDB/MongoDBDefaults.cs
+++ b/Source/DotNET/MongoDB/MongoDBDefaults.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using Cratis.Arc.Queries.ModelBound;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
@@ -74,6 +75,17 @@ public static class MongoDBDefaults
 
             RegisterConventionAsPack(conventionPackFilters, NamingPolicyNameConvention.ConventionName, new NamingPolicyNameConvention());
             RegisterConventionAsPack(conventionPackFilters, ConventionPacks.IgnoreExtraElements, new IgnoreExtraElementsConvention(true));
+
+            // Scoped to read models rather than every BSON type in the process: a collection that materializes as empty
+            // instead of null is what a read model's own declaration already promises its callers, while for an
+            // arbitrary document type it would be a change to what null means. Registered here, before RegisterClassMaps
+            // below and before anything can deserialize, because a class map freezes its conventions the first time it
+            // is built.
+            RegisterConventionAsPack(
+                conventionPackFilters,
+                ConventionPacks.ReadModelCollectionsNeverNull,
+                new ReadModelCollectionsNeverNullConvention(),
+                type => type.IsReadModel());
 
             RegisterDerivedTypeDiscriminatorConventions();
             RegisterClassMaps(builder);
@@ -153,10 +165,13 @@ public static class MongoDBDefaults
         classMap.ApplyConventions();
     }
 
-    static void RegisterConventionAsPack(IEnumerable<ICanFilterMongoDBConventionPacksForType> conventionPackFilters, string name, IConvention convention)
+    static void RegisterConventionAsPack(IEnumerable<ICanFilterMongoDBConventionPacksForType> conventionPackFilters, string name, IConvention convention, Func<Type, bool>? appliesTo = default)
     {
         var pack = new ConventionPack { convention };
-        ConventionRegistry.Register(name, pack, type => ShouldInclude(conventionPackFilters, name, pack, type));
+        ConventionRegistry.Register(
+            name,
+            pack,
+            type => (appliesTo?.Invoke(type) ?? true) && ShouldInclude(conventionPackFilters, name, pack, type));
     }
 
     static bool ShouldInclude(IEnumerable<ICanFilterMongoDBConventionPacksForType> conventionPackFilters, string conventionPackName, IConventionPack conventionPack, Type type)

--- a/Source/DotNET/MongoDB/NullToEmptyCollectionSerializer.cs
+++ b/Source/DotNET/MongoDB/NullToEmptyCollectionSerializer.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Cratis.Arc.MongoDB;
+
+/// <summary>
+/// Represents an <see cref="IBsonSerializer{TValue}"/> that deserializes a null collection as an empty one.
+/// </summary>
+/// <typeparam name="TCollection">Type of the collection member.</typeparam>
+/// <param name="inner">The <see cref="IBsonSerializer{TValue}"/> doing the actual work.</param>
+/// <param name="emptyValueFactory">Creates the empty collection to substitute for a stored null.</param>
+/// <remarks>
+/// <para>
+/// A default value only covers a member whose element is <b>absent</b> from the document — the driver never invokes the
+/// member's serializer at all in that case. An element that is present and holds null goes through the serializer, which
+/// is why <see cref="ReadModelCollectionsNeverNullConvention"/> needs both halves to make good on its guarantee.
+/// </para>
+/// <para>
+/// Writing is delegated untouched — a collection that is null in memory is still written as null. Only the read
+/// direction is adjusted, which is what keeps this from changing the shape of anything already stored.
+/// </para>
+/// </remarks>
+internal sealed class NullToEmptyCollectionSerializer<TCollection>(
+    IBsonSerializer<TCollection> inner,
+    Func<object> emptyValueFactory) : SerializerBase<TCollection>, IBsonArraySerializer
+{
+    /// <inheritdoc/>
+    public override TCollection Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        if (context.Reader.GetCurrentBsonType() == BsonType.Null)
+        {
+            context.Reader.ReadNull();
+            return (TCollection)emptyValueFactory();
+        }
+
+        return inner.Deserialize(context, args);
+    }
+
+    /// <inheritdoc/>
+    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, TCollection value) =>
+        inner.Serialize(context, args, value);
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The LINQ provider asks a member's serializer for its item serialization info to translate expressions that reach
+    /// into the collection — <c>Any()</c>, <c>Count</c>, element access. Arc's server-side paging runs on
+    /// <c>AsQueryable()</c>, so failing to forward this would silently break query translation for every member this
+    /// wraps.
+    /// </remarks>
+    public bool TryGetItemSerializationInfo(out BsonSerializationInfo serializationInfo)
+    {
+        if (inner is IBsonArraySerializer arraySerializer)
+        {
+            return arraySerializer.TryGetItemSerializationInfo(out serializationInfo);
+        }
+
+        serializationInfo = null!;
+        return false;
+    }
+}

--- a/Source/DotNET/MongoDB/ReadModelCollectionsNeverNullConvention.cs
+++ b/Source/DotNET/MongoDB/ReadModelCollectionsNeverNullConvention.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Reflection;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Cratis.Arc.MongoDB;
+
+/// <summary>
+/// Represents a <see cref="IMemberMapConvention"/> that materializes a read model's declared non-nullable collection
+/// members as empty collections rather than null.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A read model that declares a child collection as a non-nullable <c>IEnumerable&lt;T&gt;</c> promises the type system
+/// that the value is there. A store is free to disagree: Chronicle's read model sink writes no field at all for a child
+/// collection that has never had an element, and can write an explicit null for one whose last element went away.
+/// Either way the driver hands back <see langword="null"/> for a member nullable analysis has already concluded can
+/// never be null, so an unguarded <c>.Any()</c> or <c>.Select()</c> throws where nothing warned it might.
+/// </para>
+/// <para>
+/// Chronicle closes this for its own reader through a <c>JsonTypeInfo</c> modifier on the client's serializer options.
+/// That fix is confined to Chronicle's serialization boundary and never reaches the MongoDB driver — which is the
+/// sanctioned path for reading a read model by anything other than its key, and the one Arc's own server-side paging
+/// runs on. This convention is the same guarantee, restated where the driver can honor it.
+/// </para>
+/// <para>
+/// Only members the declaration says cannot be null are touched. A member declared <c>IEnumerable&lt;T&gt;?</c> keeps
+/// the distinction between "no collection" and "an empty collection", because that model asked for it. Dictionaries are
+/// left alone — an absent map is not the same defect — and <see langword="string"/> is excluded despite being an
+/// <see cref="IEnumerable"/>. A member that carries its own <see cref="BsonDefaultValueAttribute"/> has stated what it
+/// wants and is skipped entirely.
+/// </para>
+/// <para>
+/// The convention is registered under <see cref="ConventionPacks.ReadModelCollectionsNeverNull"/> and scoped to
+/// <c>[ReadModel]</c> types, so it can be turned off per type with
+/// <c>[IgnoreConventions(ConventionPacks.ReadModelCollectionsNeverNull)]</c>.
+/// </para>
+/// </remarks>
+public class ReadModelCollectionsNeverNullConvention : ConventionBase, IMemberMapConvention
+{
+    static readonly HashSet<Type> _setDefinitions =
+    [
+        typeof(HashSet<>),
+        typeof(ISet<>),
+        typeof(IReadOnlySet<>)
+    ];
+
+    static readonly HashSet<Type> _listDefinitions =
+    [
+        typeof(List<>),
+        typeof(IList<>),
+        typeof(ICollection<>),
+        typeof(IEnumerable<>),
+        typeof(IReadOnlyList<>),
+        typeof(IReadOnlyCollection<>)
+    ];
+
+    /// <summary>
+    /// Applies the convention to a member map, giving a declared non-nullable collection an empty value for both an
+    /// absent element and a stored null.
+    /// </summary>
+    /// <param name="memberMap">The <see cref="BsonMemberMap"/> to apply to.</param>
+    public void Apply(BsonMemberMap memberMap)
+    {
+        if (memberMap.MemberInfo.IsDefined(typeof(BsonDefaultValueAttribute), true) ||
+            !IsDeclaredNonNullable(memberMap.MemberInfo) ||
+            !TryGetEmptyValueFactory(memberMap.MemberType, out var emptyValueFactory))
+        {
+            return;
+        }
+
+        // The driver skips a member's serializer entirely when the element is absent and reaches for the default value
+        // instead, so the two halves cover different documents and both are needed. A factory rather than a shared
+        // instance, because the default is handed to every instance the driver materializes.
+        var serializer = WrapWithNullToEmpty(memberMap.GetSerializer(), emptyValueFactory);
+        memberMap.SetDefaultValue(emptyValueFactory).SetSerializer(serializer);
+    }
+
+    static IBsonSerializer WrapWithNullToEmpty(IBsonSerializer serializer, Func<object> emptyValueFactory) =>
+        (IBsonSerializer)Activator.CreateInstance(
+            typeof(NullToEmptyCollectionSerializer<>).MakeGenericType(serializer.ValueType),
+            serializer,
+            emptyValueFactory)!;
+
+    static bool IsDeclaredNonNullable(MemberInfo member)
+    {
+        // NullabilityInfoContext is documented as not thread safe and class maps are built on demand from whichever
+        // thread got there first, so it is created per call rather than shared.
+        var nullabilityContext = new NullabilityInfoContext();
+        var nullability = member switch
+        {
+            PropertyInfo property => nullabilityContext.Create(property),
+            FieldInfo field => nullabilityContext.Create(field),
+            _ => null
+        };
+
+        return nullability?.ReadState == NullabilityState.NotNull;
+    }
+
+    static bool TryGetEmptyValueFactory(Type memberType, out Func<object> emptyValueFactory)
+    {
+        emptyValueFactory = null!;
+
+        // string is the classic trap here — it is an IEnumerable<char> and would otherwise be replaced with an empty
+        // list the member cannot even hold.
+        if (memberType == typeof(string) || !memberType.IsAssignableTo(typeof(IEnumerable)) || IsDictionary(memberType))
+        {
+            return false;
+        }
+
+        if (memberType.IsArray && memberType.GetArrayRank() == 1)
+        {
+            var elementType = memberType.GetElementType()!;
+            emptyValueFactory = () => Array.CreateInstance(elementType, 0);
+            return true;
+        }
+
+        if (!memberType.IsGenericType)
+        {
+            return false;
+        }
+
+        var definition = memberType.GetGenericTypeDefinition();
+        var elementTypeArgument = memberType.GetGenericArguments()[0];
+
+        // Deliberately an allow list rather than "anything enumerable": the empty value is assigned straight into the
+        // member, so a shape we cannot construct something assignable for must be left as it is rather than guessed at.
+        if (_setDefinitions.Contains(definition))
+        {
+            var setType = typeof(HashSet<>).MakeGenericType(elementTypeArgument);
+            emptyValueFactory = () => Activator.CreateInstance(setType)!;
+            return true;
+        }
+
+        if (_listDefinitions.Contains(definition))
+        {
+            var listType = typeof(List<>).MakeGenericType(elementTypeArgument);
+            emptyValueFactory = () => Activator.CreateInstance(listType)!;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a type is a dictionary shape.
+    /// </summary>
+    /// <param name="type">The <see cref="Type"/> to check.</param>
+    /// <returns>True if the type is a dictionary; false otherwise.</returns>
+    /// <remarks>
+    /// The allow lists above already leave every dictionary shape alone, so this states the invariant rather than
+    /// carrying it: whatever those lists grow to hold, a map is never something this convention fills in.
+    /// </remarks>
+    static bool IsDictionary(Type type) =>
+        type.IsAssignableTo(typeof(IDictionary)) ||
+        IsDictionaryInterface(type) ||
+        Array.Exists(type.GetInterfaces(), IsDictionaryInterface);
+
+    static bool IsDictionaryInterface(Type type) =>
+        type.IsGenericType &&
+        (type.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+         type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>));
+}


### PR DESCRIPTION
## Fixed

- A read model's non-nullable collection property reads back as empty rather than `null` when queried through `IMongoCollection<T>`, whether the stored document omits the field or stores `null`