### PR TITLE
Align with Chronicle 16.19.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
          advisory (GHSA-v5pm-xwqc-g5wc). Pin to the patched 2.x release. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="16.16.0" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.16.0" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.16.0" />
+    <PackageVersion Include="Cratis.Chronicle" Version="16.19.2" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.19.2" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.19.2" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.17.1" />
     <PackageVersion Include="Cratis.Screenplay" Version="1.5.2" />

--- a/Source/DotNET/Chronicle.Testing/Commands/EventLogForScenario.cs
+++ b/Source/DotNET/Chronicle.Testing/Commands/EventLogForScenario.cs
@@ -65,6 +65,9 @@ internal sealed class EventLogForScenario(IEventLog inner, IUnitOfWorkManager un
     public Task<EventSequenceNumber> GetTailSequenceNumberForObserver(Type type) => inner.GetTailSequenceNumberForObserver(type);
 
     /// <inheritdoc/>
+    public Task Revise(EventSequenceNumber sequenceNumber, object @event) => inner.Revise(sequenceNumber, @event);
+
+    /// <inheritdoc/>
     public Task Redact(EventSequenceNumber sequenceNumber, RedactionReason reason) => inner.Redact(sequenceNumber, reason);
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Fixed

- Command and read-model scenarios work again against current Chronicle releases. Arc was built against an older Chronicle that predates `IEventSequence.Revise`, so the scenario event log did not implement it — every scenario-based specification failed at construction with a `TypeLoadException` once an application upgraded Chronicle.