### PR TITLE
Update Cratis.Screenplay to 2.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.19.2" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.17.1" />
-    <PackageVersion Include="Cratis.Screenplay" Version="2.0.0" />
+    <PackageVersion Include="Cratis.Screenplay" Version="2.1.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.16.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.17.1" />
-    <PackageVersion Include="Cratis.Screenplay" Version="1.5.2" />
+    <PackageVersion Include="Cratis.Screenplay" Version="1.8.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.19.2" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.17.1" />
-    <PackageVersion Include="Cratis.Screenplay" Version="1.8.0" />
+    <PackageVersion Include="Cratis.Screenplay" Version="2.0.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />

--- a/Source/DotNET/Screenplay.Specs/IntegrationTesting.cs
+++ b/Source/DotNET/Screenplay.Specs/IntegrationTesting.cs
@@ -67,6 +67,51 @@ public static class IntegrationTesting
             }
         }
 
+        namespace Cratis.Chronicle.Testing.ReadModels
+        {
+            public class ReadModelScenario<TReadModel>
+                where TReadModel : class
+            {
+                public TReadModel? Instance => null;
+
+                public ReadModelScenarioGivenBuilder<TReadModel> Given => new();
+            }
+
+            public class ReadModelScenarioGivenBuilder<TReadModel>
+                where TReadModel : class
+            {
+                public ReadModelSourceGivenBuilder<TReadModel> ForEventSource(EventSourceId eventSourceId) => new();
+
+                public ReadModelSourceGivenBuilder<TReadModel> ForEventSourceId(EventSourceId eventSourceId) => new();
+            }
+
+            public class ReadModelSourceGivenBuilder<TReadModel>
+                where TReadModel : class
+            {
+                public Task Events(params object[] events) => Task.CompletedTask;
+
+                public Task ReadModel(TReadModel readModel) => Task.CompletedTask;
+            }
+        }
+
+        namespace Cratis.Chronicle.Testing.Reactors
+        {
+            public class ReactorScenario<TReactor>
+            {
+                public ReactorScenarioGivenBuilder<TReactor> Given => new();
+            }
+
+            public class ReactorScenarioGivenBuilder<TReactor>
+            {
+                public ReactorSourceGivenBuilder<TReactor> ForEventSource(EventSourceId eventSourceId) => new();
+            }
+
+            public class ReactorSourceGivenBuilder<TReactor>
+            {
+                public Task Events(params object[] events) => Task.CompletedTask;
+            }
+        }
+
         namespace Cratis.Chronicle.XUnit.Integration
         {
             public static class HttpClientExtensions
@@ -80,6 +125,23 @@ public static class IntegrationTesting
 
         namespace Cratis.Chronicle.Testing.EventSequences
         {
+            public class EventScenario
+            {
+                public EventScenarioGivenBuilder Given => new();
+
+                public IEventSequence EventSequence => null!;
+            }
+
+            public class EventScenarioGivenBuilder
+            {
+                public EventSourceGivenBuilder ForEventSource(EventSourceId eventSourceId) => new();
+            }
+
+            public class EventSourceGivenBuilder
+            {
+                public Task Events(params object[] events) => Task.CompletedTask;
+            }
+
             public static class EventSequenceShouldExtensions
             {
                 public static void ShouldHaveAppendedEvent<TEvent>(this IEventSequence sequence, EventSourceId eventSourceId)

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryApplication.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryApplication.cs
@@ -30,7 +30,8 @@ public static class LibraryApplication
             Name,
             LibraryConcepts.All(),
             LibraryConcepts.Policies(),
-            Slices());
+            Slices(),
+            []);
 
     /// <summary>
     /// Declares every slice of the application.

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_handed_an_abstract_collaborator.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_handed_an_abstract_collaborator.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Arc decides what a caller sends by asking the container whether a parameter's type is a service, which source
+/// cannot answer - so what is asked instead is whether a caller could send one at all. An interface cannot be sent
+/// and neither can an abstract type: <c>TimeProvider</c>, the clock a query measures a threshold against, is
+/// abstract rather than an interface, and reached the document as a parameter typed by a name it never declares and
+/// that no caller has ever sent.
+/// </summary>
+public class a_query_handed_an_abstract_collaborator : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        public abstract class Clock
+        {
+            public abstract DateTimeOffset Now { get; }
+        }
+
+        [ReadModel]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public static IEnumerable<Author> AuthorsSince(string name, TimeProvider time, Clock clock) => [];
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    QueryModel _query;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(("Library/Authors/Listing/Listing.cs", Source));
+        _query = _analysis.Slice().Queries.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Listing/Listing.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_key_the_query_by_what_the_caller_sends() => _query.By!.Name.ShouldEqual("name");
+    [Fact] void should_leave_out_the_clock_the_host_hands_it() => _query.Filters.ShouldBeEmpty();
+    [Fact] void should_declare_nothing_for_a_type_no_caller_sends() => _analysis.Model.Concepts.Any(_ => _.Name == "TimeProvider" || _.Name == "Clock").ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_record_no_type_declaration_can_be_written_for.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_record_no_type_declaration_can_be_written_for.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Types;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A record an artifact carries is declared as a type, which leaves the two records no declaration can be written
+/// for: one carrying no value at all, whose body would be empty, and one whose simple name something else is already
+/// declared under, whose declaration would say the same word twice. Both leave a property naming a shape the document
+/// never introduces, and which of the two it was is worth saying because only one of them is closed by renaming
+/// something.
+/// </summary>
+public class a_record_no_type_declaration_can_be_written_for : Specification
+{
+    const string Source = """
+        using System;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration;
+
+        public record AuthorId(Guid Value) : ConceptAs<Guid>(Value);
+
+        public record Nothing();
+
+        public record Shelf(AuthorId Owner);
+
+        [EventType]
+        public record AuthorRegistered(AuthorId Id, Nothing Empty, Shelf Where, Elsewhere.Shelf Other);
+        """;
+
+    const string Elsewhere = """
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration.Elsewhere;
+
+        public record Shelf(BookTitle Title);
+
+        public record BookTitle(string Value) : ConceptAs<string>(Value);
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Source),
+        ("Library/Authors/Registration/Elsewhere.cs", Elsewhere)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    IEnumerable<ScreenplayDiagnostic> Shapes =>
+        _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.UndeclarableShape);
+
+    ScreenplayDiagnostic Shape(string name) => Shapes.First(_ => _.Message.Contains(name, StringComparison.Ordinal));
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_declare_the_shape_it_could_write_one_for() => _analysis.Model.Types.Select(_ => _.Name).ShouldContainOnly(["Shelf"]);
+    [Fact] void should_declare_the_first_of_two_records_sharing_a_name() => _analysis.Model.Types.Single().Properties.Select(_ => _.Name).ShouldContainOnly(["Owner"]);
+    [Fact] void should_report_every_shape_it_could_not_declare() => Shapes.Count().ShouldEqual(2);
+    [Fact] void should_say_a_record_carrying_nothing_has_nothing_to_declare() => Shape("Nothing").Message.Contains(ShapeRegistry.CarriesNothing, StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_name_the_record_that_took_the_name_first() => Shape("Elsewhere.Shelf").Message.Contains("'Library.Authors.Registration.Shelf' is already declared as 'Shelf'", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_report_it_as_a_warning() => Shapes.All(_ => _.Severity == ScreenplayDiagnosticSeverity.Warning).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_holding_a_scenario_with_no_counterpart.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_holding_a_scenario_with_no_counterpart.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An application specifies its slices through four scenarios, and the language holds two of them. A scenario
+/// appending an event states the append as its action, and a when names a command and nothing else; a scenario
+/// driving a reactor says what a collaborator was asked to do. Neither can be written down - but both hold a
+/// scenario, which is what says a specification is about the behavior of the slice rather than the inside of it, so
+/// a document silent about them reads exactly like a slice nobody specified.
+/// </summary>
+public class a_specification_holding_a_scenario_with_no_counterpart : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Appending = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_claiming_a_name;
+
+        public class and_the_name_was_already_claimed
+        {
+            readonly EventScenario _scenario = new();
+
+            async Task Establish() =>
+                await _scenario.Given.ForEventSource(EventSourceId.New()).Events(new AuthorRegistered("Jane Austen"));
+
+            void Because() => _scenario.EventSequence.ShouldHaveTailSequenceNumber(0);
+
+            [Fact] void should_hold_one_event() => _scenario.EventSequence.ShouldHaveTailSequenceNumber(0);
+        }
+        """;
+
+    const string Reacting = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.Reactors;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_an_author_is_registered;
+
+        public class Notifier
+        {
+        }
+
+        public class and_the_librarian_is_notified
+        {
+            readonly ReactorScenario<Notifier> _scenario = new();
+
+            async Task Because() =>
+                await _scenario.Given.ForEventSource(EventSourceId.New()).Events(new AuthorRegistered("Jane Austen"));
+
+            [Fact] void should_notify_the_librarian() => "notified".ShouldEqualTheExpected("notified");
+        }
+
+        public static class Assertions
+        {
+            public static void ShouldEqualTheExpected(this string actual, string expected)
+            {
+            }
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Registration/Registration.cs", Slice),
+        ("Library/Authors/Registration/when_claiming_a_name/and_the_name_was_already_claimed.cs", Appending),
+        ("Library/Authors/Registration/when_an_author_is_registered/and_the_librarian_is_notified.cs", Reacting),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    IEnumerable<ScreenplayDiagnostic> Reported =>
+        _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.ScenarioWithoutCounterpart);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_specify_the_slice_by_nothing() => _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.ShouldBeEmpty();
+    [Fact] void should_report_every_scenario_it_left_out() => Reported.Count().ShouldEqual(2);
+    [Fact] void should_report_it_as_a_warning() => Reported.All(_ => _.Severity == ScreenplayDiagnosticSeverity.Warning).ShouldBeTrue();
+    [Fact] void should_name_the_scenario_that_appends() => Reported.Any(_ => _.Message.Contains("'and_the_name_was_already_claimed' is written as a EventScenario", StringComparison.Ordinal)).ShouldBeTrue();
+    [Fact] void should_name_the_scenario_that_reacts() => Reported.Any(_ => _.Message.Contains("'and_the_librarian_is_notified' is written as a ReactorScenario", StringComparison.Ordinal)).ShouldBeTrue();
+    [Fact] void should_say_where_each_one_lives() => Reported.All(_ => _.Location!.StartsWith("Library.Authors.Registration", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_read_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_read_model.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A specification driving a read model issues no command - the events are what happened, and what followed is the
+/// model they built. That is the two halves the language already holds, so it is read as one: given the events, then
+/// the read model the scenario says it is of. Where the events are written differs from a specification of a command,
+/// which sets its world up and then acts: here the events are the action, and are routinely written straight into it.
+/// </summary>
+public class a_specification_of_a_read_model : Specification
+{
+    const string Slice = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [EventType]
+        public record AuthorArchived();
+
+        [ReadModel]
+        [FromEvent<AuthorRegistered>]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public static IEnumerable<Author> All() => [];
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.ReadModels;
+        using Xunit;
+
+        namespace Library.Authors.Listing.when_an_author_is_archived;
+
+        public class and_the_author_was_registered_first
+        {
+            readonly ReadModelScenario<Author> _scenario = new();
+
+            async Task Because() =>
+                await _scenario.Given
+                    .ForEventSource(EventSourceId.New())
+                    .Events(new AuthorRegistered("Jane Austen"), new AuthorArchived());
+
+            [Fact] void should_hold_the_author() => _scenario.Instance!.Id.ShouldEqualTheExpected(string.Empty);
+        }
+
+        public static class Assertions
+        {
+            public static void ShouldEqualTheExpected(this string actual, string expected)
+            {
+            }
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Listing/Listing.cs", Slice),
+        ("Library/Authors/Listing/when_an_author_is_archived/and_the_author_was_registered_first.cs", Scenario),
+        (IntegrationTesting.Path, IntegrationTesting.Source)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+    SpecificationModel _specification;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(_sources);
+        _specification = _analysis.Model.Slices.Single(_ => _.Name == "Listing").Specifications.Single();
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_state_what_had_happened() => _specification.Given.Select(_ => _.Name).ShouldContainOnly(["AuthorArchived", "AuthorRegistered"]);
+    [Fact] void should_read_the_events_from_where_the_action_is() => _specification.Given.Count().ShouldEqual(2);
+    [Fact] void should_state_them_as_events() => _specification.Given.All(_ => _.Kind == SpecificationStateKind.Event).ShouldBeTrue();
+    [Fact] void should_issue_no_command() => _specification.When.ShouldBeNull();
+    [Fact] void should_say_the_read_model_followed() => _specification.Then.Single().Name.ShouldEqual("Author");
+    [Fact] void should_state_it_as_a_read_model() => _specification.Then.Single().Kind.ShouldEqual(SpecificationStateKind.ReadModel);
+    [Fact] void should_report_no_scenario_left_out() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.UnreadableSpecification).ShouldBeFalse();
+    [Fact] void should_report_no_scenario_without_a_counterpart() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.ScenarioWithoutCounterpart).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/concepts_carried_only_inside_a_record.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/concepts_carried_only_inside_a_record.cs
@@ -7,10 +7,10 @@ using Cratis.Arc.Screenplay.Model;
 namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
 
 /// <summary>
-/// A record is referred to by name and never declared, so nothing inside it is ever named on its own. Collecting only
-/// the types written straight onto an artifact therefore lost every concept reached through one - and a concept marked
-/// as personal data lost that way leaves a document understating what the application holds about people, which is the
-/// one thing declaring concepts is most for. A concept can be declared wherever it was reached from, so it is.
+/// A record an artifact carries is declared as a <c>type</c> and everything inside it named on its own. Collecting
+/// only the types written straight onto an artifact lost every concept reached through one - and a concept marked as
+/// personal data lost that way leaves a document understating what the application holds about people, which is the
+/// one thing declaring concepts is most for. Both are declared wherever they were reached from, so both are.
 /// </summary>
 public class concepts_carried_only_inside_a_record : Specification
 {
@@ -59,6 +59,8 @@ public class concepts_carried_only_inside_a_record : Specification
 
     ConceptModel Concept(string name) => _analysis.Model.Concepts.First(_ => _.Name == name);
 
+    TypeModel Shape(string name) => _analysis.Model.Types.First(_ => _.Name == name);
+
     IEnumerable<ScreenplayDiagnostic> Shapes =>
         _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.UndeclarableShape);
 
@@ -69,7 +71,10 @@ public class concepts_carried_only_inside_a_record : Specification
     [Fact] void should_declare_a_concept_carried_inside_a_record_a_collection_holds() => Concept("MentorNote").Primitive.ShouldEqual(ScreenplayPrimitive.String);
     [Fact] void should_declare_a_concept_only_a_read_model_carries() => Concept("ShelfCode").Primitive.ShouldEqual(ScreenplayPrimitive.String);
     [Fact] void should_walk_a_record_referring_to_itself_only_once() => _analysis.Model.Concepts.Select(_ => _.Name).ShouldContainOnly(["AuthorId", "ContactPreference", "FirstName", "MentorNote", "ShelfCode"]);
-    [Fact] void should_say_the_shape_of_a_record_a_property_carries_is_not_declared() => Shapes.Count().ShouldEqual(2);
-    [Fact] void should_name_the_records_it_could_not_declare() => Shapes.All(_ => _.Message.Contains("PersonalDetails", StringComparison.Ordinal) || _.Message.Contains("Mentorship", StringComparison.Ordinal)).ShouldBeTrue();
-    [Fact] void should_not_say_it_of_a_read_model_the_slice_describes() => Shapes.Any(_ => _.Message.Contains("Author'", StringComparison.Ordinal)).ShouldBeFalse();
+    [Fact] void should_declare_the_shape_of_every_record_a_property_carries() => _analysis.Model.Types.Select(_ => _.Name).ShouldContainOnly(["Mentorship", "PersonalDetails"]);
+    [Fact] void should_say_what_a_shape_carries() => Shape("PersonalDetails").Properties.Select(_ => _.Type.Name).ShouldContainOnly(["ContactPreference", "FirstName"]);
+    [Fact] void should_declare_a_record_referring_to_itself_once() => Shape("Mentorship").Properties.Select(_ => _.Name).ShouldContainOnly(["Next", "Note"]);
+    [Fact] void should_say_a_value_that_may_be_absent_is_optional() => Shape("Mentorship").Properties.Single(_ => _.Name == "Next").Type.IsOptional.ShouldBeTrue();
+    [Fact] void should_not_declare_the_shape_of_a_read_model_the_slice_describes() => _analysis.Model.Types.Any(_ => _.Name == "Author").ShouldBeFalse();
+    [Fact] void should_report_no_shape_it_could_not_declare() => Shapes.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_AuthorizeSyntaxBuilder/when_building/what_a_command_requires_of_the_caller.cs
+++ b/Source/DotNET/Screenplay.Specs/for_AuthorizeSyntaxBuilder/when_building/what_a_command_requires_of_the_caller.cs
@@ -3,6 +3,8 @@
 
 using Cratis.Arc.Screenplay.Emission.Policies;
 using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Printing;
 using Cratis.Screenplay.Syntax;
 
 namespace Cratis.Arc.Screenplay.for_AuthorizeSyntaxBuilder.when_building;
@@ -12,10 +14,17 @@ namespace Cratis.Arc.Screenplay.for_AuthorizeSyntaxBuilder.when_building;
 /// authenticated policy stands in only when nothing else was asked for. Adding it alongside a role would quietly
 /// turn "any librarian" into "any librarian who is also authenticated by name", which is a different rule.
 /// </summary>
+/// <remarks>
+/// The shape of the requirement carries as much as the names in it. <c>and</c> binds tighter than <c>or</c>, so the
+/// alternatives have to sit nested under the demand: a flat <c>Archivist or Librarian and SeniorStaff</c> reads back
+/// as "any archivist, or anyone who is senior staff", which lets in a caller that neither the roles nor the policy
+/// admits on its own. That is why the tree is asserted here branch by branch and not only by the policies it names.
+/// </remarks>
 public class what_a_command_requires_of_the_caller : Specification
 {
     AuthorizeSyntaxBuilder _builder;
     AuthorizeSyntax? _withRoles;
+    AuthorizeSyntax? _withRolesAndAPolicy;
     AuthorizeSyntax? _withNothingNamed;
     AuthorizeSyntax? _withNothingRequired;
 
@@ -24,14 +33,53 @@ public class what_a_command_requires_of_the_caller : Specification
     void Because()
     {
         _withRoles = _builder.Build(new AuthorizationModel(true, ["Librarian", "Archivist"]));
+        _withRolesAndAPolicy = _builder.Build(new AuthorizationModel(true, ["Librarian", "Archivist"]) { Policies = ["SeniorStaff"] });
         _withNothingNamed = _builder.Build(new AuthorizationModel(true, []));
         _withNothingRequired = _builder.Build(null);
     }
 
-    [Fact] void should_reference_every_role_it_was_given() => _withRoles!.Policies.Select(_ => _.Name).ShouldEqual(["Archivist", "Librarian"]);
-    [Fact] void should_offer_the_roles_as_alternatives() => _withRoles!.Policies.Select(_ => _.IsAlternative).ShouldEqual([false, true]);
-    [Fact] void should_not_add_authentication_alongside_a_role() => _withRoles!.Policies.Select(_ => _.Name).ShouldNotContain(AuthorizeSyntaxBuilder.AuthenticatedPolicy);
-    [Fact] void should_stand_in_with_authentication_when_nothing_was_named() => _withNothingNamed!.Policies.Select(_ => _.Name).ShouldEqual([AuthorizeSyntaxBuilder.AuthenticatedPolicy]);
+    [Fact] void should_reference_every_role_it_was_given() => _withRoles!.References().Select(_ => _.Name).ShouldEqual(["Archivist", "Librarian"]);
+    [Fact] void should_offer_the_roles_as_alternatives() => Operator(_withRoles!.Requirement).ShouldEqual(LogicalOperator.Or);
+    [Fact] void should_not_add_authentication_alongside_a_role() => _withRoles!.References().Select(_ => _.Name).ShouldNotContain(AuthorizeSyntaxBuilder.AuthenticatedPolicy);
+
+    [Fact] void should_demand_the_named_policy_on_top_of_the_roles() => Operator(_withRolesAndAPolicy!.Requirement).ShouldEqual(LogicalOperator.And);
+    [Fact] void should_keep_the_roles_alternatives_to_each_other_under_that_demand() => Operator(Left(_withRolesAndAPolicy!.Requirement)).ShouldEqual(LogicalOperator.Or);
+    [Fact] void should_hold_every_role_on_the_side_the_demand_is_asked_of() => Names(Left(_withRolesAndAPolicy!.Requirement)).ShouldEqual(["Archivist", "Librarian"]);
+    [Fact] void should_ask_for_the_policy_itself_rather_than_as_another_alternative() => Names(Right(_withRolesAndAPolicy!.Requirement)).ShouldEqual(["SeniorStaff"]);
+    [Fact] void should_group_the_alternatives_where_the_document_would_otherwise_read_them_apart() =>
+        AuthorizeLine(_withRolesAndAPolicy!).ShouldEqual("authorize (Archivist or Librarian) and SeniorStaff");
+
+    [Fact] void should_stand_in_with_authentication_when_nothing_was_named() => _withNothingNamed!.References().Select(_ => _.Name).ShouldEqual([AuthorizeSyntaxBuilder.AuthenticatedPolicy]);
     [Fact] void should_build_nothing_when_nothing_is_required() => _withNothingRequired.ShouldBeNull();
-    [Fact] void should_record_every_policy_the_document_has_to_declare() => _builder.Referenced.ShouldContainOnly(["Archivist", "Librarian", AuthorizeSyntaxBuilder.AuthenticatedPolicy]);
+    [Fact] void should_record_every_policy_the_document_has_to_declare() => _builder.Referenced.ShouldContainOnly(["Archivist", "Librarian", "SeniorStaff", AuthorizeSyntaxBuilder.AuthenticatedPolicy]);
+
+    /// <summary>
+    /// Prints a document carrying the requirement and hands back the line the caller reads it on.
+    /// </summary>
+    /// <param name="authorize">The <see cref="AuthorizeSyntax"/> to print.</param>
+    /// <returns>The <c>authorize</c> line as it appears in the document.</returns>
+    /// <remarks>
+    /// The tree is asserted branch by branch above; this asks the language's own printer what that tree says out
+    /// loud, which is the thing a reader of the document - and the compiler reading it back - actually goes by.
+    /// </remarks>
+    static string AuthorizeLine(AuthorizeSyntax authorize)
+    {
+        var command = new CommandSyntax("ReserveBook", [], authorize, [], [], null, SourceLocation.Start);
+        var slice = new SliceSyntax(SliceType.StateChange, "Reserving", [], [command], [], [], [], [], [], [], [], SourceLocation.Start);
+        var module = new ModuleSyntax("Library", [], [new FeatureSyntax("Lending", [], [slice], SourceLocation.Start)], SourceLocation.Start);
+        var printed = new ScreenplayPrinter().Print(new ApplicationSyntax([], [], [], [module], SourceLocation.Start));
+
+        return printed.Split('\n').Select(_ => _.Trim()).Single(_ => _.StartsWith("authorize ", StringComparison.Ordinal));
+    }
+
+    static LogicalOperator Operator(PolicyRequirementSyntax requirement) => ((LogicalPolicyRequirementSyntax)requirement).Operator;
+
+    static PolicyRequirementSyntax Left(PolicyRequirementSyntax requirement) => ((LogicalPolicyRequirementSyntax)requirement).Left;
+
+    static PolicyRequirementSyntax Right(PolicyRequirementSyntax requirement) => ((LogicalPolicyRequirementSyntax)requirement).Right;
+
+    static IEnumerable<string> Names(PolicyRequirementSyntax requirement) =>
+        requirement is LogicalPolicyRequirementSyntax logical
+            ? Names(logical.Left).Concat(Names(logical.Right))
+            : [((PolicyReferenceSyntax)requirement).Name];
 }

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/a_concept_carrying_personal_data.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/a_concept_carrying_personal_data.cs
@@ -28,6 +28,6 @@ public class a_concept_carrying_personal_data : given.a_concept_syntax_builder
         _unmarked = concepts.First(_ => _.Name == "BookTitle");
     }
 
-    [Fact] void should_mark_the_concept_carrying_personal_data() => _marked.Attributes.ShouldContainOnly([ConceptSyntaxBuilder.PersonallyIdentifiableInformation]);
+    [Fact] void should_mark_the_concept_carrying_personal_data() => _marked.AttributeNames.ShouldContainOnly([ConceptSyntaxBuilder.PersonallyIdentifiableInformation]);
     [Fact] void should_not_mark_a_concept_that_carries_none() => _unmarked.Attributes.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_number.cs
+++ b/Source/DotNET/Screenplay.Specs/for_LiteralConverter/when_converting_a_number.cs
@@ -63,7 +63,7 @@ public class when_converting_a_number : Specification
                     SourceLocation.Start)
             ],
             [],
-            null,
+            [],
             [],
             [],
             [],

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_scenario_that_issues_no_command.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_scenario_that_issues_no_command.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Arc.Screenplay.Verification;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// A scenario about a read model issues no command - the events are what happened, and what followed is the model
+/// they built. The language holds that as a specification with no <c>when</c> at all rather than as one naming an
+/// empty command, so what comes out has to be the first of those and not the second.
+/// </summary>
+public class a_scenario_that_issues_no_command : given.an_emitter
+{
+    ApplicationModel _model;
+    ScreenplayEmission _emission;
+    RoundTripResult _roundTrip;
+
+    void Establish() =>
+        _model = LibraryApplication.Build() with
+        {
+            Slices =
+            [
+                .. LibraryApplication.Slices(),
+                SliceModel.Empty("Library.Authors.Watching", "Watching", SliceKind.StateView) with
+                {
+                    Events = [new("AuthorFollowed", [], [])],
+                    Specifications =
+                    [
+                        new(
+                            "WhenAnAuthorIsFollowed",
+                            [new("AuthorFollowed", SpecificationStateKind.Event, [])],
+                            null,
+                            [new("AuthorWatch", SpecificationStateKind.ReadModel, [])],
+                            [])
+                    ]
+                }
+            ]
+        };
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    [Fact] void should_compile_without_errors() => _roundTrip.Errors.ShouldBeEmpty();
+    [Fact] void should_compile_without_any_diagnostics() => _roundTrip.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _roundTrip.Reprinted.ShouldEqual(_roundTrip.Printed);
+    [Fact] void should_state_what_had_happened() => _emission.Source.Contains("given AuthorFollowed", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_say_the_read_model_followed() => _emission.Source.Contains("then readmodel AuthorWatch", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_write_no_command_at_all() => _emission.Application.Modules.Single().Features.SelectMany(_ => _.Slices).SelectMany(_ => _.Specifications).Single(_ => _.Name == "WhenAnAuthorIsFollowed").When.ShouldBeNull();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/an_application_carrying_records.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/an_application_carrying_records.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission;
+using Cratis.Arc.Screenplay.Library;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Arc.Screenplay.Verification;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayEmitter.when_emitting;
+
+/// <summary>
+/// A record an artifact carries is a shape the document declares in its own right, so the property naming it resolves
+/// to a declaration rather than to nothing. A name is what two shapes finally collide under, and it is emission that
+/// decides what a name becomes - so a shape whose name a concept was already written under is the one that has to be
+/// left out here, because a document declaring one word twice does not compile.
+/// </summary>
+public class an_application_carrying_records : given.an_emitter
+{
+    ApplicationModel _model;
+    ScreenplayEmission _emission;
+    RoundTripResult _roundTrip;
+
+    void Establish() =>
+        _model = LibraryApplication.Build() with
+        {
+            Types =
+            [
+                new("ShelfPosition", [new("Aisle", new("CopyCount", false, false)), new("Note", new("String", false, true))]),
+                new("BookTitle", [new("Value", new("String", false, false))])
+            ],
+            Slices =
+            [
+                .. LibraryApplication.Slices(),
+                SliceModel.Empty("Library.Inventory.Shelving", "Shelving", SliceKind.StateChange) with
+                {
+                    Events = [new("BookShelved", [new("Position", new("ShelfPosition", false, false))], [])]
+                }
+            ]
+        };
+
+    void Because()
+    {
+        _emission = _emitter.Emit(_model, _options);
+        _roundTrip = RoundTrip.For(_emission.Application);
+    }
+
+    [Fact] void should_compile_without_errors() => _roundTrip.Errors.ShouldBeEmpty();
+    [Fact] void should_compile_without_any_diagnostics() => _roundTrip.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_print_the_same_text_on_a_second_pass() => _roundTrip.Reprinted.ShouldEqual(_roundTrip.Printed);
+    [Fact] void should_declare_the_shape() => _emission.Source.Contains("type ShelfPosition", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_say_what_the_shape_carries() => _emission.Source.Contains("  aisle CopyCount", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_say_a_value_may_be_absent() => _emission.Source.Contains("  note String?", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_leave_out_a_shape_a_concept_is_already_declared_as() => _emission.Source.Contains("type BookTitle", StringComparison.Ordinal).ShouldBeFalse();
+    [Fact] void should_say_which_shape_it_left_out() => _emission.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.UndeclarableShape).Message.Contains("BookTitle", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_document_the_language_rejects.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_document_the_language_rejects.cs
@@ -16,8 +16,11 @@ namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.given;
 /// Every way of emitting a rejected document that anyone has found has since been fixed, which is exactly why the
 /// check exists - it has to hold for the one nobody has found yet. Replacing the printed text is the smallest seam
 /// that produces one: the analysis, the emitter, the syntax tree the emitter builds and the compiler reading the
-/// text back are all the real ones, and nothing on the path a host takes is substituted. The text is the defect that
-/// shipped, which is a command property called <c>Description</c> written out as the directive of the same name.
+/// text back are all the real ones, and nothing on the path a host takes is substituted. The text is the shape the
+/// defect that shipped took - a name written where the grammar holds a quoted description - moved to a body that
+/// reads <c>description</c> as nothing but the directive. The command body it was written in no longer rejects it:
+/// the language now reads a directive-shaped property line as the property, so the exact text that shipped is
+/// something it holds rather than something it turns away.
 /// </remarks>
 public class a_document_the_language_rejects : Specification
 {
@@ -28,8 +31,8 @@ public class a_document_the_language_rejects : Specification
         domain Library
         module Library
           feature Authors
-            slice StateChange Registration
-              command RegisterAuthor
+            slice StateView Registration
+              query AuthorById => Author
                 description RequestDescription
         """;
 

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_command_naming_a_policy_an_identifier_cannot_hold.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_a_command_naming_a_policy_an_identifier_cannot_hold.cs
@@ -47,13 +47,16 @@ public class from_a_command_naming_a_policy_an_identifier_cannot_hold : Specific
 
     bool HasLine(string text) => _result.Source.Split('\n').Any(_ => string.Equals(_.Trim(), text, StringComparison.Ordinal));
 
+    string Authorize() => _result.Source.Split('\n').Select(_ => _.Trim()).Single(_ => _.StartsWith("authorize ", StringComparison.Ordinal));
+
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
     [Fact] void should_produce_a_document_that_compiles() => _compiled.Success.ShouldBeTrue();
     [Fact] void should_produce_a_document_the_compiler_says_nothing_about() => _compiled.Diagnostics.ShouldBeEmpty();
     [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
-    [Fact] void should_refer_to_the_policy_by_a_name_the_grammar_accepts() => HasLine("CanReserve").ShouldBeTrue();
+    [Fact] void should_refer_to_the_policy_by_a_name_the_grammar_accepts() => Authorize().Contains("CanReserve", StringComparison.Ordinal).ShouldBeTrue();
     [Fact] void should_declare_the_policy_it_refers_to() => HasLine("policy CanReserve").ShouldBeTrue();
-    [Fact] void should_refer_to_the_role_by_a_name_the_grammar_accepts() => HasLine("authorize Reader").ShouldBeTrue();
+    [Fact] void should_refer_to_the_role_by_a_name_the_grammar_accepts() => Authorize().Contains("Reader", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_demand_the_policy_on_top_of_the_role() => Authorize().ShouldEqual("authorize Reader and CanReserve");
     [Fact] void should_keep_the_role_the_application_really_names() => HasLine("require role \"reader\"").ShouldBeTrue();
     [Fact] void should_report_that_nothing_registers_the_policy() => _result.Diagnostics.Select(_ => _.Code).ShouldContainOnly([ScreenplayDiagnosticCodes.PolicyRequirementsUnrecoverable]);
 }

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_using_policies_and_aggregates.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_an_application_using_policies_and_aggregates.cs
@@ -34,10 +34,10 @@ public class from_the_source_of_an_application_using_policies_and_aggregates : S
     [Fact] void should_print_the_same_text_on_a_second_pass() => _reprinted.ShouldEqual(_result.Source);
     [Fact] void should_refer_to_the_policy_the_command_names() => Says("authorize CanReserve").ShouldBeTrue();
     [Fact] void should_declare_the_policy_it_refers_to() => Says("policy CanReserve").ShouldBeTrue();
-    [Fact] void should_declare_what_the_policy_requires() => HasLine("require role \"Librarian\" and claim \"branch\" matches central").ShouldBeTrue();
+    [Fact] void should_declare_what_the_policy_requires() => HasLine("require role \"Librarian\" and claim \"branch\" matches \"central\"").ShouldBeTrue();
     [Fact] void should_declare_the_several_values_of_one_requirement_as_alternatives() => HasLine("require role \"Librarian\" or role \"Archivist\"").ShouldBeTrue();
-    [Fact] void should_ask_for_a_role_before_the_policy_it_is_asked_with() => HasLine("authorize Librarian").ShouldBeTrue();
-    [Fact] void should_ask_for_the_policy_alongside_the_role() => HasLine("SeniorStaff").ShouldBeTrue();
+    [Fact] void should_ask_for_a_role_before_the_policy_it_is_asked_with() => HasLine("authorize Librarian and SeniorStaff").ShouldBeTrue();
+    [Fact] void should_demand_the_policy_on_top_of_the_role_rather_than_as_an_alternative() => HasLine("authorize Librarian or SeniorStaff").ShouldBeFalse();
     [Fact] void should_state_what_a_command_governed_by_an_aggregate_root_produces() => Says("produces BookReserved").ShouldBeTrue();
     [Fact] void should_map_the_produced_event_from_the_command_input() => Says("member = memberId").ShouldBeTrue();
     [Fact] void should_carry_the_message_of_a_length_range_on_its_lower_bound() => Says("isbn min 10 message \"An ISBN is between 10 and 13 characters\"").ShouldBeTrue();

--- a/Source/DotNET/Screenplay.Specs/for_SliceContent/when_checking_a_slice_with_nothing_declared.cs
+++ b/Source/DotNET/Screenplay.Specs/for_SliceContent/when_checking_a_slice_with_nothing_declared.cs
@@ -32,5 +32,5 @@ public class when_checking_a_slice_with_nothing_declared : Specification
     [Fact] void should_not_report_a_slice_carrying_only_a_description_as_empty() => SliceContent.IsEmpty(_withOnlyADescription).ShouldBeFalse();
 
     static SliceSyntax Slice(string? description) =>
-        new(SliceType.StateView, "Listing", [], [], [], null, [], [], [], [], [], SourceLocation.Start, description);
+        new(SliceType.StateView, "Listing", [], [], [], [], [], [], [], [], [], SourceLocation.Start, description);
 }

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -94,7 +94,8 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
                 options.Module ?? options.Domain ?? ScreenplayOptions.DefaultName,
                 whole.Types.Concepts,
                 new PolicyCatalog(ordered, domain, diagnostics).Declare(slices.SelectMany(AuthorizationsIn)),
-                slices)
+                slices,
+                whole.Types.Types)
             {
                 Imports = imports
             },

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
@@ -89,14 +89,23 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
     /// <param name="parameter">The parameter to check.</param>
     /// <returns>True when the parameter is input rather than infrastructure.</returns>
     /// <remarks>
-    /// An interface parameter is a collaborator the host injects, never something a caller can send, so it is not
-    /// part of the query's shape. Being an interface is not the whole of that though: a cancellation token, the page
-    /// asked for and the order asked for are all filled in by the host from the request rather than sent as
-    /// arguments, and all three are values rather than interfaces. Stating one as caller input puts a parameter in
-    /// the document that no caller sends, typed by a name the document never declares.
+    /// Arc decides this at run time by asking the container whether the parameter's type is a service, which is not a
+    /// question source can answer - so what is asked instead is whether a caller could possibly send one. An interface
+    /// and an abstract type both fail that outright: neither has a value to send, and both are how a collaborator the
+    /// host injects is written - <c>TimeProvider</c>, the clock a query measures a threshold against, is abstract
+    /// rather than an interface and reached the document as a parameter no caller has ever sent. Being uninstantiable
+    /// is not the whole of it though: a cancellation token, the page asked for and the order asked for are all filled
+    /// in by the host from the request, and all three are concrete values. Stating any of them as caller input puts a
+    /// parameter in the document that no caller sends, typed by a name the document never declares.
+    /// <para>
+    /// A concrete class the container happens to resolve still comes through as input, because nothing in the source
+    /// tells it apart from a value a caller sends. That is the residue of approximating a container lookup statically,
+    /// and it is the narrow side of the trade: a parameter wrongly stated is visible in the document, while one
+    /// wrongly dropped is not.
+    /// </para>
     /// </remarks>
     static bool IsInput(IParameterSymbol parameter) =>
-        parameter.Type.TypeKind != TypeKind.Interface &&
+        parameter.Type is { TypeKind: not TypeKind.Interface, IsAbstract: false } &&
         !Array.Exists(InfrastructureTypes, parameter.Type.Is);
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCalls.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCalls.cs
@@ -57,7 +57,7 @@ public static class SpecificationCalls
     /// <returns>True when the call states events.</returns>
     public static bool IsGivenEvents(IMethodSymbol method) =>
         (IsOn(method, WellKnownTypeNames.EventSequence) && (Named(method, AppendMethod) || Named(method, AppendManyMethod))) ||
-        (IsOn(method, WellKnownTypeNames.CommandScenarioSourceGivenBuilder) && Named(method, EventsMethod));
+        (OnAGivenBuilder(method) && Named(method, EventsMethod));
 
     /// <summary>
     /// Determines whether a call pins the read model a specification starts from.
@@ -65,7 +65,7 @@ public static class SpecificationCalls
     /// <param name="method">The method being called.</param>
     /// <returns>True when the call pins a read model.</returns>
     public static bool IsGivenReadModel(IMethodSymbol method) =>
-        IsOn(method, WellKnownTypeNames.CommandScenarioSourceGivenBuilder) && Named(method, ReadModelMethod);
+        OnAGivenBuilder(method) && Named(method, ReadModelMethod);
 
     /// <summary>
     /// Determines whether a call issues the command a specification is about.
@@ -100,6 +100,20 @@ public static class SpecificationCalls
 
         return Named(method, AppendMethod) ? EventParameter : EventsParameter;
     }
+
+    /// <summary>
+    /// Determines whether a method belongs to a builder stating what one event source had already seen.
+    /// </summary>
+    /// <param name="method">The method to check.</param>
+    /// <returns>True when the method belongs to one of them.</returns>
+    /// <remarks>
+    /// Both testing packages state the world the same way, through a builder reached from the scenario for one event
+    /// source, and the two builders differ only in which scenario handed them over. What a step says is the same
+    /// either way, so both are recognized here rather than each scenario reading its own.
+    /// </remarks>
+    static bool OnAGivenBuilder(IMethodSymbol method) =>
+        IsOn(method, WellKnownTypeNames.CommandScenarioSourceGivenBuilder) ||
+        IsOn(method, WellKnownTypeNames.ReadModelSourceGivenBuilder);
 
     /// <summary>
     /// Determines whether a method carries a name.

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCatalog.cs
@@ -38,8 +38,14 @@ public class SpecificationCatalog
         var placement = new SpecificationPlacement(slices);
         var bySlice = new Dictionary<string, List<SpecificationModel>>(StringComparer.Ordinal);
 
-        foreach (var type in catalog.Types.Where(reader.IsSpecification))
+        foreach (var type in catalog.Types)
         {
+            if (!reader.IsSpecification(type))
+            {
+                Report(reader.ScenarioWithoutCounterpart(type), type, diagnostics);
+                continue;
+            }
+
             if (placement.SliceOf(type) is not { } slice)
             {
                 diagnostics.Warning(
@@ -68,6 +74,30 @@ public class SpecificationCatalog
         _bySlice.TryGetValue(@namespace, out var specifications)
             ? specifications.OrderBy(_ => _.Name, StringComparer.Ordinal)
             : [];
+
+    /// <summary>
+    /// Reports a scenario a slice is specified by that the language has nowhere to put.
+    /// </summary>
+    /// <param name="scenario">The name of the scenario, or <see langword="null"/> when there is nothing to report.</param>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <remarks>
+    /// This is said before the specification is placed under a slice rather than after, because where it belongs is
+    /// beside the point: nothing of it is going into the document either way, and a scenario nobody hears about is
+    /// exactly as lost whichever namespace it sits in.
+    /// </remarks>
+    static void Report(string? scenario, INamedTypeSymbol type, ScreenplayDiagnostics diagnostics)
+    {
+        if (scenario is null)
+        {
+            return;
+        }
+
+        diagnostics.Warning(
+            ScreenplayDiagnosticCodes.ScenarioWithoutCounterpart,
+            $"The scenario '{type.Name}' is written as a {scenario}, which specifies the slice through something the language has nowhere to hold, so the whole of it was left out",
+            type.ToDisplayString());
+    }
 
     /// <summary>
     /// Adds a specification under the slice it belongs to.

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
@@ -87,10 +87,50 @@ public static class SpecificationMembers
     /// exactly why it is asked: a specification that holds a scenario and issues its command through a helper is one
     /// this cannot read, and saying so is the difference between a known gap and a silent one.
     /// </remarks>
-    public static bool HoldsAScenario(INamedTypeSymbol type) =>
+    public static bool HoldsAScenario(INamedTypeSymbol type) => Holds(type, WellKnownTypeNames.CommandScenario) is not null;
+
+    /// <summary>
+    /// Gets the read model a type is written as a scenario of.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>The read model, or <see langword="null"/> when the type holds no read model scenario.</returns>
+    /// <remarks>
+    /// A read model scenario says which read model it is about in its own type argument, which is the whole of what
+    /// the outcome of such a specification is: the events went in and this is what they built. Nothing in the body
+    /// has to be read to know it, so a scenario whose assertions are written in a way this cannot follow still says
+    /// exactly as much as the language holds for it.
+    /// </remarks>
+    public static ITypeSymbol? ReadModelOf(INamedTypeSymbol type) =>
+        Holds(type, WellKnownTypeNames.ReadModelScenario) is INamedTypeSymbol { TypeArguments.Length: 1 } scenario
+            ? scenario.TypeArguments[0]
+            : null;
+
+    /// <summary>
+    /// Gets the scenario a type holds of a kind Screenplay has no way to read.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>The name of the scenario, or <see langword="null"/> when the type holds none of them.</returns>
+    /// <remarks>
+    /// A scenario is what tells a specification of a slice apart from a unit level one about a collaborator, so a
+    /// type holding one is specifying the slice whether or not this can express what it says. Which of them it holds
+    /// is what the report needs: the gap between an append that is rejected and a reactor asked what it did is not
+    /// one gap, and a reader cannot act on being told only that something was left out.
+    /// </remarks>
+    public static string? ScenarioWithoutCounterpart(INamedTypeSymbol type) =>
+        Holds(type, WellKnownTypeNames.EventScenario)?.Name ??
+        Holds(type, WellKnownTypeNames.ReactorScenario)?.Name;
+
+    /// <summary>
+    /// Gets the scenario of a kind a type holds.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="fullMetadataName">The fully qualified metadata name of the scenario.</param>
+    /// <returns>The type of the scenario held, or <see langword="null"/> when the type holds none.</returns>
+    static ITypeSymbol? Holds(INamedTypeSymbol type, string fullMetadataName) =>
         ChainOf(type)
             .SelectMany(_ => _.GetMembers())
-            .Any(member => TypeOf(member).Is(WellKnownTypeNames.CommandScenario));
+            .Select(TypeOf)
+            .FirstOrDefault(held => held.Is(fullMetadataName));
 
     /// <summary>
     /// Determines whether a type declares a method itself.

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
@@ -29,15 +29,40 @@ public class SpecificationReader(Compilation compilation, ScreenplayDiagnostics 
     /// <returns>True when the type is a specification of the kind this reads.</returns>
     public bool IsSpecification(INamedTypeSymbol type)
     {
-        if (type is not { TypeKind: TypeKind.Class, IsAbstract: false, ContainingType: null })
+        if (!IsWrittenAsOne(type))
         {
             return false;
         }
 
         var steps = SpecificationMembers.StepsOf(type);
 
-        return SpecificationMembers.MethodsIn(steps, SpecificationMembers.BecauseMethod).Any() &&
-            (SpecificationMembers.HoldsAScenario(steps) || DrivesASlice(steps));
+        return SpecificationMembers.HoldsAScenario(steps) ||
+            SpecificationMembers.ReadModelOf(steps) is not null ||
+            DrivesASlice(steps);
+    }
+
+    /// <summary>
+    /// Gets the scenario a type specifies a slice by that Screenplay has no way to hold.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>The name of the scenario, or <see langword="null"/> when there is nothing to report.</returns>
+    /// <remarks>
+    /// A specification holding one of these is specifying the slice as much as any other - what it does is real, and
+    /// leaving it out without a word is the one thing the catalogue of codes exists to prevent. Two of the four
+    /// scenarios an application is written with have nowhere to go: a scenario appending an event states the append
+    /// itself as its action, and a <c>when</c> names a command and nothing else; a scenario driving a reactor says
+    /// what a collaborator was asked to do, which is a statement about the inside of the slice. Both are said rather
+    /// than recovered, because a document quietly missing four specifications in ten reads exactly like an
+    /// application that has none.
+    /// </remarks>
+    public string? ScenarioWithoutCounterpart(INamedTypeSymbol type)
+    {
+        if (!IsWrittenAsOne(type) || IsSpecification(type))
+        {
+            return null;
+        }
+
+        return SpecificationMembers.ScenarioWithoutCounterpart(SpecificationMembers.StepsOf(type));
     }
 
     /// <summary>
@@ -55,15 +80,20 @@ public class SpecificationReader(Compilation compilation, ScreenplayDiagnostics 
     {
         var location = type.ToDisplayString();
         var steps = SpecificationMembers.StepsOf(type);
+        var readModel = SpecificationMembers.ReadModelOf(steps);
         var draft = new SpecificationDraft();
         var stated = new ScreenplayDiagnostics();
 
         var reader = new SpecificationStepReader(compilation, new(stated, new GeneratedIdentities(compilation)));
-        reader.ReadGiven(steps, draft, name, location);
+        reader.ReadGiven(steps, draft, name, location, alsoWhereTheActionIs: readModel is not null);
         reader.ReadWhen(steps, draft, name, location);
         new SpecificationOutcomeReader(compilation, stated).Read(type, draft, name, location);
 
-        if (draft.When is null)
+        if (readModel is not null && draft.When is null)
+        {
+            ReadStateOfTheReadModel(readModel, draft);
+        }
+        else if (draft.When is null)
         {
             draft.CannotRead("the command it issues is put together somewhere this cannot read");
         }
@@ -85,6 +115,42 @@ public class SpecificationReader(Compilation compilation, ScreenplayDiagnostics 
         diagnostics.AddRange(stated.All);
 
         return new(name, [.. draft.Given], draft.When, [.. draft.Then], [.. draft.Errors]);
+    }
+
+    /// <summary>
+    /// Determines whether a type is written the way a specification is, whatever it turns out to specify.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is shaped like a specification.</returns>
+    static bool IsWrittenAsOne(INamedTypeSymbol type) =>
+        type is { TypeKind: TypeKind.Class, IsAbstract: false, ContainingType: null } &&
+        SpecificationMembers.MethodsIn(SpecificationMembers.StepsOf(type), SpecificationMembers.BecauseMethod).Any();
+
+    /// <summary>
+    /// States the read model a scenario is about as what followed the events it started from.
+    /// </summary>
+    /// <param name="readModel">The read model the scenario is of.</param>
+    /// <param name="draft">The scenario collected so far.</param>
+    /// <remarks>
+    /// A scenario of a read model has no command to issue - the events are what happened and the model is what they
+    /// built - so what it says is the two halves the language already holds: <c>given</c> the events, and then the
+    /// <c>readmodel</c> they left behind. Which values the model ended up with is asserted in the host language
+    /// against the instance the scenario holds, and stays unsaid for the same reason the values of an event do.
+    /// <para>
+    /// A scenario stating nothing that had happened is left out rather than written, because a read model with no
+    /// events behind it is the empty one every read model starts as, and saying so describes nothing the application
+    /// does.
+    /// </para>
+    /// </remarks>
+    static void ReadStateOfTheReadModel(ITypeSymbol readModel, SpecificationDraft draft)
+    {
+        if (draft.Given.Count == 0)
+        {
+            draft.CannotRead("it states nothing that had happened, and what a read model holds is what happened before it");
+            return;
+        }
+
+        draft.Then.Add(new(readModel.Name, SpecificationStateKind.ReadModel, []));
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
@@ -23,9 +23,21 @@ public class SpecificationStepReader(Compilation compilation, SpecificationValue
     /// <param name="draft">The scenario collected so far.</param>
     /// <param name="name">The name of the specification.</param>
     /// <param name="location">Where the specification lives, for use in diagnostics.</param>
-    public void ReadGiven(INamedTypeSymbol steps, SpecificationDraft draft, string name, string location)
+    /// <param name="alsoWhereTheActionIs">Whether to read the method performing the action as well.</param>
+    /// <remarks>
+    /// Where the world a scenario starts from is written depends on what the scenario is. One issuing a command sets
+    /// the world up first and issues the command as its action, so the world is in <c>Establish</c> and reading the
+    /// action would take the command's own events for events that had already happened. One about a read model has no
+    /// command: the events are the action, and are routinely written straight into it. So the action is read only
+    /// when there is no command to confuse them with.
+    /// </remarks>
+    public void ReadGiven(INamedTypeSymbol steps, SpecificationDraft draft, string name, string location, bool alsoWhereTheActionIs = false)
     {
-        foreach (var (invocation, method, semanticModel, always) in CallsIn(steps, SpecificationMembers.EstablishMethod))
+        var calls = alsoWhereTheActionIs
+            ? CallsIn(steps, SpecificationMembers.EstablishMethod).Concat(CallsIn(steps, SpecificationMembers.BecauseMethod))
+            : CallsIn(steps, SpecificationMembers.EstablishMethod);
+
+        foreach (var (invocation, method, semanticModel, always) in calls)
         {
             if (!SpecificationCalls.IsGivenEvents(method) && !SpecificationCalls.IsGivenReadModel(method))
             {

--- a/Source/DotNET/Screenplay/Analysis/Types/ConceptRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/ConceptRegistry.cs
@@ -50,6 +50,15 @@ public class ConceptRegistry
     ];
 
     /// <summary>
+    /// Gets the name every concept is declared under.
+    /// </summary>
+    /// <remarks>
+    /// A concept and a shape are declared side by side at the top of the document and referred to the same way, so
+    /// the two cannot share a name - which is a question only something holding both can answer.
+    /// </remarks>
+    public IReadOnlySet<string> Names => _concepts.Keys.ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
     /// Registers a type as a concept when it is one.
     /// </summary>
     /// <param name="type">The type to register.</param>

--- a/Source/DotNET/Screenplay/Analysis/Types/ShapeRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/ShapeRegistry.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Collects the shapes an application refers to, keeping one declaration per name.
+/// </summary>
+/// <remarks>
+/// A record an artifact carries is referred to by its simple name and declared once at the top of the document,
+/// exactly as a concept is - so the same two questions decide what comes out of here. Which shapes the document
+/// declares follows from which ones were reached while a type was being resolved rather than from which ones the
+/// application defines, and two records sharing a simple name cannot both be described under it.
+/// <para>
+/// A name is claimed before what it holds is read, which is what lets a record referring to itself - directly or
+/// around a loop - be walked once instead of forever.
+/// </para>
+/// </remarks>
+public class ShapeRegistry
+{
+    /// <summary>The reason given for a record that carries nothing a declaration could hold.</summary>
+    public const string CarriesNothing = "it carries no value a declaration could hold";
+
+    readonly Dictionary<string, TypeModel> _shapes = new(StringComparer.Ordinal);
+    readonly Dictionary<string, string> _declaredFrom = new(StringComparer.Ordinal);
+    readonly Dictionary<string, string> _undeclarable = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets every shape the document declares, ordered by name.
+    /// </summary>
+    /// <param name="taken">The names something else already declares, which a shape cannot be declared under.</param>
+    /// <returns>The shapes.</returns>
+    public IEnumerable<TypeModel> Declared(IReadOnlySet<string> taken) =>
+    [
+        .. _shapes
+            .Where(_ => !taken.Contains(_.Key))
+            .Select(_ => _.Value)
+            .OrderBy(_ => _.Name, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Gets every shape no declaration could be written for, ordered by name.
+    /// </summary>
+    /// <param name="taken">The names something else already declares, which a shape cannot be declared under.</param>
+    /// <returns>The shapes, each with why it was left out.</returns>
+    public IEnumerable<UndeclarableShape> Undeclarable(IReadOnlySet<string> taken) =>
+    [
+        .. _undeclarable
+            .Select(_ => new UndeclarableShape(_.Key, _.Value))
+            .Concat(_shapes
+                .Where(_ => taken.Contains(_.Key))
+                .Select(_ => new UndeclarableShape(_declaredFrom[_.Key], $"a concept is already declared as '{_.Key}'")))
+            .OrderBy(_ => _.Type, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Registers a record as a shape, reading what it carries through the resolver naming each value.
+    /// </summary>
+    /// <param name="type">The record to register.</param>
+    /// <param name="resolve">The resolver naming the type of one value, which registers whatever it reaches in turn.</param>
+    /// <remarks>
+    /// The values are read in the order the source declares them, because the order of a record's positional
+    /// parameters is what the developer wrote and the document reads best the same way round.
+    /// </remarks>
+    public void Register(ITypeSymbol type, Func<ITypeSymbol, TypeReferenceModel> resolve)
+    {
+        var name = type.Name;
+        var full = type.ToDisplayString();
+
+        if (_declaredFrom.TryGetValue(name, out var already))
+        {
+            if (!string.Equals(already, full, StringComparison.Ordinal))
+            {
+                _undeclarable[full] = $"'{already}' is already declared as '{name}'";
+            }
+
+            return;
+        }
+
+        _declaredFrom[name] = full;
+
+        var properties = type.DeclaredProperties().Select(_ => new PropertyModel(_.Name, resolve(_.Type))).ToList();
+        if (properties.Count == 0)
+        {
+            _declaredFrom.Remove(name);
+            _undeclarable[full] = CarriesNothing;
+
+            return;
+        }
+
+        _shapes[name] = new(name, properties);
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
@@ -16,16 +16,18 @@ namespace Cratis.Arc.Screenplay.Analysis.Types;
 /// because every concept reached on the way has to be declared before it can be referenced, and every name that says
 /// less than the type does has to be reported rather than passed off as a description.
 /// <para>
-/// The first question is answered here. The second is split: what a name loses and which shapes no declaration can
-/// hold are kept here because they are consequences of writing the name, while the concepts themselves are kept by a
-/// <see cref="ConceptRegistry"/>, which decides what a concept is and what happens when two of them share a name.
+/// The first question is answered here. The second is split: what a name loses is kept here because it is a
+/// consequence of writing the name, while the declarations it commits the document to are kept by a
+/// <see cref="ConceptRegistry"/> and a <see cref="ShapeRegistry"/>, each of which decides what it holds and what
+/// happens when two of them share a name. The two are asked together on the way out, because a concept and a shape
+/// are declared side by side and cannot share one.
 /// </para>
 /// </remarks>
 public class TypeRegistry
 {
     readonly ConceptRegistry _concepts = new();
+    readonly ShapeRegistry _shapes = new();
     readonly HashSet<string> _unmappable = new(StringComparer.Ordinal);
-    readonly HashSet<string> _shapes = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets the full name of every type that had to be referred to by a name that does not say what it is.
@@ -33,9 +35,14 @@ public class TypeRegistry
     public IEnumerable<string> Unmappable => _unmappable.Order(StringComparer.Ordinal);
 
     /// <summary>
-    /// Gets the full name of every record a property carries whose shape no declaration can hold.
+    /// Gets every record a property carries whose shape no declaration could be written for.
     /// </summary>
-    public IEnumerable<string> Shapes => _shapes.Order(StringComparer.Ordinal);
+    public IEnumerable<UndeclarableShape> Shapes => _shapes.Undeclarable(_concepts.Names);
+
+    /// <summary>
+    /// Gets every shape referenced by the application, ordered by name.
+    /// </summary>
+    public IEnumerable<TypeModel> Types => _shapes.Declared(_concepts.Names);
 
     /// <summary>
     /// Gets the full name of every type whose simple name a concept was already declared under.
@@ -66,10 +73,10 @@ public class TypeRegistry
     /// <param name="type">The type to resolve.</param>
     /// <returns>The <see cref="TypeReferenceModel"/>.</returns>
     /// <remarks>
-    /// A property is where a record the document has no way to declare is really referred to - the line carrying it
-    /// names a shape nothing in the document introduces. That is asked here rather than everywhere a type is resolved,
-    /// because a query returning a read model refers to something the slice around it already describes, while a
-    /// property carrying a record refers to a shape stated nowhere at all.
+    /// A property is where a record is really referred to - the line carrying it names a shape, and the document has
+    /// to introduce that shape or the name resolves to nothing. That is asked here rather than everywhere a type is
+    /// resolved, because a query returning a read model refers to something the slice around it already describes,
+    /// while a property carrying a record refers to a shape declared nowhere else.
     /// </remarks>
     public TypeReferenceModel ResolveCarried(ITypeSymbol type)
     {
@@ -79,7 +86,7 @@ public class TypeRegistry
 
         if (CarriedTypes.IsRecord(carried))
         {
-            _shapes.Add(carried.ToDisplayString());
+            _shapes.Register(carried, ResolveCarried);
         }
 
         return new(NameOf(carried), collection, optional);
@@ -127,10 +134,10 @@ public class TypeRegistry
     /// </summary>
     /// <param name="type">The type being named.</param>
     /// <remarks>
-    /// A record is referred to by name and never declared, so nothing inside it is ever named on its own - which left
-    /// every concept reached only through a line of a timesheet or a property of a read model out of the document
-    /// entirely. A concept can be declared wherever it was reached from, so it is, and the shape carrying it waits on
-    /// the language.
+    /// A concept can be declared wherever it was reached from, so one reached only through a line of a timesheet or a
+    /// property of a read model is declared just as one written straight onto an event is. A record carried by an
+    /// artifact reaches its own concepts through <see cref="ResolveCarried"/> as it is declared; this is what covers
+    /// the rest - a type named somewhere no declaration follows from, such as the read model a query answers with.
     /// </remarks>
     void RegisterWhatItCarries(ITypeSymbol type)
     {

--- a/Source/DotNET/Screenplay/Analysis/Types/TypesTheDocumentCannotName.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/TypesTheDocumentCannotName.cs
@@ -45,9 +45,9 @@ public static class TypesTheDocumentCannotName
 
         foreach (var shape in types.Shapes)
         {
-            diagnostics.Information(
+            diagnostics.Warning(
                 ScreenplayDiagnosticCodes.UndeclarableShape,
-                $"'{shape}' is a record an artifact carries, and there is no way to declare what a record holds, so the document names it without saying what is in it - the concepts it carries are declared, the shape itself is not",
+                $"'{shape.Type}' is a record an artifact carries, and no type declaration could be written for it because {shape.Reason}, so the document names it without saying what is in it",
                 location);
         }
     }

--- a/Source/DotNET/Screenplay/Analysis/Types/UndeclarableShape.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/UndeclarableShape.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Represents a record an artifact carries that no <c>type</c> declaration could be written for.
+/// </summary>
+/// <param name="Type">The full name of the record.</param>
+/// <param name="Reason">Why the shape could not be declared, written to follow "because".</param>
+/// <remarks>
+/// A shape being left out is worth far more to a reader than the fact of it: a record carrying nothing the document
+/// can name and a record whose name a concept already took are two different gaps, and only one of them is closed by
+/// renaming something.
+/// </remarks>
+public record UndeclarableShape(string Type, string Reason);

--- a/Source/DotNET/Screenplay/Analysis/Types/UnderlyingTypes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/UnderlyingTypes.cs
@@ -57,6 +57,13 @@ public static class UnderlyingTypes
     /// <param name="type">The type to strip.</param>
     /// <param name="optional">Set when a wrapper said the value may be absent.</param>
     /// <returns>The wrapped type.</returns>
+    /// <remarks>
+    /// The annotation saying a reference may be absent is stripped along with the wrapper that says the same of a
+    /// value, and for the same reason: whether it is there is answered by <paramref name="optional"/>, so leaving it
+    /// on hands back a symbol whose name carries the answer twice. That is not cosmetic - a reader telling two types
+    /// apart by the text of their name reads <c>Mentorship</c> and <c>Mentorship?</c> as two different records, and a
+    /// record referring to itself through an optional property is exactly where that happens.
+    /// </remarks>
     static ITypeSymbol Unwrap(ITypeSymbol type, ref bool optional)
     {
         if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullable)
@@ -66,11 +73,16 @@ public static class UnderlyingTypes
             return nullable.TypeArguments[0];
         }
 
-        if (type.NullableAnnotation == NullableAnnotation.Annotated && type.IsReferenceType)
+        if (type.NullableAnnotation != NullableAnnotation.Annotated)
+        {
+            return type;
+        }
+
+        if (type.IsReferenceType)
         {
             optional = true;
         }
 
-        return type;
+        return type.WithNullableAnnotation(NullableAnnotation.None);
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
@@ -132,6 +132,18 @@ public static class WellKnownTypeNames
     /// <summary>The builder a specification states the state of one event source with.</summary>
     public const string CommandScenarioSourceGivenBuilder = "Cratis.Arc.Chronicle.Testing.Commands.CommandScenarioSourceGivenBuilder`1";
 
+    /// <summary>The scenario a specification drives a read model through in process.</summary>
+    public const string ReadModelScenario = "Cratis.Chronicle.Testing.ReadModels.ReadModelScenario`1";
+
+    /// <summary>The builder a specification states the events one event source had seen with.</summary>
+    public const string ReadModelSourceGivenBuilder = "Cratis.Chronicle.Testing.ReadModels.ReadModelSourceGivenBuilder`1";
+
+    /// <summary>The scenario a specification appends events through in process, without a command pipeline.</summary>
+    public const string EventScenario = "Cratis.Chronicle.Testing.EventSequences.EventScenario";
+
+    /// <summary>The scenario a specification drives a reactor through in process.</summary>
+    public const string ReactorScenario = "Cratis.Chronicle.Testing.Reactors.ReactorScenario`1";
+
     /// <summary>The extensions a specification issues a command through over HTTP.</summary>
     public const string HttpClientExtensions = "Cratis.Chronicle.XUnit.Integration.HttpClientExtensions";
 

--- a/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
@@ -54,7 +54,8 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
     {
         var domain = ToName(model.Domain, options.Domain);
         var modules = BuildModules(model, options, domain);
-        var concepts = new ConceptSyntaxBuilder(naming, _validations, diagnostics, _names).Build(model.Concepts);
+        var concepts = new ConceptSyntaxBuilder(naming, _validations, diagnostics, _names).Build(model.Concepts).ToList();
+        var declaredTypes = new TypeSyntaxBuilder(naming, _types, diagnostics).Build(model.Types, concepts, model.Domain);
         var policies = new PolicySyntaxBuilder(naming).Build(model.Policies, _authorize.Referenced);
 
         return new(
@@ -63,7 +64,8 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
             [.. policies],
             [.. modules],
             SourceLocation.Start,
-            new DomainSyntax(domain, SourceLocation.Start));
+            new DomainSyntax(domain, SourceLocation.Start),
+            Types: [.. declaredTypes]);
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
@@ -26,7 +26,7 @@ public class ConceptSyntaxBuilder(
     /// <summary>
     /// The Screenplay attribute marking a concept as personally identifiable information.
     /// </summary>
-    public const string PersonallyIdentifiableInformation = "pii";
+    public const string PersonallyIdentifiableInformation = ConceptAttributeSyntax.Pii;
 
     /// <summary>
     /// Builds every concept the document declares.
@@ -59,7 +59,7 @@ public class ConceptSyntaxBuilder(
             declared[name] = new(
                 name,
                 ScreenplayPrimitiveTypes.GetName(concept.Primitive),
-                concept.IsPii ? [PersonallyIdentifiableInformation] : [],
+                concept.IsPii ? [new ConceptAttributeSyntax(PersonallyIdentifiableInformation, SourceLocation.Start)] : [],
                 values,
                 SourceLocation.Start,
                 [.. validations.Build(concept.Validations, concept.Name, impliedSubject: true)]);

--- a/Source/DotNET/Screenplay/Emission/Policies/AuthorizeSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/AuthorizeSyntaxBuilder.cs
@@ -16,7 +16,7 @@ namespace Cratis.Arc.Screenplay.Emission.Policies;
 /// a generated document nobody trusts.
 /// <para>
 /// Roles are alternatives to each other - holding any one of them is enough - while a named policy is an additional
-/// demand, so roles are combined with <c>or</c> and policies follow them without one.
+/// demand, so roles are combined with <c>or</c> and the policies with <c>and</c>.
 /// </para>
 /// </remarks>
 public class AuthorizeSyntaxBuilder
@@ -58,13 +58,50 @@ public class AuthorizeSyntaxBuilder
             _referenced.Add(policy);
         }
 
-        return new(
-            [
-                .. roles.Select((role, index) => new PolicyReferenceSyntax(role, index > 0, SourceLocation.Start)),
-                .. named.Select(policy => new PolicyReferenceSyntax(policy, false, SourceLocation.Start))
-            ],
-            SourceLocation.Start);
+        return new(Require(roles, named), SourceLocation.Start);
     }
+
+    /// <summary>
+    /// Combines the roles and the named policies into the single requirement the caller has to satisfy.
+    /// </summary>
+    /// <param name="roles">The roles, any one of which is enough.</param>
+    /// <param name="named">The named policies, every one of which is demanded.</param>
+    /// <returns>The <see cref="PolicyRequirementSyntax"/>.</returns>
+    /// <remarks>
+    /// The two groups are joined into a tree rather than laid out in a list, because <c>and</c> binds tighter than
+    /// <c>or</c>. "Any librarian, who is also senior staff" written flat reads back as "any librarian, or anyone who
+    /// is senior staff", which admits a caller neither the roles nor the policy admits on its own. Nesting the
+    /// alternatives under the demand says what was meant, and the printer parenthesizes it because the operators
+    /// differ.
+    /// </remarks>
+    static PolicyRequirementSyntax Require(IEnumerable<string> roles, IEnumerable<string> named)
+    {
+        var anyRole = Combine(roles, LogicalOperator.Or);
+        var everyPolicy = Combine(named, LogicalOperator.And);
+
+        if (anyRole is not null && everyPolicy is not null)
+        {
+            return new LogicalPolicyRequirementSyntax(anyRole, LogicalOperator.And, everyPolicy, SourceLocation.Start);
+        }
+
+        // Build never leaves both groups empty - it stands in with the authenticated policy - so one of them is here.
+        return anyRole ?? everyPolicy ?? new PolicyReferenceSyntax(AuthenticatedPolicy, SourceLocation.Start);
+    }
+
+    /// <summary>
+    /// Folds names into one requirement combined with a single operator.
+    /// </summary>
+    /// <param name="names">The names to fold.</param>
+    /// <param name="operator">The <see cref="LogicalOperator"/> combining them.</param>
+    /// <returns>The requirement, or <see langword="null"/> when there are no names to fold.</returns>
+    static PolicyRequirementSyntax? Combine(IEnumerable<string> names, LogicalOperator @operator) =>
+        names
+            .Select(name => (PolicyRequirementSyntax)new PolicyReferenceSyntax(name, SourceLocation.Start))
+            .Aggregate(
+                default(PolicyRequirementSyntax),
+                (left, right) => left is null
+                    ? right
+                    : new LogicalPolicyRequirementSyntax(left, @operator, right, SourceLocation.Start));
 
     /// <summary>
     /// Converts names into the form a policy reference takes, leaving out anything nothing is left of.

--- a/Source/DotNET/Screenplay/Emission/Policies/PolicyConditionConverter.cs
+++ b/Source/DotNET/Screenplay/Emission/Policies/PolicyConditionConverter.cs
@@ -54,9 +54,13 @@ public class PolicyConditionConverter(IScreenplayNaming naming)
     /// </summary>
     /// <param name="claim">The requirement to convert.</param>
     /// <returns>The condition, or <see langword="null"/> when either part cannot be written.</returns>
+    /// <remarks>
+    /// The value a claim is matched against is an expression rather than bare text, so it is written as the string
+    /// literal it is. A bare word would read as a path naming something else in scope, which is a different claim.
+    /// </remarks>
     ClaimConditionSyntax? Claim(ClaimRequirement claim) =>
         naming.ToStringLiteral(claim.Claim) is { } name && naming.ToStringLiteral(claim.Value) is { } value
-            ? new ClaimConditionSyntax(name, false, value, SourceLocation.Start)
+            ? new ClaimConditionSyntax(name, false, new LiteralExpressionSyntax(value, SourceLocation.Start), SourceLocation.Start)
             : null;
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceContent.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceContent.cs
@@ -24,7 +24,7 @@ public static class SliceContent
         !slice.Events.Any() &&
         !slice.Commands.Any() &&
         !slice.Queries.Any() &&
-        slice.Projection is null &&
+        !slice.Projections.Any() &&
         !slice.Captures.Any() &&
         !slice.Reactors.Any() &&
         !slice.Screens.Any() &&

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
@@ -57,7 +57,7 @@ public class SliceSyntaxBuilder(
             [.. slice.Events.Select(_ => events.Build(_, slice.Namespace)).OrderBy(_ => _.Name, StringComparer.Ordinal)],
             [.. slice.Commands.Select(_ => commands.Build(_, slice.Namespace)).OrderBy(_ => _.Name, StringComparer.Ordinal)],
             [.. slice.Queries.Select(queries.Build).OrderBy(_ => _.Name, StringComparer.Ordinal)],
-            BuildProjection(slice),
+            BuildProjections(slice),
             [],
             [
                 .. slice.Reactors
@@ -81,12 +81,21 @@ public class SliceSyntaxBuilder(
             naming.ToStringLiteral(slice.Description));
 
     /// <summary>
-    /// Builds the single projection a slice may declare.
+    /// Builds the projections a slice declares.
     /// </summary>
     /// <param name="slice">The slice to build for.</param>
-    /// <returns>The projection, or <see langword="null"/> when the slice has none.</returns>
-    ProjectionSyntax? BuildProjection(SliceModel slice) =>
-        slice.Projection is null ? null : projections.Build(slice.Projection, slice.Namespace);
+    /// <returns>The projections, empty when the slice declares none.</returns>
+    /// <remarks>
+    /// A slice can now hold several projections, while the model recovered from source still holds at most one -
+    /// a second one is turned away during analysis and reported. This yields what the model has, so widening the
+    /// analysis is the only thing left to do to carry them all.
+    /// <para>
+    /// A projection nothing could be expressed of yields nothing rather than an absent entry, so a slice left with
+    /// no other content is still recognized as empty and dropped.
+    /// </para>
+    /// </remarks>
+    IEnumerable<ProjectionSyntax> BuildProjections(SliceModel slice) =>
+        slice.Projection is { } projection && projections.Build(projection, slice.Namespace) is { } built ? [built] : [];
 
     /// <summary>
     /// Gets the name of the slice, falling back to the last segment of its namespace.

--- a/Source/DotNET/Screenplay/Emission/Specifications/SpecificationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Specifications/SpecificationSyntaxBuilder.cs
@@ -44,15 +44,26 @@ public class SpecificationSyntaxBuilder(IScreenplayNaming naming)
         new(
             naming.ToDeclarationName(specification.Name),
             [.. Events(specification.Given)],
-            new SpecificationCommandSyntax(
-                naming.ToDeclarationName(specification.When.Name),
-                [.. Values(specification.When)],
-                SourceLocation.Start),
+            When(specification.When),
             [.. Events(specification.Then)],
             [.. specification.Errors.Select(_ => new SpecificationErrorSyntax(naming.ToStringLiteral(_) ?? string.Empty, SourceLocation.Start))],
             SourceLocation.Start,
             [.. ReadModels(specification.Given)],
             [.. ReadModels(specification.Then)]);
+
+    /// <summary>
+    /// Builds the command a scenario issued.
+    /// </summary>
+    /// <param name="command">The command, or <see langword="null"/> when the scenario issued none.</param>
+    /// <returns>The <see cref="SpecificationCommandSyntax"/>, or <see langword="null"/>.</returns>
+    /// <remarks>
+    /// A scenario about a read model issues no command - the events are what happened - and the language holds that
+    /// as a specification with no <c>when</c> rather than as one with an empty one.
+    /// </remarks>
+    SpecificationCommandSyntax? When(SpecificationStateModel? command) =>
+        command is null
+            ? null
+            : new(naming.ToDeclarationName(command.Name), [.. Values(command)], SourceLocation.Start);
 
     /// <summary>
     /// Builds the states of a step that name an event.

--- a/Source/DotNET/Screenplay/Emission/Types/TypeSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Types/TypeSyntaxBuilder.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Diagnostics;
+using Cratis.Screenplay.Syntax;
+
+namespace Cratis.Arc.Screenplay.Emission.Types;
+
+/// <summary>
+/// Builds the document level <c>type</c> declarations.
+/// </summary>
+/// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
+/// <param name="types">The <see cref="TypeReferenceConverter"/> used for property types.</param>
+/// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything left out is reported to.</param>
+/// <remarks>
+/// A declaration name is what two names finally become the same or stay apart under, so the last word on whether two
+/// shapes can both be declared is here rather than where they were collected. Two records the source tells apart by
+/// namespace, and a shape whose name a concept was written under, both come out of naming as one word - and a
+/// document declaring that word twice does not compile.
+/// </remarks>
+public class TypeSyntaxBuilder(IScreenplayNaming naming, TypeReferenceConverter types, ScreenplayDiagnostics diagnostics)
+{
+    /// <summary>
+    /// Builds every shape the document declares.
+    /// </summary>
+    /// <param name="models">The shapes to build.</param>
+    /// <param name="concepts">The concepts already declared, whose names a shape cannot be declared under.</param>
+    /// <param name="location">Where to report anything left out against.</param>
+    /// <returns>The type declarations, ordered by name.</returns>
+    public IEnumerable<TypeSyntax> Build(IEnumerable<TypeModel> models, IEnumerable<ConceptSyntax> concepts, string? location)
+    {
+        var declared = new Dictionary<string, TypeSyntax>(StringComparer.Ordinal);
+        var taken = concepts.Select(_ => _.Name).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var model in models)
+        {
+            var name = naming.ToDeclarationName(model.Name);
+            if (name.Length <= 1 || taken.Contains(name) || declared.ContainsKey(name))
+            {
+                diagnostics.Warning(
+                    ScreenplayDiagnosticCodes.UndeclarableShape,
+                    $"'{model.Name}' is a record an artifact carries, and no type declaration could be written for it because '{name}' is a name the document already uses, so the document names it without saying what is in it",
+                    location);
+                continue;
+            }
+
+            declared[name] = new(name, [.. ToProperties(model)], SourceLocation.Start);
+        }
+
+        return [.. declared.Values.OrderBy(_ => _.Name, StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Converts the values a shape carries, keeping one line per name.
+    /// </summary>
+    /// <param name="model">The shape to convert the values of.</param>
+    /// <returns>The properties the body carries.</returns>
+    /// <remarks>
+    /// Nothing here is reserved - a <c>type</c> body dispatches on nothing, so every name the source declares is
+    /// written as it stands. Two values whose names come out the same are the one case a line is dropped, because the
+    /// second would be read as declaring the first one twice.
+    /// </remarks>
+    IEnumerable<PropertySyntax> ToProperties(TypeModel model) =>
+        model.Properties
+            .Select(_ => new PropertySyntax(naming.ToPropertyName(_.Name), types.Convert(_.Type), SourceLocation.Start))
+            .DistinctBy(_ => _.Name, StringComparer.Ordinal);
+}

--- a/Source/DotNET/Screenplay/Model/ApplicationModel.cs
+++ b/Source/DotNET/Screenplay/Model/ApplicationModel.cs
@@ -11,17 +11,19 @@ namespace Cratis.Arc.Screenplay.Model;
 /// <param name="Concepts">The concepts declared at the document level.</param>
 /// <param name="Policies">The policies declared at the document level.</param>
 /// <param name="Slices">Every slice of the application, flat - emission builds the feature tree from the namespaces.</param>
+/// <param name="Types">The shapes declared at the document level, which artifacts carry values of.</param>
 public record ApplicationModel(
     string Domain,
     string Module,
     IEnumerable<ConceptModel> Concepts,
     IEnumerable<PolicyModel> Policies,
-    IEnumerable<SliceModel> Slices)
+    IEnumerable<SliceModel> Slices,
+    IEnumerable<TypeModel> Types)
 {
     /// <summary>
     /// Represents an application that declares nothing at all.
     /// </summary>
-    public static readonly ApplicationModel Empty = new(string.Empty, string.Empty, [], [], []);
+    public static readonly ApplicationModel Empty = new(string.Empty, string.Empty, [], [], [], []);
 
     /// <summary>
     /// Gets the fully qualified name of every event the application refers to that something it references declares.

--- a/Source/DotNET/Screenplay/Model/SpecificationModel.cs
+++ b/Source/DotNET/Screenplay/Model/SpecificationModel.cs
@@ -9,17 +9,21 @@ namespace Cratis.Arc.Screenplay.Model;
 /// </summary>
 /// <param name="Name">The name of the specification.</param>
 /// <param name="Given">What had already happened when the command was issued.</param>
-/// <param name="When">The command that was issued.</param>
+/// <param name="When">The command that was issued, or <see langword="null"/> when no command was.</param>
 /// <param name="Then">The events and read model states that followed.</param>
 /// <param name="Errors">The rejections that followed, each named by the reason the source gives for it.</param>
 /// <remarks>
 /// A rejection the source names no reason for carries an empty one. The scenario is named after the words the
 /// source itself uses for it, so what the rejection was about is already said by the name and inventing a sentence
 /// to repeat it would be describing an application nobody wrote.
+/// <para>
+/// A scenario about a read model issues no command - the events are the whole of what happened, and what followed is
+/// the model they built. So the command is optional, which is what the language says too.
+/// </para>
 /// </remarks>
 public record SpecificationModel(
     string Name,
     IEnumerable<SpecificationStateModel> Given,
-    SpecificationStateModel When,
+    SpecificationStateModel? When,
     IEnumerable<SpecificationStateModel> Then,
     IEnumerable<string> Errors);

--- a/Source/DotNET/Screenplay/Model/TypeModel.cs
+++ b/Source/DotNET/Screenplay/Model/TypeModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Model;
+
+/// <summary>
+/// Represents a shape declared at the document level - several values under one name.
+/// </summary>
+/// <param name="Name">The name of the type.</param>
+/// <param name="Properties">The values the type carries.</param>
+/// <remarks>
+/// A concept is one value with a name; this is the other half of what an artifact can carry. A record an event
+/// holds - the lines of an approved timesheet, the milestones of an onboarding - is referred to by name from the
+/// property carrying it, and this is the declaration that name resolves to.
+/// </remarks>
+public record TypeModel(string Name, IEnumerable<PropertyModel> Properties);

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -286,16 +286,17 @@ public static class ScreenplayDiagnosticCodes
     public const string DocumentDidNotCompile = "SP0034";
 
     /// <summary>
-    /// A value an artifact carries is a record, whose shape no declaration in the language can hold.
+    /// A value an artifact carries is a record no <c>type</c> declaration could be written for.
     /// </summary>
     /// <remarks>
-    /// A concept is one value with a name, and every concept the application refers to is declared. A record carrying
-    /// several values is a different thing: an event property written as <c>days ApprovedDayLine[]</c> names a shape
-    /// the document has no construct to introduce, so what that line holds is stated nowhere - including anything
-    /// within it the application marks as personal data. The concepts inside it are recovered and declared, because a
-    /// concept can be declared wherever it was reached from; the shape itself waits on the language
-    /// (Cratis/Screenplay#29). This is reported rather than left unsaid because a reader counting what the document
-    /// declares against what the application holds otherwise has no way of knowing where the difference went.
+    /// A record carrying several values is what a <c>type</c> declares, so an event property written as
+    /// <c>days ApprovedDayLine[]</c> names a shape the document introduces and the line resolves. What is left is the
+    /// handful of records no declaration can be written for: one carrying no value at all, and one whose simple name a
+    /// concept or another record already holds - a document is one namespace of declarations, and the second of two
+    /// names cannot be written twice. The concepts inside such a record are still recovered and declared, because a
+    /// concept can be declared wherever it was reached from; the shape is not, so the property naming it refers to
+    /// something the document never introduces. That is what this reports, and why it says which of the reasons it
+    /// was: only one of them is closed by renaming something.
     /// </remarks>
     public const string UndeclarableShape = "SP0035";
 

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -403,4 +403,28 @@ public static class ScreenplayDiagnosticCodes
     /// about the request, it is a declaration the document does not make at all.
     /// </remarks>
     public const string ReadModelFeatureWithoutCounterpart = "SP0042";
+
+    /// <summary>
+    /// A slice is specified by a scenario of a kind the language has nowhere to put, so the whole of it is left out.
+    /// </summary>
+    /// <remarks>
+    /// An application specifies its slices through four scenarios, and a <c>specification</c> holds two of them. One
+    /// issuing a command is a <c>when</c>; one driving a read model is <c>given</c> the events and then the
+    /// <c>readmodel</c> they built. The other two have nowhere to go, for reasons of their own rather than one
+    /// shared reason.
+    /// <para>
+    /// A scenario appending an event states the append as its action, and a <c>when</c> names a command and nothing
+    /// else - so writing the appended event as something that followed would state the action as an outcome, and
+    /// writing only the rejection would say a scenario was rejected without saying what was. A scenario driving a
+    /// reactor says what a collaborator was asked to do, which is a statement about the inside of a slice in the same
+    /// way a unit level specification is, and is left out for the same reason.
+    /// </para>
+    /// <para>
+    /// This is reported rather than passed over precisely because those two are not unit level specifications. They
+    /// hold a scenario, which is what says a specification is about the behavior of the slice - so a document silent
+    /// about them reads exactly like a slice specified by nothing, and on a real application that is a large fraction
+    /// of everything the slice is specified by.
+    /// </para>
+    /// </remarks>
+    public const string ScenarioWithoutCounterpart = "SP0043";
 }


### PR DESCRIPTION
# Summary

Moves the Screenplay language package to 2.0.0 and follows the language where it changed shape, so generated documents keep reading back clean against the compiler that will actually read them.

## Changed

- `Cratis.Screenplay` 1.8.0 to 2.0.0.
- A generated `authorize` block states what it requires on one line, keeping the roles it accepts as alternatives to each other and a named policy as a demand on top of them.
- The value a generated `claim` requirement is matched against is written as a quoted string rather than as a bare word.
