### PR TITLE
Carry nullability into a generated command's property accessors

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithOptionalProperties.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithOptionalProperties.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+/// <summary>
+/// A command mixing required and optional properties, for verifying that the generated proxy keeps the nullability of
+/// every property.
+/// </summary>
+public class CommandWithOptionalProperties
+{
+    /// <summary>
+    /// Gets or sets the required name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the optional description.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional value.
+    /// </summary>
+    public int? Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the required tags.
+    /// </summary>
+    public IEnumerable<string> Tags { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the optional labels.
+    /// </summary>
+    public IEnumerable<string>? Labels { get; set; }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_optional_properties.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_optional_properties.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+public class when_generating_command_with_optional_properties : Specification, IDisposable
+{
+    JavaScriptRuntime _runtime = null!;
+    string _generatedCode = null!;
+    CommandDescriptor _descriptor = null!;
+    IReadOnlyList<string> _diagnostics = null!;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        var commandType = typeof(CommandWithOptionalProperties);
+        var method = commandType.GetMethod("Handle") ?? typeof(object).GetMethod("GetHashCode");
+        var properties = commandType.GetProperties()
+            .Select(p => p.ToPropertyDescriptor())
+            .ToList();
+
+        _descriptor = new CommandDescriptor(
+            commandType,
+            method,
+            "/api/commands/command-with-optional-properties",
+            "CommandWithOptionalProperties",
+            properties,
+            Enumerable.Empty<ImportStatement>().OrderBy(_ => _.Module),
+            [],
+            false,
+            ModelDescriptor.Empty,
+            [],
+            null,
+            [],
+            false,
+            []);
+    }
+
+    void Because()
+    {
+        _generatedCode = InMemoryProxyGenerator.GenerateCommand(_descriptor);
+        _diagnostics = _runtime.GetSyntacticDiagnostics(_generatedCode);
+    }
+
+    [Fact] void should_declare_the_optional_backing_field_as_optional() => _generatedCode.ShouldContain("private _description?: string;");
+    [Fact] void should_declare_the_optional_getter_as_optional() => _generatedCode.ShouldContain("get description(): string | undefined {");
+    [Fact] void should_declare_the_optional_setter_as_optional() => _generatedCode.ShouldContain("set description(value: string | undefined) {");
+    [Fact] void should_declare_the_optional_value_type_getter_as_optional() => _generatedCode.ShouldContain("get value(): number | undefined {");
+    [Fact] void should_declare_the_optional_enumerable_backing_field_as_optional() => _generatedCode.ShouldContain("private _labels?: string[];");
+    [Fact] void should_declare_the_optional_enumerable_getter_as_optional() => _generatedCode.ShouldContain("get labels(): string[] | undefined {");
+    [Fact] void should_declare_the_optional_enumerable_setter_as_optional() => _generatedCode.ShouldContain("set labels(value: string[] | undefined) {");
+    [Fact] void should_declare_the_required_backing_field_as_definite() => _generatedCode.ShouldContain("private _name!: string;");
+    [Fact] void should_declare_the_required_getter_as_required() => _generatedCode.ShouldContain("get name(): string {");
+    [Fact] void should_declare_the_required_setter_as_required() => _generatedCode.ShouldContain("set name(value: string) {");
+    [Fact] void should_declare_the_required_enumerable_backing_field_as_definite() => _generatedCode.ShouldContain("private _tags!: string[];");
+    [Fact] void should_declare_the_required_enumerable_getter_as_required() => _generatedCode.ShouldContain("get tags(): string[] {");
+    [Fact] void should_declare_the_required_enumerable_setter_as_required() => _generatedCode.ShouldContain("set tags(value: string[]) {");
+    [Fact] void should_declare_the_optional_property_descriptor_as_nullable() => _generatedCode.ShouldContain("new PropertyDescriptor('description', String, true)");
+    [Fact] void should_declare_the_required_property_descriptor_as_not_nullable() => _generatedCode.ShouldContain("new PropertyDescriptor('name', String, false)");
+    [Fact] void should_produce_parseable_typescript() => _diagnostics.ShouldBeEmpty();
+
+    public void Dispose() => _runtime?.Dispose();
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
@@ -70,9 +70,17 @@ export class {{Name}} extends Command<I{{Name}}> implements I{{Name}} {
 
     {{#Properties}}
     {{#if IsEnumerable}}
+    {{#if IsNullable}}
+    private _{{camelcase Name}}?: {{{Type}}}[];
+    {{else}}
     private _{{camelcase Name}}!: {{{Type}}}[];
+    {{/if}}
+    {{else}}
+    {{#if IsNullable}}
+    private _{{camelcase Name}}?: {{{Type}}};
     {{else}}
     private _{{camelcase Name}}!: {{{Type}}};
+    {{/if}}
     {{/if}}
     {{/Properties}}
 
@@ -101,20 +109,20 @@ export class {{Name}} extends Command<I{{Name}}> implements I{{Name}} {
      */
     {{/if}}
     {{#if IsEnumerable}}
-    get {{camelcase Name}}(): {{{Type}}}[] {
+    get {{camelcase Name}}(): {{{Type}}}[]{{#if IsNullable}} | undefined{{/if}} {
         return this._{{camelcase Name}};
     }
 
-    set {{camelcase Name}}(value: {{{Type}}}[]) {
+    set {{camelcase Name}}(value: {{{Type}}}[]{{#if IsNullable}} | undefined{{/if}}) {
         this._{{camelcase Name}} = value;
         this.propertyChanged('{{camelcase Name}}');
     }
     {{else}}
-    get {{camelcase Name}}(): {{{Type}}} {
+    get {{camelcase Name}}(): {{{Type}}}{{#if IsNullable}} | undefined{{/if}} {
         return this._{{camelcase Name}};
     }
 
-    set {{camelcase Name}}(value: {{{Type}}}) {
+    set {{camelcase Name}}(value: {{{Type}}}{{#if IsNullable}} | undefined{{/if}}) {
         this._{{camelcase Name}} = value;
         this.propertyChanged('{{camelcase Name}}');
     }


### PR DESCRIPTION
## Fixed

- A generated command proxy declares an optional property as optional, so its accessors carry `| undefined` instead of claiming a value is always present (#2494)
