### PR TITLE
Publish CommandForm execution state to context and parents

### DIFF
--- a/Documentation/frontend/react/command-form/form-lifecycle.md
+++ b/Documentation/frontend/react/command-form/form-lifecycle.md
@@ -264,6 +264,98 @@ function AutoSaveForm() {
 }
 ```
 
+## Reaching the Form From a Parent
+
+Hooks such as `useIsCommandExecuting` only work *inside* the form. When the submit button lives outside it
+— in a dialog footer, a page toolbar, a wizard's navigation bar — the form exposes two props for that.
+They are complementary, and a parent that renders a button generally wants both.
+
+### formRef — executing the form and reading its state
+
+`formRef` hands the parent a `CommandFormHandle`:
+
+```ts
+interface CommandFormState {
+    isExecuting: boolean;
+    isValid: boolean;
+    isAuthorized: boolean;
+}
+
+interface CommandFormHandle extends CommandFormState {
+    execute(): Promise<ICommandResult<unknown>>;
+}
+```
+
+It is a named prop rather than a forwarded ref, because forwarding erases the generic arguments and
+callers write `<CommandForm<TCommand, TResponse> … />`.
+
+```tsx
+import { useRef } from 'react';
+import { CommandForm, type CommandFormHandle } from '@cratis/arc.react/commands';
+
+function ProfilePanel() {
+    const formRef = useRef<CommandFormHandle>(null);
+
+    return (
+        <>
+            <CommandForm<UpdateProfile> command={UpdateProfile} formRef={formRef}>
+                <InputTextField<UpdateProfile> value={c => c.name} title="Name" />
+            </CommandForm>
+            <footer>
+                <button onClick={() => formRef.current?.execute()}>Save</button>
+            </footer>
+        </>
+    );
+}
+```
+
+The handle is created once for the lifetime of the form, so a **callback ref** passed here is invoked
+exactly once on mount and once on unmount, however often the parent re-renders. Its state members are
+getters over live values, so a handle captured once never reports stale state.
+
+### onStateChange — re-rendering the parent
+
+A ref is not reactive: reading `formRef.current.isExecuting` in an event handler is fine, but it cannot
+make the parent re-render, so a button cannot *disable itself* from the handle alone. `onStateChange` is
+the reactive half — it is called whenever execution, validity or authorization changes:
+
+```tsx
+function ProfilePanel() {
+    const formRef = useRef<CommandFormHandle>(null);
+    const [state, setState] = useState<CommandFormState>({
+        isExecuting: false,
+        isValid: false,
+        isAuthorized: true
+    });
+
+    return (
+        <>
+            <CommandForm<UpdateProfile>
+                command={UpdateProfile}
+                formRef={formRef}
+                onStateChange={setState}>
+                <InputTextField<UpdateProfile> value={c => c.name} title="Name" />
+            </CommandForm>
+            <footer>
+                <button
+                    onClick={() => formRef.current?.execute()}
+                    disabled={state.isExecuting || !state.isValid || !state.isAuthorized}>
+                    {state.isExecuting ? 'Saving…' : 'Save'}
+                </button>
+            </footer>
+        </>
+    );
+}
+```
+
+An inline arrow function is safe here — the callback is read through a ref, so re-creating it on every
+render does not re-fire it. The callback is invoked on mount with the form's initial state and then on
+every change, never for a parent re-render on its own.
+
+`isExecuting` counts executions rather than flagging them, so it stays true until the last overlapping
+submission settles, and a rejected command gives its count back — see
+[Working with Hooks](./hooks.md#useiscommandexecuting).
+
 ## See Also
 
 - [CommandForm Overview](./index.md)

--- a/Documentation/frontend/react/command-form/hooks.md
+++ b/Documentation/frontend/react/command-form/hooks.md
@@ -42,6 +42,44 @@ function CustomSubmitButton() {
 </CommandForm>
 ```
 
+## useIsCommandExecuting
+
+Reports whether the surrounding form currently has an execution in flight. Use it for anything inside the
+form that has to reflect execution — a submit button that disables itself, a spinner — without threading
+state down by hand:
+
+```tsx
+import { useIsCommandExecuting } from '@cratis/arc.react/commands';
+
+function SubmitButton() {
+    const isExecuting = useIsCommandExecuting();
+
+    return (
+        <button type="submit" disabled={isExecuting}>
+            {isExecuting ? 'Saving…' : 'Save'}
+        </button>
+    );
+}
+
+// Use within CommandForm
+<CommandForm command={UpdateProfile}>
+    <InputTextField<UpdateProfile> value={c => c.name} title="Name" />
+    <SubmitButton />
+</CommandForm>
+```
+
+The same value is on the form context as `isExecuting`, so `useCommandFormContext().isExecuting` is
+equivalent when you need other members of the context anyway.
+
+Executions are counted rather than flagged. A form can be submitted again while the previous submission
+is still running — a double click, or a submit button and a keyboard submit racing — and a flag would be
+cleared by whichever one finished first, re-enabling the button with a command still in flight. The count
+goes `0 → 1 → 2 → 1 → 0` instead, so `isExecuting` stays true until the last execution settles. A command
+that rejects gives its count back too, so a failed request never leaves the form stuck.
+
+Like every CommandForm hook, this one must be called from inside a `CommandForm`; it throws otherwise.
+To observe execution state from *outside* the form, see [Form Lifecycle](./form-lifecycle.md).
+
 ## useCommandInstance
 
 Create and manage a command instance outside of CommandForm:

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { CommandFormFields, ColumnInfo, CommandFormFieldWrapper } from './CommandFormFields';
-import { CommandFormContext, useCommandFormContext, type BeforeExecuteCallback, type CommandFormContextValue, type FieldValidationInfo, type FieldContainerProps, type FieldDecoratorProps, type ErrorDisplayProps, type TooltipWrapperProps } from './CommandFormContext';
+import { CommandFormContext, useCommandFormContext, type BeforeExecuteCallback, type CommandFormContextValue, type CommandFormHandle, type CommandFormState, type FieldValidationInfo, type FieldContainerProps, type FieldDecoratorProps, type ErrorDisplayProps, type TooltipWrapperProps } from './CommandFormContext';
 import { Constructor } from '@cratis/fundamentals';
 import { useCommand, SetCommandValues } from '../useCommand';
 import { ICommandResult } from '@cratis/arc/commands';
 import { Command } from '@cratis/arc/commands';
 import { ValidationResult } from '@cratis/arc/validation';
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useImperativeHandle } from 'react';
 import type { CommandFormFieldProps } from './CommandFormField';
 import { getPropertyNameFromAccessor } from './getPropertyNameFromAccessor';
 import { memberMatchesField } from './memberMatchesField';
@@ -74,6 +74,25 @@ export interface CommandFormProps<TCommand extends object, TResponse = object> {
     tooltipComponent?: React.ComponentType<TooltipWrapperProps>;
     errorClassName?: string;
     iconAddonClassName?: string;
+
+    /**
+     * Receives the imperative handle for the form, letting a parent outside the form execute it and
+     * read its state. Named rather than taken through `forwardRef`, because forwarding erases the
+     * generic arguments and callers write `<CommandForm<TCommand, TResponse> ... />`.
+     *
+     * The handle is created once for the lifetime of the form, so a callback ref passed here is
+     * invoked exactly once on mount and once on unmount, however often the parent re-renders. Its
+     * state members are getters over live values and are therefore never stale - but reading them
+     * does not re-render the parent. Use {@link CommandFormProps.onStateChange} for that.
+     */
+    formRef?: React.Ref<CommandFormHandle>;
+
+    /**
+     * Called whenever the form's execution, validity or authorization state changes - the reactive
+     * counterpart to {@link CommandFormProps.formRef}. An inline arrow function is safe here: the
+     * callback is read through a ref, so re-creating it on every render does not re-fire it.
+     */
+    onStateChange?: (state: CommandFormState) => void;
     children?: React.ReactNode;
 }
 
@@ -198,6 +217,16 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
     const [commandResult, setCommandResult] = useState<ICommandResult<unknown> | undefined>(undefined);
     const [silentValidationResult, setSilentValidationResult] = useState<ICommandResult<unknown> | undefined>(undefined);
     const [customFieldErrors, setCustomFieldErrors] = useState<Record<string, string>>({});
+
+    // Executions are counted, not flagged. Nothing stops a form from being submitted again while the
+    // previous submission is still in flight - a second click, a submit button and a keyboard submit
+    // racing - and a flag would be cleared by whichever execution settles first, reporting the form as
+    // idle while the other is still running. The count goes 0 -> 1 -> 2 -> 1 -> 0 instead, so the form
+    // keeps reporting executing until the last one settles. The ref is the source of truth, mirrored
+    // into state so that the render path reacts to it.
+    const executionCountRef = React.useRef(0);
+    const [executionCount, setExecutionCount] = useState(0);
+    const isExecuting = executionCount > 0;
     const initializedRef = React.useRef(false);
     const lastServerValidateVersion = React.useRef<number>(-1);
     const serverValidateThrottleTimer = React.useRef<NodeJS.Timeout | null>(null);
@@ -383,31 +412,69 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
 
         // Execute the command
         if (typeof (finalValues as unknown as Command).execute === 'function') {
-            const result = await (finalValues as unknown as Command).execute() as ICommandResult<TResponse>;
-            setCommandResult(result);
-            
-            // Invoke callbacks based on result state
-            if (result.isSuccess && props.onSuccess) {
-                props.onSuccess(result.response as TResponse);
+            // Counted strictly inside this guard, so the throw below can never leak a count that is
+            // never given back. The decrement is in a finally rather than a catch, so a rejection
+            // restores the count and still propagates unchanged.
+            executionCountRef.current += 1;
+            setExecutionCount(executionCountRef.current);
+            try {
+                const result = await (finalValues as unknown as Command).execute() as ICommandResult<TResponse>;
+                setCommandResult(result);
+
+                // Invoke callbacks based on result state
+                if (result.isSuccess && props.onSuccess) {
+                    props.onSuccess(result.response as TResponse);
+                }
+                if (!result.isSuccess && props.onFailed) {
+                    props.onFailed(result);
+                }
+                if (result.hasExceptions && props.onException) {
+                    props.onException(result.exceptionMessages, result.exceptionStackTrace);
+                }
+                if (!result.isAuthorized && props.onUnauthorized) {
+                    props.onUnauthorized();
+                }
+                if (!result.isValid && props.onValidationFailure) {
+                    props.onValidationFailure(result.validationResults);
+                }
+
+                return result;
+            } finally {
+                executionCountRef.current -= 1;
+                setExecutionCount(executionCountRef.current);
             }
-            if (!result.isSuccess && props.onFailed) {
-                props.onFailed(result);
-            }
-            if (result.hasExceptions && props.onException) {
-                props.onException(result.exceptionMessages, result.exceptionStackTrace);
-            }
-            if (!result.isAuthorized && props.onUnauthorized) {
-                props.onUnauthorized();
-            }
-            if (!result.isValid && props.onValidationFailure) {
-                props.onValidationFailure(result.validationResults);
-            }
-            
-            return result;
         }
 
         throw new Error('Command instance does not have an execute method');
     }, [commandInstance, props, setCommandValues, setCommandResult]);
+
+    // handleExecute is re-created on every render - its dependencies include props, and CommandForm
+    // renders <CommandFormComponent {...props} />, so props is a fresh object each time. That cannot be
+    // stabilized, because parents legitimately pass inline arrow callbacks. So the handle below does not
+    // depend on it: everything it needs is parked in a ref, refreshed after every commit, and the handle
+    // itself is built once. A handle rebuilt per render would re-attach a callback ref on every parent
+    // render, which is a re-attach loop when the parent re-renders in response to being handed the ref.
+    const latestRef = React.useRef({ handleExecute, isValid, isAuthorized });
+    const onStateChangeRef = React.useRef(props.onStateChange);
+    React.useLayoutEffect(() => {
+        latestRef.current = { handleExecute, isValid, isAuthorized };
+        onStateChangeRef.current = props.onStateChange;
+    });
+
+    useImperativeHandle(props.formRef, () => ({
+        execute: () => latestRef.current.handleExecute(),
+        get isExecuting() { return executionCountRef.current > 0; },
+        get isValid() { return latestRef.current.isValid; },
+        get isAuthorized() { return latestRef.current.isAuthorized; }
+    }), []);
+
+    // An imperative handle is not reactive - reading it cannot re-render the parent. This is the other
+    // half: the parent is told when the state changes so its own submit button can follow along. The
+    // dependencies are the three booleans and nothing else; the callback is read through a ref so an
+    // inline arrow cannot re-fire it.
+    React.useEffect(() => {
+        onStateChangeRef.current?.({ isExecuting, isValid, isAuthorized });
+    }, [isExecuting, isValid, isAuthorized]);
 
     const handleFormSubmit = useCallback((e: React.FormEvent) => {
         e.preventDefault();
@@ -428,6 +495,7 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
         getFieldError,
         isValid,
         isAuthorized,
+        isExecuting,
         beginSilentValidation,
         setSilentValidationResult: applySilentValidationResult,
         onFieldValidate: props.onFieldValidate,

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormContext.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormContext.tsx
@@ -35,6 +35,39 @@ export interface FieldValidationInfo {
     errors: string[];
 }
 
+/**
+ * The observable state of a command form, as a parent outside the form sees it.
+ */
+export interface CommandFormState {
+    /**
+     * Whether at least one execution of the command is in flight. Overlapping executions are counted,
+     * so this stays true until the last one has settled.
+     */
+    isExecuting: boolean;
+
+    /**
+     * Whether the form currently passes silent validation.
+     */
+    isValid: boolean;
+
+    /**
+     * Whether the current identity holds at least one of the roles the command requires.
+     */
+    isAuthorized: boolean;
+}
+
+/**
+ * The imperative surface a parent reaches through the `formRef` prop. The state members are getters
+ * reading live values, so a handle captured once never goes stale - but they are not reactive. Use the
+ * `onStateChange` prop to re-render on a change.
+ */
+export interface CommandFormHandle extends CommandFormState {
+    /**
+     * Executes the command the same way submitting the form does.
+     */
+    execute(): Promise<ICommandResult<unknown>>;
+}
+
 export interface CommandFormContextValue<TCommand> {
     command: Constructor<TCommand>;
     commandInstance: TCommand;
@@ -45,6 +78,12 @@ export interface CommandFormContextValue<TCommand> {
     getFieldError: (propertyName: string) => string | undefined;
     isValid: boolean;
     isAuthorized: boolean;
+
+    /**
+     * Whether at least one execution of the command is in flight. Executions are counted rather than
+     * flagged, so overlapping submissions keep this true until the last one has settled.
+     */
+    isExecuting: boolean;
     /**
      * Claims a token for a silent validation that is about to be issued. Several validations are
      * legitimately in flight at once, so hand the token back to {@link setSilentValidationResult} and a
@@ -90,3 +129,11 @@ export const useCommandFormContext = <TCommand,>() => {
     }
     return context as CommandFormContextValue<TCommand>;
 };
+
+/**
+ * Whether the command form this is used within currently has an execution in flight. Intended for
+ * anything inside the form that has to reflect execution - a submit button that disables itself, a
+ * spinner - without threading state down by hand.
+ * @returns True while at least one execution is in flight.
+ */
+export const useIsCommandExecuting = (): boolean => useCommandFormContext().isExecuting;

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/given/a_command_form_being_executed.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/given/a_command_form_being_executed.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult, type ICommandResult } from '@cratis/arc/commands';
+import { a_command_form_context } from './a_command_form_context';
+
+/**
+ * An execution the spec decides the outcome of. Without one, the window in which the form is
+ * executing closes before anything can observe it - the assertion would be racing the command.
+ */
+export class a_settleable_execution {
+    readonly promise: Promise<ICommandResult<unknown>>;
+    private _resolve!: (result: ICommandResult<unknown>) => void;
+    private _reject!: (reason: unknown) => void;
+
+    constructor() {
+        this.promise = new Promise<ICommandResult<unknown>>((resolve, reject) => {
+            this._resolve = resolve;
+            this._reject = reject;
+        });
+    }
+
+    succeed(result: ICommandResult<unknown>) {
+        this._resolve(result);
+    }
+
+    fail(reason: unknown) {
+        this._reject(reason);
+    }
+}
+
+export class a_command_form_being_executed extends a_command_form_context {
+    readonly executions: a_settleable_execution[] = [];
+
+    /**
+     * An execute implementation that hands out a fresh unsettled execution per call, recorded in
+     * {@link executions} in call order, so overlapping calls can be settled independently.
+     */
+    executeDeferred = () => {
+        const execution = new a_settleable_execution();
+        this.executions.push(execution);
+        return execution.promise;
+    };
+
+    /**
+     * The suite context is constructed once for the whole suite, not once per example, so the
+     * executions recorded by one example are still here for the next one. Call this first: without it
+     * the next example settles the previous example's execution and waits forever on its own.
+     */
+    reset() {
+        this.executions.length = 0;
+    }
+
+    successfulResult(): ICommandResult<unknown> {
+        return new CommandResult({
+            correlationId: 'b0d1e1b6-3b7b-4a1e-9a0c-2a5a5b7a91f1',
+            isSuccess: true,
+            isAuthorized: true,
+            isValid: true,
+            hasExceptions: false,
+            validationResults: [],
+            exceptionMessages: [],
+            exceptionStackTrace: '',
+            authorizationFailureReason: '',
+            response: {}
+        }, Object, false) as unknown as ICommandResult<unknown>;
+    }
+}

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_a_seeded_value_was_typed_over.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_a_seeded_value_was_typed_over.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
+import { CommandForm, useCommandFormContext } from '../../CommandForm';
+import { asCommandFormField } from '../../asCommandFormField';
+import { Command } from '@cratis/arc/commands';
+import { TestCommand } from '../TestCommand';
+import { a_command_form_being_executed } from '../given/a_command_form_being_executed';
+import { given } from '../../../../given';
+
+const SimpleTextField = asCommandFormField<{
+    value: string;
+    onChange: (value: unknown) => void;
+    onBlur?: () => void;
+    invalid: boolean;
+    required: boolean;
+    errors: string[];
+    'data-testid'?: string;
+}>(
+    (props) => React.createElement('input', {
+        type: 'text',
+        value: props.value,
+        onChange: props.onChange,
+        onBlur: props.onBlur,
+        'data-testid': props['data-testid']
+    }),
+    {
+        defaultValue: '',
+        extractValue: (e: unknown) => (e as React.ChangeEvent<HTMLInputElement>).target.value
+    }
+);
+
+// The seed layer is a stable object, which is how a caller that is not fighting the form writes it.
+const seededValues = { name: 'seed' };
+
+// The control. Reporting execution state adds renders to the form, and extra renders are exactly what
+// makes a seed layer overwrite what the user has typed - which is how the previous attempt at this
+// feature reverted field values on submit. Nothing here is about execution state; it fails the moment
+// the new state disturbs value resolution.
+describe('when executing the command and a seeded value was typed over', given(a_command_form_being_executed, context => {
+    let contextValue: ReturnType<typeof useCommandFormContext> | null = null;
+    let valueBeforeSubmitting: string | undefined;
+    let valueAfterSubmitting: string | undefined;
+
+    const Recorder = () => {
+        contextValue = useCommandFormContext();
+        return React.createElement('div');
+    };
+
+    beforeEach(async () => {
+        context.reset();
+        contextValue = null;
+
+        const renderResult = render(
+            React.createElement(
+                CommandForm,
+                {
+                    command: TestCommand,
+                    currentValues: seededValues
+                },
+                React.createElement(SimpleTextField, {
+                    value: (c: TestCommand) => c.name,
+                    title: 'Name',
+                    'data-testid': 'name-input'
+                }),
+                React.createElement(Recorder)
+            ),
+            { wrapper: context.createWrapper() }
+        );
+
+        const nameInput = renderResult.getByTestId('name-input') as HTMLInputElement;
+        await waitFor(() => { expect((contextValue!.commandInstance as TestCommand).name).to.equal('seed'); });
+
+        await act(async () => {
+            fireEvent.change(nameInput, { target: { value: 'typed-by-user' } });
+        });
+        valueBeforeSubmitting = (contextValue!.commandInstance as TestCommand).name;
+
+        let pending: Promise<unknown> = Promise.resolve();
+        await act(async () => {
+            (contextValue!.commandInstance as unknown as Command).execute = context.executeDeferred as never;
+            pending = contextValue!.onExecute!();
+        });
+
+        await act(async () => {
+            context.executions[0].succeed(context.successfulResult());
+            await pending;
+        });
+
+        valueAfterSubmitting = (contextValue!.commandInstance as TestCommand).name;
+    });
+
+    it('should hold the typed value before submitting', () => expect(valueBeforeSubmitting).to.equal('typed-by-user'));
+    it('should still hold the typed value after submitting', () => expect(valueAfterSubmitting).to.equal('typed-by-user'));
+    it('should not have reverted to the seeded value', () => expect(valueAfterSubmitting).to.not.equal('seed'));
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_command_rejects.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_command_rejects.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { CommandForm, useCommandFormContext } from '../../CommandForm';
+import { useIsCommandExecuting } from '../../CommandFormContext';
+import { Command } from '@cratis/arc/commands';
+import { TestCommand } from '../TestCommand';
+import { a_command_form_being_executed } from '../given/a_command_form_being_executed';
+import { given } from '../../../../given';
+
+// The count is given back in a finally, not a catch: a form that is left permanently executing after a
+// network failure is unusable, and swallowing the rejection to achieve that would hide the failure from
+// the caller. Both halves are asserted here.
+describe('when executing the command and the command rejects', given(a_command_form_being_executed, context => {
+    const failure = new Error('the command could not be reached');
+    let isExecuting = false;
+    let contextValue: ReturnType<typeof useCommandFormContext> | null = null;
+    let caught: unknown;
+
+    const Recorder = () => {
+        contextValue = useCommandFormContext();
+        isExecuting = useIsCommandExecuting();
+        return React.createElement('div');
+    };
+
+    beforeEach(async () => {
+        context.reset();
+        contextValue = null;
+        caught = undefined;
+
+        render(
+            React.createElement(
+                CommandForm,
+                { command: TestCommand },
+                React.createElement(Recorder)
+            ),
+            { wrapper: context.createWrapper() }
+        );
+        await act(async () => { await Promise.resolve(); });
+
+        let pending: Promise<unknown> = Promise.resolve();
+        await act(async () => {
+            (contextValue!.commandInstance as unknown as Command).execute = context.executeDeferred as never;
+            pending = contextValue!.onExecute!().catch(reason => { caught = reason; });
+        });
+
+        await act(async () => {
+            context.executions[0].fail(failure);
+            await pending;
+        });
+    });
+
+    it('should stop reporting executing', () => isExecuting.should.be.false);
+    it('should let the rejection propagate unchanged', () => expect(caught).to.equal(failure));
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_handle_is_held_across_a_parent_render.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_handle_is_held_across_a_parent_render.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { CommandForm } from '../../CommandForm';
+import type { CommandFormHandle } from '../../CommandFormContext';
+import { TestCommand } from '../TestCommand';
+import { a_command_form_being_executed } from '../given/a_command_form_being_executed';
+import { given } from '../../../../given';
+
+// The regression guard for the re-attach loop. A handle rebuilt on every render re-attaches the
+// callback ref on every render, and a parent that stores what the ref hands it re-renders in response -
+// which rebuilds the handle again. The ref callback itself is stable here, so the only thing that can
+// re-invoke it is the handle changing identity.
+describe('when executing the command and the handle is held across a parent render', given(a_command_form_being_executed, context => {
+    let attachments = 0;
+    let detachments = 0;
+    let handle: CommandFormHandle | null = null;
+    let renderParentAgain: () => void = () => { /* replaced on first render */ };
+
+    const Parent = () => {
+        const [renderCount, setRenderCount] = React.useState(0);
+        renderParentAgain = () => setRenderCount(count => count + 1);
+
+        const formRef = React.useCallback((formHandle: CommandFormHandle | null) => {
+            if (formHandle) {
+                attachments++;
+                handle = formHandle;
+            } else {
+                detachments++;
+            }
+        }, []);
+
+        return React.createElement(
+            'div',
+            null,
+            React.createElement('span', { 'data-testid': 'render-count' }, String(renderCount)),
+            React.createElement(CommandForm, { command: TestCommand, formRef })
+        );
+    };
+
+    beforeEach(async () => {
+        context.reset();
+        attachments = 0;
+        detachments = 0;
+        handle = null;
+
+        render(React.createElement(Parent), { wrapper: context.createWrapper() });
+        await act(async () => { await Promise.resolve(); });
+
+        for (let i = 0; i < 3; i++) {
+            await act(async () => {
+                renderParentAgain();
+            });
+        }
+    });
+
+    it('should attach the handle exactly once', () => expect(attachments).to.equal(1));
+    it('should not detach the handle while the form is mounted', () => expect(detachments).to.equal(0));
+    it('should expose an execute function on the handle', () => expect(typeof handle!.execute).to.equal('function'));
+    it('should report the form as not executing', () => handle!.isExecuting.should.be.false);
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_parent_is_notified.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_parent_is_notified.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { CommandForm, useCommandFormContext } from '../../CommandForm';
+import type { CommandFormState } from '../../CommandFormContext';
+import { Command } from '@cratis/arc/commands';
+import { TestCommand } from '../TestCommand';
+import { a_command_form_being_executed } from '../given/a_command_form_being_executed';
+import { given } from '../../../../given';
+
+// An imperative handle cannot re-render a parent, so a submit button outside the form would never
+// follow execution without this channel. The callback is deliberately an inline arrow - the most
+// common way a parent writes it, and the one that re-fires an effect that depends on it.
+describe('when executing the command and the parent is notified', given(a_command_form_being_executed, context => {
+    const notifications: CommandFormState[] = [];
+    let contextValue: ReturnType<typeof useCommandFormContext> | null = null;
+    let renderParentAgain: () => void = () => { /* replaced on first render */ };
+    let notificationsBeforeTheParentRerendered = 0;
+    let notificationsAfterTheParentRerendered = 0;
+
+    const Recorder = () => {
+        contextValue = useCommandFormContext();
+        return React.createElement('div');
+    };
+
+    const Parent = () => {
+        const [renderCount, setRenderCount] = React.useState(0);
+        renderParentAgain = () => setRenderCount(count => count + 1);
+
+        return React.createElement(
+            'div',
+            null,
+            React.createElement('span', { 'data-testid': 'render-count' }, String(renderCount)),
+            React.createElement(
+                CommandForm,
+                {
+                    command: TestCommand,
+                    onStateChange: (state: CommandFormState) => { notifications.push({ ...state }); }
+                },
+                React.createElement(Recorder)
+            )
+        );
+    };
+
+    beforeEach(async () => {
+        context.reset();
+        notifications.length = 0;
+        contextValue = null;
+
+        render(React.createElement(Parent), { wrapper: context.createWrapper() });
+        await act(async () => { await Promise.resolve(); });
+
+        notificationsBeforeTheParentRerendered = notifications.length;
+        for (let i = 0; i < 3; i++) {
+            await act(async () => {
+                renderParentAgain();
+            });
+        }
+        notificationsAfterTheParentRerendered = notifications.length;
+
+        let pending: Promise<unknown> = Promise.resolve();
+        await act(async () => {
+            (contextValue!.commandInstance as unknown as Command).execute = context.executeDeferred as never;
+            pending = contextValue!.onExecute!();
+        });
+
+        await act(async () => {
+            context.executions[0].succeed(context.successfulResult());
+            await pending;
+        });
+    });
+
+    it('should tell the parent that execution started', () => notifications.some(state => state.isExecuting).should.be.true);
+    it('should tell the parent that execution finished', () => notifications[notifications.length - 1].isExecuting.should.be.false);
+    it('should report the transition in order', () => {
+        const executionReadings = notifications.map(state => state.isExecuting);
+        const changes = executionReadings.filter((value, index) => index === 0 || value !== executionReadings[index - 1]);
+        expect(changes).to.eql([false, true, false]);
+    });
+    it('should not notify again for a parent re-render alone', () => expect(notificationsAfterTheParentRerendered).to.equal(notificationsBeforeTheParentRerendered));
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_state_transitions.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_state_transitions.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { CommandForm, useCommandFormContext } from '../../CommandForm';
+import { useIsCommandExecuting } from '../../CommandFormContext';
+import { Command } from '@cratis/arc/commands';
+import { TestCommand } from '../TestCommand';
+import { a_command_form_being_executed } from '../given/a_command_form_being_executed';
+import { given } from '../../../../given';
+
+// Asserting only "it stops reporting executing" is vacuous - a form that never reports executing at
+// all passes it. The whole sequence is recorded and asserted instead, so the true in the middle is
+// what the spec is really about.
+describe('when executing the command and the state transitions', given(a_command_form_being_executed, context => {
+    const readings: boolean[] = [];
+    let contextValue: ReturnType<typeof useCommandFormContext> | null = null;
+
+    const Recorder = () => {
+        contextValue = useCommandFormContext();
+        const isExecuting = useIsCommandExecuting();
+        if (readings[readings.length - 1] !== isExecuting) {
+            readings.push(isExecuting);
+        }
+        return React.createElement('div');
+    };
+
+    beforeEach(async () => {
+        context.reset();
+        readings.length = 0;
+        contextValue = null;
+
+        render(
+            React.createElement(
+                CommandForm,
+                { command: TestCommand },
+                React.createElement(Recorder)
+            ),
+            { wrapper: context.createWrapper() }
+        );
+        await act(async () => { await Promise.resolve(); });
+
+        let pending: Promise<unknown> = Promise.resolve();
+        await act(async () => {
+            (contextValue!.commandInstance as unknown as Command).execute = context.executeDeferred as never;
+            pending = contextValue!.onExecute!();
+        });
+
+        await act(async () => {
+            context.executions[0].succeed(context.successfulResult());
+            await pending;
+        });
+    });
+
+    it('should go from not executing to executing and back', () => expect(readings).to.eql([false, true, false]));
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_two_executions_overlap.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_two_executions_overlap.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { CommandForm, useCommandFormContext } from '../../CommandForm';
+import { useIsCommandExecuting } from '../../CommandFormContext';
+import { Command } from '@cratis/arc/commands';
+import { TestCommand } from '../TestCommand';
+import { a_command_form_being_executed } from '../given/a_command_form_being_executed';
+import { given } from '../../../../given';
+
+// Nothing stops a second submission while the first is still in flight. A flag would be cleared by
+// whichever one settles first and the form would report itself idle with a command still running, so
+// executions are counted: 0 -> 1 -> 2 -> 1 -> 0.
+describe('when executing the command and two executions overlap', given(a_command_form_being_executed, context => {
+    let isExecuting = false;
+    let contextValue: ReturnType<typeof useCommandFormContext> | null = null;
+    let whileBothAreInFlight = false;
+    let afterTheFirstSettles = false;
+    let afterTheLastSettles = false;
+
+    const Recorder = () => {
+        contextValue = useCommandFormContext();
+        isExecuting = useIsCommandExecuting();
+        return React.createElement('div');
+    };
+
+    beforeEach(async () => {
+        context.reset();
+        contextValue = null;
+
+        render(
+            React.createElement(
+                CommandForm,
+                { command: TestCommand },
+                React.createElement(Recorder)
+            ),
+            { wrapper: context.createWrapper() }
+        );
+        await act(async () => { await Promise.resolve(); });
+
+        let first: Promise<unknown> = Promise.resolve();
+        let second: Promise<unknown> = Promise.resolve();
+
+        await act(async () => {
+            (contextValue!.commandInstance as unknown as Command).execute = context.executeDeferred as never;
+            first = contextValue!.onExecute!();
+        });
+
+        await act(async () => {
+            second = contextValue!.onExecute!();
+        });
+        whileBothAreInFlight = isExecuting;
+
+        await act(async () => {
+            context.executions[0].succeed(context.successfulResult());
+            await first;
+        });
+        afterTheFirstSettles = isExecuting;
+
+        await act(async () => {
+            context.executions[1].succeed(context.successfulResult());
+            await second;
+        });
+        afterTheLastSettles = isExecuting;
+    });
+
+    it('should have started two executions', () => expect(context.executions.length).to.equal(2));
+    it('should report executing while both are in flight', () => whileBothAreInFlight.should.be.true);
+    it('should still report executing after the first one settles', () => afterTheFirstSettles.should.be.true);
+    it('should stop reporting executing once the last one settles', () => afterTheLastSettles.should.be.false);
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_explicit_required_override.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_explicit_required_override.tsx
@@ -50,6 +50,7 @@ describe('when field has explicit required override', () => {
                 customFieldErrors: {},
                 isValid: true,
                 isAuthorized: true,
+                isExecuting: false,
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 setFieldValidity: () => {},
                 showTitles: true,
@@ -108,6 +109,7 @@ describe('when field has explicit required override', () => {
                 customFieldErrors: {},
                 isValid: true,
                 isAuthorized: true,
+                isExecuting: false,
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 setFieldValidity: () => {},
                 showTitles: true,

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_no_property_descriptor.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_no_property_descriptor.tsx
@@ -48,6 +48,7 @@ describe('when field has no property descriptor', () => {
             customFieldErrors: {},
             isValid: true,
             isAuthorized: true,
+            isExecuting: false,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             setFieldValidity: () => {},
             showTitles: true,

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_non_nullable_property.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_non_nullable_property.tsx
@@ -49,6 +49,7 @@ describe('when field has non-nullable property', () => {
             customFieldErrors: {},
             isValid: true,
             isAuthorized: true,
+            isExecuting: false,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             setFieldValidity: () => {},
             showTitles: true,

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_nullable_property.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_asCommandFormField/when_field_has_nullable_property.tsx
@@ -49,6 +49,7 @@ describe('when field has nullable property', () => {
             customFieldErrors: {},
             isValid: true,
             isAuthorized: true,
+            isExecuting: false,
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             setFieldValidity: () => {},
             showTitles: true,


### PR DESCRIPTION
## Added

- `useIsCommandExecuting` for reading whether a `CommandForm`'s command is currently executing (#2497)
- `formRef` on `CommandForm`, exposing `execute()` plus `isExecuting`, `isValid` and `isAuthorized` to a parent rendering its own submit control (#2497)
- `onStateChange` on `CommandForm`, notifying a parent when execution, validity or authorization changes (#2497)
- `isExecuting` on the command form context (#2497)
