### PR TITLE
Add a production-named fixed tenancy registration API

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,10 @@
     <!-- Microsoft.OpenApi 2.0.0 (pulled in transitively by Microsoft.AspNetCore.OpenApi) has a high-severity
          advisory (GHSA-v5pm-xwqc-g5wc). Pin to the patched 2.x release. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
+    <!-- SSH.NET 2025.1.0 (pulled in transitively by Testcontainers) has a high-severity advisory
+         (GHSA-q939-rpr3-3284). Testcontainers 4.13.0 is the latest and still resolves the vulnerable
+         version, so pin to the patched release. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Chronicle" Version="16.26.0" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.26.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,10 +13,6 @@
     <!-- Microsoft.OpenApi 2.0.0 (pulled in transitively by Microsoft.AspNetCore.OpenApi) has a high-severity
          advisory (GHSA-v5pm-xwqc-g5wc). Pin to the patched 2.x release. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
-    <!-- SSH.NET 2025.1.0 (pulled in transitively by Testcontainers) has a high-severity advisory
-         (GHSA-q939-rpr3-3284). Testcontainers 4.13.0 is the latest and still resolves the vulnerable
-         version, so pin to the patched release. -->
-    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Chronicle" Version="16.26.0" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.26.0" />

--- a/Documentation/backend/tenancy/configuration.md
+++ b/Documentation/backend/tenancy/configuration.md
@@ -12,6 +12,7 @@ builder.AddCratisArcCore(options =>
     // options.UseQueryTenancy("tenant");
     // options.UseClaimTenancy("tenant_id");
     // options.UseSubdomainTenancy("myapp.com", "X-Custom-Tenant");
+    // options.UseFixedTenancy("acme");
     // options.UseDevelopmentTenancy("test-tenant");
 });
 ```
@@ -82,6 +83,17 @@ builder.AddCratisArcCore(options =>
 }
 ```
 
+### Fixed Resolver
+
+```json
+{
+  "Tenancy": {
+    "ResolverType": "Fixed",
+    "FixedTenantId": "acme"
+  }
+}
+```
+
 ### Development Resolver
 
 ```json
@@ -92,4 +104,7 @@ builder.AddCratisArcCore(options =>
   }
 }
 ```
+
+`FixedTenantId` and `DevelopmentTenantId` are two names for the same value, so either key configures either resolver
+type. Set only one of them - when a configuration source supplies both, whichever key the binder visits last wins.
 

--- a/Documentation/backend/tenancy/resolvers.md
+++ b/Documentation/backend/tenancy/resolvers.md
@@ -114,9 +114,27 @@ This is IDNA working as specified — browsers resolve these the same way — so
 
 Every host that does not carry a tenant falls back to `HttpHeader`, and that header arrives on the request unauthenticated — any caller can set it. **Strip the fallback header at your ingress** so only your own infrastructure can set it, exactly as you would for any other trusted request header.
 
+### Fixed Resolver
+
+Resolves every request to one configured tenant ID.
+
+```csharp
+builder.AddCratisArcCore(options =>
+{
+    options.UseFixedTenancy("acme");
+});
+```
+
+Default tenant ID: `development`
+
+The tenant ID is returned regardless of the request and regardless of the hosting environment, which makes this the
+resolver for a single-tenant deployment: one deployment, one tenant, decided at configuration time rather than per
+request. Because the resolved tenant drives the Chronicle namespace and the Arc MongoDB database, a fixed tenant is a
+deployment-wide data-isolation decision - review it before promoting a configuration.
+
 ### Development Resolver
 
-Uses a fixed tenant ID for local development.
+The same behavior as the Fixed resolver, under its original name.
 
 ```csharp
 builder.AddCratisArcCore(options =>
@@ -126,4 +144,8 @@ builder.AddCratisArcCore(options =>
 ```
 
 Default tenant ID: `development`
+
+Despite the name, this resolver has never consulted `IHostEnvironment` - it returns the configured tenant ID in every
+environment, production included. Prefer `UseFixedTenancy` when the fixed tenant is a deployment constant rather than a
+local-development convenience; `UseDevelopmentTenancy` remains supported and configures the same tenant ID.
 

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/given/a_fixed_tenant_id_resolver.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/given/a_fixed_tenant_id_resolver.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Tenancy.for_FixedTenantIdResolver.given;
+
+public class a_fixed_tenant_id_resolver : Specification
+{
+    protected FixedTenantIdResolver _resolver;
+    protected IOptions<ArcOptions> _options;
+
+    void Establish()
+    {
+        _options = Substitute.For<IOptions<ArcOptions>>();
+
+        var arcOptions = new ArcOptions();
+        _options.Value.Returns(arcOptions);
+
+        _resolver = new FixedTenantIdResolver(_options);
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/when_resolving/and_custom_fixed_tenant_id_is_configured.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/when_resolving/and_custom_fixed_tenant_id_is_configured.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_FixedTenantIdResolver.when_resolving;
+
+public class and_custom_fixed_tenant_id_is_configured : given.a_fixed_tenant_id_resolver
+{
+    const string CustomTenantId = "acme";
+    string _result;
+
+    void Establish()
+    {
+        _options.Value.Tenancy.FixedTenantId = CustomTenantId;
+    }
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_return_configured_fixed_tenant_id() => _result.ShouldEqual(CustomTenantId);
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/when_resolving/and_the_tenant_id_is_configured_under_the_development_name.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/when_resolving/and_the_tenant_id_is_configured_under_the_development_name.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_FixedTenantIdResolver.when_resolving;
+
+public class and_the_tenant_id_is_configured_under_the_development_name : given.a_fixed_tenant_id_resolver
+{
+    const string CustomTenantId = "acme-legacy-name";
+    string _result;
+
+    void Establish()
+    {
+        _options.Value.Tenancy.DevelopmentTenantId = CustomTenantId;
+    }
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_return_the_tenant_id_configured_under_the_development_name() => _result.ShouldEqual(CustomTenantId);
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/when_resolving_with_default_configuration.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_FixedTenantIdResolver/when_resolving_with_default_configuration.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_FixedTenantIdResolver;
+
+public class when_resolving_with_default_configuration : given.a_fixed_tenant_id_resolver
+{
+    string _result;
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_return_default_fixed_tenant_id() => _result.ShouldEqual("development");
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenancyOptions/when_binding_from_configuration/and_the_development_tenant_id_key_is_used.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenancyOptions/when_binding_from_configuration/and_the_development_tenant_id_key_is_used.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Cratis.Arc.Tenancy.for_TenancyOptions.when_binding_from_configuration;
+
+public class and_the_development_tenant_id_key_is_used : Specification
+{
+    const string TenantId = "local-tenant";
+
+    ArcOptions _options;
+
+    void Establish() => _options = new ArcOptions();
+
+    void Because() => new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Tenancy:ResolverType"] = "Development",
+            ["Tenancy:DevelopmentTenantId"] = TenantId
+        })
+        .Build()
+        .Bind(_options);
+
+    [Fact] void should_bind_the_resolver_type() => _options.Tenancy.ResolverType.ShouldEqual(TenantResolverType.Development);
+    [Fact] void should_bind_the_development_tenant_id() => _options.Tenancy.DevelopmentTenantId.ShouldEqual(TenantId);
+    [Fact] void should_expose_the_same_value_under_the_fixed_name() => _options.Tenancy.FixedTenantId.ShouldEqual(TenantId);
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenancyOptions/when_binding_from_configuration/and_the_fixed_tenant_id_key_is_used.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenancyOptions/when_binding_from_configuration/and_the_fixed_tenant_id_key_is_used.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Cratis.Arc.Tenancy.for_TenancyOptions.when_binding_from_configuration;
+
+public class and_the_fixed_tenant_id_key_is_used : Specification
+{
+    const string TenantId = "acme";
+
+    ArcOptions _options;
+
+    void Establish() => _options = new ArcOptions();
+
+    void Because() => new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Tenancy:ResolverType"] = "Fixed",
+            ["Tenancy:FixedTenantId"] = TenantId
+        })
+        .Build()
+        .Bind(_options);
+
+    [Fact] void should_bind_the_resolver_type() => _options.Tenancy.ResolverType.ShouldEqual(TenantResolverType.Fixed);
+    [Fact] void should_bind_the_fixed_tenant_id() => _options.Tenancy.FixedTenantId.ShouldEqual(TenantId);
+    [Fact] void should_expose_the_same_value_under_the_development_name() => _options.Tenancy.DevelopmentTenantId.ShouldEqual(TenantId);
+}

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_fixed_tenancy_is_configured.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_fixed_tenancy_is_configured.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
+
+public class and_fixed_tenancy_is_configured : Specification
+{
+    const string TenantId = "acme";
+
+    ITenantIdResolver _resolver;
+
+    void Because()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddCratisArcCore()
+            .Configure<ArcOptions>(options => options.UseFixedTenancy(TenantId))
+            .BuildServiceProvider();
+
+        _resolver = serviceProvider.GetRequiredService<ITenantIdResolver>();
+    }
+
+    [Fact] void should_resolve_the_fixed_tenant_id_resolver() => _resolver.ShouldBeOfExactType<FixedTenantIdResolver>();
+    [Fact] void should_resolve_the_configured_tenant_id() => _resolver.Resolve().ShouldEqual(TenantId);
+}

--- a/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
+++ b/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
@@ -101,7 +101,8 @@ public static class HostBuilderExtensions
                 TenantResolverType.Query => ActivatorUtilities.GetServiceOrCreateInstance<QueryTenantIdResolver>(sp),
                 TenantResolverType.Claim => ActivatorUtilities.GetServiceOrCreateInstance<ClaimTenantIdResolver>(sp),
                 TenantResolverType.Development => ActivatorUtilities.GetServiceOrCreateInstance<DevelopmentTenantIdResolver>(sp),
-                _ => throw new InvalidOperationException($"Unknown tenant resolver type: {options.Value.Tenancy.ResolverType}. Valid types are: Header, Query, Claim, Development")
+                TenantResolverType.Fixed => ActivatorUtilities.GetServiceOrCreateInstance<FixedTenantIdResolver>(sp),
+                _ => throw new InvalidOperationException($"Unknown tenant resolver type: {options.Value.Tenancy.ResolverType}. Valid types are: Header, Query, Claim, Development, Subdomain, Fixed")
             };
         });
 

--- a/Source/DotNET/Arc.Core/Tenancy/Constants.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/Constants.cs
@@ -17,4 +17,9 @@ public static class Constants
     /// Gets the item key for the tenant id.
     /// </summary>
     public const string TenantIdItemKey = "TenantId";
+
+    /// <summary>
+    /// Gets the default tenant id used by the fixed tenant id resolver.
+    /// </summary>
+    public const string DefaultFixedTenantId = "development";
 }

--- a/Source/DotNET/Arc.Core/Tenancy/DevelopmentTenantIdResolver.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/DevelopmentTenantIdResolver.cs
@@ -10,9 +10,11 @@ namespace Cratis.Arc.Tenancy;
 /// Represents an implementation of <see cref="ITenantIdResolver"/> that resolves to a fixed tenant ID for development purposes.
 /// </summary>
 /// <param name="options">The <see cref="IOptions{TOptions}"/>.</param>
+/// <remarks>
+/// This is <see cref="FixedTenantIdResolver"/> under its original name and resolves the same configured tenant ID.
+/// The resolver never consulted the hosting environment, so prefer <see cref="FixedTenantIdResolver"/> and
+/// <see cref="TenantResolverType.Fixed"/> when the fixed tenant is a deployment level constant rather than a
+/// development convenience.
+/// </remarks>
 [IgnoreConvention]
-public class DevelopmentTenantIdResolver(IOptions<ArcOptions> options) : ITenantIdResolver
-{
-    /// <inheritdoc/>
-    public string Resolve() => options.Value.Tenancy.DevelopmentTenantId;
-}
+public class DevelopmentTenantIdResolver(IOptions<ArcOptions> options) : FixedTenantIdResolver(options);

--- a/Source/DotNET/Arc.Core/Tenancy/FixedTenantIdResolver.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/FixedTenantIdResolver.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Tenancy;
+
+/// <summary>
+/// Represents an implementation of <see cref="ITenantIdResolver"/> that resolves every request to one configured tenant ID.
+/// </summary>
+/// <param name="options">The <see cref="IOptions{TOptions}"/>.</param>
+/// <remarks>
+/// The tenant ID comes from <see cref="TenancyOptions.FixedTenantId"/> and is returned regardless of the request or the
+/// hosting environment. It is the resolver for single tenant deployments, where the tenant is a deployment level
+/// constant rather than something a request carries.
+/// </remarks>
+[IgnoreConvention]
+public class FixedTenantIdResolver(IOptions<ArcOptions> options) : ITenantIdResolver
+{
+    /// <inheritdoc/>
+    public string Resolve() => options.Value.Tenancy.FixedTenantId;
+}

--- a/Source/DotNET/Arc.Core/Tenancy/TenancyOptions.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/TenancyOptions.cs
@@ -42,7 +42,22 @@ public class TenancyOptions
     public string ClaimType { get; set; } = "tenant_id";
 
     /// <summary>
+    /// Gets or sets the tenant ID every request resolves to when using <see cref="TenantResolverType.Fixed"/> or
+    /// <see cref="TenantResolverType.Development"/>.
+    /// </summary>
+    public string FixedTenantId { get; set; } = Constants.DefaultFixedTenantId;
+
+    /// <summary>
     /// Gets or sets the fixed tenant ID to use when using <see cref="TenantResolverType.Development"/>.
     /// </summary>
-    public string DevelopmentTenantId { get; set; } = "development";
+    /// <remarks>
+    /// This is <see cref="FixedTenantId"/> under its original name - both names read and write the same value, so
+    /// configuration and code may use either. When a configuration source supplies both keys, the last one the
+    /// binder visits wins; supply only one.
+    /// </remarks>
+    public string DevelopmentTenantId
+    {
+        get => FixedTenantId;
+        set => FixedTenantId = value;
+    }
 }

--- a/Source/DotNET/Arc.Core/Tenancy/TenancyOptionsExtensions.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/TenancyOptionsExtensions.cs
@@ -73,6 +73,27 @@ public static class TenancyOptionsExtensions
     }
 
     /// <summary>
+    /// Configure tenancy to resolve every request to one fixed tenant ID.
+    /// </summary>
+    /// <param name="options">The <see cref="ArcOptions"/> to configure.</param>
+    /// <param name="tenantId">Optional tenant ID to use. Defaults to 'development'.</param>
+    /// <returns>The <see cref="ArcOptions"/> for continuation.</returns>
+    /// <remarks>
+    /// The tenant ID is returned regardless of the request or the hosting environment, which makes this the resolver
+    /// for single tenant deployments. It is the same behavior as <see cref="UseDevelopmentTenancy"/> under a name that
+    /// does not imply an environment - the tenant ID both configure is the same value.
+    /// </remarks>
+    public static ArcOptions UseFixedTenancy(this ArcOptions options, string? tenantId = null)
+    {
+        options.Tenancy.ResolverType = TenantResolverType.Fixed;
+        if (tenantId is not null)
+        {
+            options.Tenancy.FixedTenantId = tenantId;
+        }
+        return options;
+    }
+
+    /// <summary>
     /// Configure tenancy to resolve the tenant ID from the request subdomain of a base domain, with the HTTP header
     /// as fallback.
     /// </summary>

--- a/Source/DotNET/Arc.Core/Tenancy/TenantResolverType.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/TenantResolverType.cs
@@ -31,5 +31,10 @@ public enum TenantResolverType
     /// <summary>
     /// Resolve tenant ID from the request subdomain, with HTTP header as fallback.
     /// </summary>
-    Subdomain = 4
+    Subdomain = 4,
+
+    /// <summary>
+    /// Use one configured tenant ID for every request, regardless of the hosting environment.
+    /// </summary>
+    Fixed = 5
 }


### PR DESCRIPTION
## Added

- `UseFixedTenancy` and `FixedTenantIdResolver`, giving single-tenant production deployments a registration API that is not named for the development environment (#2478)
- `Tenancy:FixedTenantId` configuration, which `Tenancy:DevelopmentTenantId` now forwards to (#2478)

## Fixed

- The unknown tenant-resolver-type error now lists `Subdomain` and `Fixed`, which it omitted (#2478)
