### PR TITLE
Declare server-consumed command response types

### DIFF
--- a/Arc.slnx
+++ b/Arc.slnx
@@ -39,6 +39,8 @@
         <Project Path="Source\DotNET\Tools\ProxyGenerator\ProxyGenerator.csproj" />
         <Project Path="Source\DotNET\Tools\ProxyGenerator.Build\ProxyGenerator.Build.csproj" />
         <Project Path="Source\DotNET\Tools\ProxyGenerator.Specs\ProxyGenerator.Specs.csproj" />
+        <Project Path="Source\DotNET\Tools\ProxyGenerator.Specs\TestArtifacts\CommandResponseHandlerDependency\CommandResponseHandlerDependency.csproj" />
+        <Project Path="Source\DotNET\Tools\ProxyGenerator.Specs\TestArtifacts\FakeCommandResponseHandlerDependency\FakeCommandResponseHandlerDependency.csproj" />
     </Folder>
     <Folder Name="/TestApps/">
         <Project Path="TestApps\AspNetCore\AspNetCore.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Transitive security pins -->
+    <!-- SSH.NET through Testcontainers <= 2025.1.0 has a high-severity advisory
+         (GHSA-q939-rpr3-3284). Pin the transitive dependency to the patched release. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <!-- SQLitePCLRaw 2.1.10/2.1.11 (pulled in transitively by EF Core Sqlite) has a high-severity advisory
          (GHSA-2m69-gcr7-jv3q). Pin the native library to the patched release. -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />

--- a/Documentation/backend/commands/response-value-handlers.md
+++ b/Documentation/backend/commands/response-value-handlers.md
@@ -84,10 +84,14 @@ public record CreateUser(string Name, string Email)
 
 ## Creating Custom Value Handlers
 
-You can create custom response value handlers by implementing the `ICommandResponseValueHandler` interface:
+You can create custom response value handlers by implementing the runtime `ICommandResponseValueHandler` interface.
+When the handler consumes a statically known type, also implement `ICommandResponseValueHandler<TValue>` so build-time
+tools know that the value is handled on the server and must not be generated as a client response model:
 
 ```csharp
-public class AuditInfoResponseValueHandler : ICommandResponseValueHandler
+public class AuditInfoResponseValueHandler :
+    ICommandResponseValueHandler,
+    ICommandResponseValueHandler<AuditInfo>
 {
     public bool CanHandle(CommandContext commandContext, object value)
     {
@@ -108,6 +112,11 @@ public class AuditInfoResponseValueHandler : ICommandResponseValueHandler
 ```
 
 The Arc will automatically discover and register custom value handlers in the command pipeline.
+
+The typed interface is a declaration for tooling; it does not replace the runtime interface. Implementing only
+`ICommandResponseValueHandler<TValue>` neither registers a runtime handler nor suppresses the client response. A
+handler whose accepted types are determined dynamically at runtime should implement only the runtime interface,
+because declaring an overly broad type such as `object` would hide legitimate client response models.
 
 ## Response Object Availability
 
@@ -184,7 +193,9 @@ In this example:
 ### Example Implementation
 
 ```csharp
-public class MyResponseValueHandler : ICommandResponseValueHandler
+public class MyResponseValueHandler :
+    ICommandResponseValueHandler,
+    ICommandResponseValueHandler<MyValueType>
 {
     public bool CanHandle(CommandContext commandContext, object value)
     {

--- a/Source/DotNET/Arc.Core/Commands/ICommandResponseValueHandler.cs
+++ b/Source/DotNET/Arc.Core/Commands/ICommandResponseValueHandler.cs
@@ -24,3 +24,14 @@ public interface ICommandResponseValueHandler
     /// <returns><see cref="CommandResult"/> representing the result of handling the value.</returns>
     Task<CommandResult> Handle(CommandContext commandContext, object value);
 }
+
+/// <summary>
+/// Defines a command response value handler for a specific value type.
+/// </summary>
+/// <typeparam name="TValue">The type of value consumed by the handler on the server.</typeparam>
+/// <remarks>
+/// The typed declaration lets build-time tooling distinguish values consumed by the command pipeline from values
+/// returned to the client. Runtime handlers continue to implement <see cref="ICommandResponseValueHandler"/>
+/// directly so type discovery and dependency injection retain their existing contract.
+/// </remarks>
+public interface ICommandResponseValueHandler<TValue>;

--- a/Source/DotNET/Arc.Core/Commands/ResponseValueHandlers/AuthorizationResultResponseValueHandler.cs
+++ b/Source/DotNET/Arc.Core/Commands/ResponseValueHandlers/AuthorizationResultResponseValueHandler.cs
@@ -8,7 +8,7 @@ namespace Cratis.Arc.Commands.ResponseValueHandlers;
 /// <summary>
 /// Represents an implementation of <see cref="ICommandResponseValueHandler"/> that handles <see cref="AuthorizationResult"/>.
 /// </summary>
-public class AuthorizationResultResponseValueHandler : ICommandResponseValueHandler
+public class AuthorizationResultResponseValueHandler : ICommandResponseValueHandler, ICommandResponseValueHandler<AuthorizationResult>
 {
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value) => value is AuthorizationResult;

--- a/Source/DotNET/Arc.Core/Commands/ResponseValueHandlers/ValidationResultResponseValueHandler.cs
+++ b/Source/DotNET/Arc.Core/Commands/ResponseValueHandlers/ValidationResultResponseValueHandler.cs
@@ -8,7 +8,7 @@ namespace Cratis.Arc.Commands.ResponseValueHandlers;
 /// <summary>
 /// Represents an implementation of <see cref="ICommandResponseValueHandler"/> that handles <see cref="ValidationResult"/>.
 /// </summary>
-public class ValidationResultResponseValueHandler : ICommandResponseValueHandler
+public class ValidationResultResponseValueHandler : ICommandResponseValueHandler, ICommandResponseValueHandler<ValidationResult>
 {
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value) => value is ValidationResult;

--- a/Source/DotNET/Chronicle/Commands/AggregateRootCommitResultCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/AggregateRootCommitResultCommandResponseValueHandler.cs
@@ -11,7 +11,7 @@ namespace Cratis.Arc.Chronicle.Commands;
 /// into a <see cref="CommandResult"/>, propagating validation results, constraint violations,
 /// concurrency violations, and errors back to the command pipeline.
 /// </summary>
-public class AggregateRootCommitResultCommandResponseValueHandler : ICommandResponseValueHandler
+public class AggregateRootCommitResultCommandResponseValueHandler : ICommandResponseValueHandler, ICommandResponseValueHandler<AggregateRootCommitResult>
 {
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value) =>

--- a/Source/DotNET/Chronicle/Commands/EventsCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/EventsCommandResponseValueHandler.cs
@@ -14,6 +14,11 @@ namespace Cratis.Arc.Chronicle.Commands;
 /// <param name="eventLog">The event log to append events to.</param>
 /// <param name="eventTypes">The event types.</param>
 /// <param name="concurrencyScopeStrategies">The <see cref="IConcurrencyScopeStrategies"/> for resolving the expected sequence number.</param>
+/// <remarks>
+/// This handler intentionally has no typed response declaration. Its event-type registry decides at runtime whether
+/// an arbitrary collection contains domain events; declaring <c>IEnumerable&lt;object&gt;</c> would incorrectly hide
+/// ordinary client response collections from generated proxies.
+/// </remarks>
 public class EventsCommandResponseValueHandler(
     IEventLog eventLog,
     IEventTypes eventTypes,

--- a/Source/DotNET/Chronicle/Commands/EventsForEventSourceIdCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/EventsForEventSourceIdCommandResponseValueHandler.cs
@@ -27,7 +27,7 @@ namespace Cratis.Arc.Chronicle.Commands;
 public class EventsForEventSourceIdCommandResponseValueHandler(
     IEventLog eventLog,
     IEventTypes eventTypes,
-    IConcurrencyScopeStrategies concurrencyScopeStrategies) : ICommandResponseValueHandler
+    IConcurrencyScopeStrategies concurrencyScopeStrategies) : ICommandResponseValueHandler, ICommandResponseValueHandler<IEnumerable<EventForEventSourceId>>
 {
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value)

--- a/Source/DotNET/Chronicle/Commands/EventsWithConcurrencyScopesCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/EventsWithConcurrencyScopesCommandResponseValueHandler.cs
@@ -10,7 +10,7 @@ namespace Cratis.Arc.Chronicle.Commands;
 /// Handles an ordered collection of cross-source events with exact concurrency scopes returned from a command.
 /// </summary>
 /// <param name="eventLog">The event log to append events to.</param>
-public class EventsWithConcurrencyScopesCommandResponseValueHandler(IEventLog eventLog) : ICommandResponseValueHandler
+public class EventsWithConcurrencyScopesCommandResponseValueHandler(IEventLog eventLog) : ICommandResponseValueHandler, ICommandResponseValueHandler<EventsWithConcurrencyScopes>
 {
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value) =>

--- a/Source/DotNET/Chronicle/Commands/SingleEventCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/SingleEventCommandResponseValueHandler.cs
@@ -14,6 +14,11 @@ namespace Cratis.Arc.Chronicle.Commands;
 /// <param name="eventLog">The event log to append events to.</param>
 /// <param name="eventTypes">The event types.</param>
 /// <param name="concurrencyScopeStrategies">The <see cref="IConcurrencyScopeStrategies"/> for resolving the expected sequence number.</param>
+/// <remarks>
+/// This handler intentionally has no typed response declaration. Its event-type registry decides at runtime whether
+/// an arbitrary value is a domain event; declaring <see cref="object"/> would incorrectly hide every client response
+/// type from generated proxies.
+/// </remarks>
 public class SingleEventCommandResponseValueHandler(
     IEventLog eventLog,
     IEventTypes eventTypes,

--- a/Source/DotNET/Chronicle/Commands/SingleEventForEventSourceIdCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/SingleEventForEventSourceIdCommandResponseValueHandler.cs
@@ -17,7 +17,7 @@ namespace Cratis.Arc.Chronicle.Commands;
 public class SingleEventForEventSourceIdCommandResponseValueHandler(
     IEventLog eventLog,
     IEventTypes eventTypes,
-    IConcurrencyScopeStrategies concurrencyScopeStrategies) : ICommandResponseValueHandler
+    IConcurrencyScopeStrategies concurrencyScopeStrategies) : ICommandResponseValueHandler, ICommandResponseValueHandler<EventForEventSourceId>
 {
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value) =>

--- a/Source/DotNET/Chronicle/Commands/SubjectCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/SubjectCommandResponseValueHandler.cs
@@ -9,7 +9,7 @@ namespace Cratis.Arc.Chronicle.Commands;
 /// <summary>
 /// Represents a command response value handler that captures an explicit <see cref="Subject"/> from a command response.
 /// </summary>
-public class SubjectCommandResponseValueHandler : ICommandResponseValueContextUpdater
+public class SubjectCommandResponseValueHandler : ICommandResponseValueContextUpdater, ICommandResponseValueHandler<Subject>
 {
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value) =>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/AssemblyInfo.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
@@ -14,8 +14,11 @@
     <ItemGroup>
         <ProjectReference Include="../ProxyGenerator/ProxyGenerator.csproj" />
         <ProjectReference Include="../../Arc/Arc.csproj" />
-        <ProjectReference Include="TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj" />
-        <ProjectReference Include="TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj" Aliases="FakeContracts" />
+        <ProjectReference Include="TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj"
+                          AdditionalProperties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)" />
+        <ProjectReference Include="TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj"
+                          AdditionalProperties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)"
+                          Aliases="FakeContracts" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
@@ -14,11 +14,8 @@
     <ItemGroup>
         <ProjectReference Include="../ProxyGenerator/ProxyGenerator.csproj" />
         <ProjectReference Include="../../Arc/Arc.csproj" />
-        <ProjectReference Include="TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj"
-                          AdditionalProperties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)" />
-        <ProjectReference Include="TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj"
-                          AdditionalProperties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)"
-                          Aliases="FakeContracts" />
+        <ProjectReference Include="TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj" />
+        <ProjectReference Include="TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj" Aliases="FakeContracts" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
@@ -14,6 +14,8 @@
     <ItemGroup>
         <ProjectReference Include="../ProxyGenerator/ProxyGenerator.csproj" />
         <ProjectReference Include="../../Arc/Arc.csproj" />
+        <ProjectReference Include="TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj" />
+        <ProjectReference Include="TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj" Aliases="FakeContracts" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
@@ -27,6 +29,7 @@
     </ItemGroup>
     <ItemGroup>
         <Compile Remove="$(MSBuildThisFileDirectory)../../GlobalUsings.Specs.cs" />
+        <Compile Remove="TestArtifacts/**/*.cs" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Scenarios\Infrastructure\arc-bootstrap.js" Condition="Exists('Scenarios\Infrastructure\arc-bootstrap.js')" />

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <AssemblyName>Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency</AssemblyName>
         <RootNamespace>Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency</RootNamespace>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="../../../../Arc.Core/Arc.Core.csproj" />

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency</AssemblyName>
+        <RootNamespace>Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../../../Arc.Core/Arc.Core.csproj" />
+    </ItemGroup>
+
+    <Target Name="RemoveTypeDiscoveryGenerator" BeforeTargets="CoreCompile">
+        <ItemGroup>
+            <Analyzer Remove="@(Analyzer)" Condition="$([System.String]::new('%(Analyzer.Identity)').Contains('Cratis.Fundamentals.TypeDiscovery.Generator.dll'))" />
+        </ItemGroup>
+    </Target>
+</Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/DependencyHandledValue.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/DependencyHandledValue.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+/// <summary>
+/// A value handled by a dependency-supplied command response handler.
+/// </summary>
+public record DependencyHandledValue;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/DependencyHandledValueHandler.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/DependencyHandledValueHandler.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+/// <summary>
+/// Handles <see cref="DependencyHandledValue"/> on the server.
+/// </summary>
+public class DependencyHandledValueHandler :
+    ICommandResponseValueHandler,
+    ICommandResponseValueHandler<DependencyHandledValue>,
+    ICommandResponseValueHandler<IEnumerable<DependencyHandledValue>>
+{
+    /// <inheritdoc/>
+    public bool CanHandle(CommandContext commandContext, object value) =>
+        value is DependencyHandledValue or IEnumerable<DependencyHandledValue>;
+
+    /// <inheritdoc/>
+    public Task<CommandResult> Handle(CommandContext commandContext, object value) =>
+        Task.FromResult(CommandResult.Success(commandContext.CorrelationId));
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/MarkerOnlyValue.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/MarkerOnlyValue.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+/// <summary>
+/// A client response value with a declaration that is not backed by a runtime handler.
+/// </summary>
+public record MarkerOnlyValue;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/MarkerOnlyValueDeclaration.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/MarkerOnlyValueDeclaration.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+/// <summary>
+/// Declares a handled type without implementing the runtime handler contract.
+/// </summary>
+public class MarkerOnlyValueDeclaration : ICommandResponseValueHandler<MarkerOnlyValue>;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency</AssemblyName>
+        <RootNamespace>Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency</RootNamespace>
+    </PropertyGroup>
+</Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj
@@ -2,5 +2,6 @@
     <PropertyGroup>
         <AssemblyName>Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency</AssemblyName>
         <RootNamespace>Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency</RootNamespace>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 </Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeHandledValue.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeHandledValue.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency;
+
+/// <summary>
+/// A client response value claimed by counterfeit response-handler contracts.
+/// </summary>
+public record FakeHandledValue;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeHandledValueHandler.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeHandledValueHandler.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency;
+
+/// <summary>
+/// Claims a value through counterfeit response-handler contracts.
+/// </summary>
+public class FakeHandledValueHandler : ICommandResponseValueHandler, ICommandResponseValueHandler<FakeHandledValue>;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/ICommandResponseValueHandler.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/ICommandResponseValueHandler.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Counterfeit runtime response handler contract with the same full name as the Arc contract.
+/// </summary>
+public interface ICommandResponseValueHandler;
+
+/// <summary>
+/// Counterfeit typed response handler declaration with the same full name as the Arc declaration.
+/// </summary>
+/// <typeparam name="TValue">The allegedly handled value.</typeparam>
+public interface ICommandResponseValueHandler<TValue>;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_Generator/when_project_assembly_initialization_fails.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_Generator/when_project_assembly_initialization_fails.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_Generator;
+
+public class when_project_assembly_initialization_fails : Specification
+{
+    string _invalidAssemblyFile;
+    string _outputPath;
+    bool _result;
+
+    void Establish()
+    {
+        _invalidAssemblyFile = Path.Combine(Path.GetTempPath(), $"proxy-generator-invalid-{Guid.NewGuid():N}.dll");
+        _outputPath = Path.Combine(Path.GetTempPath(), $"proxy-generator-output-{Guid.NewGuid():N}");
+        File.WriteAllText(_invalidAssemblyFile, "not a managed assembly");
+    }
+
+    async Task Because() => _result = await Generator.Generate(_invalidAssemblyFile, _outputPath, 0, _ => { }, _ => { });
+
+    void Destroy()
+    {
+        File.Delete(_invalidAssemblyFile);
+        if (Directory.Exists(_outputPath))
+        {
+            Directory.Delete(_outputPath, true);
+        }
+    }
+
+    [Fact] void should_stop_generation() => _result.ShouldBeFalse();
+    [Fact] void should_not_write_any_proxy_files() => Directory.GetFiles(_outputPath, "*", SearchOption.AllDirectories).ShouldBeEmpty();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_a_marker_without_a_runtime_handler_is_returned.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_a_marker_without_a_runtime_handler_is_returned.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_a_marker_without_a_runtime_handler_is_returned : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because() => _result = typeof(command_methods)
+        .GetMethod(nameof(command_methods.ReturnsMarkerOnlyValue))!
+        .GetResponseModel();
+
+    [Fact] void should_expose_a_client_response() => _result.HasResponse.ShouldBeTrue();
+    [Fact] void should_use_the_returned_type() => _result.ResponseModel.Type.ShouldEqual(typeof(MarkerOnlyValue));
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_a_tuple_contains_a_server_handled_value.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_a_tuple_contains_a_server_handled_value.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_a_tuple_contains_a_server_handled_value : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _direct;
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _wrapped;
+
+    void Because()
+    {
+        _ = typeof(DependencyHandledValueHandler).Assembly;
+        _direct = typeof(command_methods).GetMethod(nameof(command_methods.ReturnsHandledAndClientTuple))!.GetResponseModel();
+        _wrapped = typeof(command_methods).GetMethod(nameof(command_methods.ReturnsWrappedHandledAndClientTuple))!.GetResponseModel();
+    }
+
+    [Fact] void should_expose_the_client_value_from_the_direct_tuple() => _direct.ResponseModel.Type.ShouldEqual(typeof(ClientResponse));
+    [Fact] void should_expose_the_client_value_from_the_wrapped_tuple() => _wrapped.ResponseModel.Type.ShouldEqual(typeof(ClientResponse));
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_a_value_is_claimed_by_counterfeit_handler_contracts.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_a_value_is_claimed_by_counterfeit_handler_contracts.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias FakeContracts;
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+using FakeHandledValue = FakeContracts::Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency.FakeHandledValue;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_a_value_is_claimed_by_counterfeit_handler_contracts : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because() => _result = typeof(command_methods)
+        .GetMethod(nameof(command_methods.ReturnsValueClaimedByCounterfeitContracts))!
+        .GetResponseModel();
+
+    [Fact] void should_expose_a_client_response() => _result.HasResponse.ShouldBeTrue();
+    [Fact] void should_use_the_returned_type() => _result.ResponseModel.Type.ShouldEqual(typeof(FakeHandledValue));
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_all_tuple_values_are_server_handled.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_all_tuple_values_are_server_handled.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_all_tuple_values_are_server_handled : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because()
+    {
+        _ = typeof(DependencyHandledValueHandler).Assembly;
+        _result = typeof(command_methods).GetMethod(nameof(command_methods.ReturnsAllHandledTuple))!.GetResponseModel();
+    }
+
+    [Fact] void should_not_expose_a_client_response() => _result.HasResponse.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_an_unhandled_client_collection_is_returned.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_an_unhandled_client_collection_is_returned.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_an_unhandled_client_collection_is_returned : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because() => _result = typeof(command_methods)
+        .GetMethod(nameof(command_methods.ReturnsClientResponses))!
+        .GetResponseModel();
+
+    [Fact] void should_expose_a_client_response() => _result.HasResponse.ShouldBeTrue();
+    [Fact] void should_preserve_the_collection_shape() => _result.ResponseModel.IsEnumerable.ShouldBeTrue();
+    [Fact] void should_use_the_element_type() => _result.ResponseModel.Type.ShouldEqual(typeof(ClientResponse));
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_return_type_implements_a_handled_collection_contract.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_return_type_implements_a_handled_collection_contract.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_the_return_type_implements_a_handled_collection_contract : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because()
+    {
+        _ = typeof(DependencyHandledValueHandler).Assembly;
+        _result = typeof(command_methods)
+            .GetMethod(nameof(command_methods.ReturnsHandledValues))!
+            .GetResponseModel();
+    }
+
+    [Fact] void should_not_expose_a_client_response() => _result.HasResponse.ShouldBeFalse();
+    [Fact] void should_not_create_a_response_model() => _result.ResponseModel.ShouldEqual(Templates.ModelDescriptor.Empty);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_server_handled_value_is_wrapped_in_a_result.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_server_handled_value_is_wrapped_in_a_result.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_the_server_handled_value_is_wrapped_in_a_result : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because()
+    {
+        _ = typeof(DependencyHandledValueHandler).Assembly;
+        _result = typeof(command_methods)
+            .GetMethod(nameof(command_methods.ReturnsServerHandledValueOrValidationResult))!
+            .GetResponseModel();
+    }
+
+    [Fact] void should_not_expose_a_client_response() => _result.HasResponse.ShouldBeFalse();
+    [Fact] void should_not_create_a_response_model() => _result.ResponseModel.ShouldEqual(Templates.ModelDescriptor.Empty);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_value_has_no_server_handler.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_value_has_no_server_handler.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_the_value_has_no_server_handler : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because() => _result = typeof(command_methods)
+        .GetMethod(nameof(command_methods.ReturnsClientResponse))!
+        .GetResponseModel();
+
+    [Fact] void should_expose_a_client_response() => _result.HasResponse.ShouldBeTrue();
+    [Fact] void should_use_the_returned_type() => _result.ResponseModel.Type.ShouldEqual(typeof(ClientResponse));
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_value_is_consumed_by_a_dependency_handler.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/and_the_value_is_consumed_by_a_dependency_handler.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model;
+
+public class and_the_value_is_consumed_by_a_dependency_handler : Specification
+{
+    (bool HasResponse, Templates.ModelDescriptor ResponseModel) _result;
+
+    void Because()
+    {
+        _ = typeof(DependencyHandledValueHandler).Assembly;
+        _result = typeof(command_methods)
+            .GetMethod(nameof(command_methods.ReturnsServerHandledValue))!
+            .GetResponseModel();
+    }
+
+    [Fact] void should_discover_the_handler_from_a_dependency_assembly() => typeof(DependencyHandledValueHandler).Assembly.ShouldNotEqual(typeof(MethodInfoExtensions).Assembly);
+    [Fact] void should_not_expose_a_client_response() => _result.HasResponse.ShouldBeFalse();
+    [Fact] void should_not_create_a_response_model() => _result.ResponseModel.ShouldEqual(Templates.ModelDescriptor.Empty);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/given/command_methods.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_MethodInfoExtensions/when_getting_a_response_model/given/command_methods.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias FakeContracts;
+
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+using Cratis.Arc.Validation;
+using Cratis.Monads;
+using FakeHandledValue = FakeContracts::Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency.FakeHandledValue;
+
+namespace Cratis.Arc.ProxyGenerator.for_MethodInfoExtensions.when_getting_a_response_model.given;
+
+public record ClientResponse(string Value);
+
+public static class command_methods
+{
+    public static DependencyHandledValue ReturnsServerHandledValue() => null!;
+
+    public static Result<DependencyHandledValue, ValidationResult> ReturnsServerHandledValueOrValidationResult() => null!;
+
+    public static ClientResponse ReturnsClientResponse() => new(string.Empty);
+
+    public static IReadOnlyList<ClientResponse> ReturnsClientResponses() => [];
+
+    public static DependencyHandledValue[] ReturnsHandledValues() => [];
+
+    public static MarkerOnlyValue ReturnsMarkerOnlyValue() => new();
+
+    public static FakeHandledValue ReturnsValueClaimedByCounterfeitContracts() => new();
+
+    public static (DependencyHandledValue Handled, ClientResponse Client) ReturnsHandledAndClientTuple() => default;
+
+    public static (DependencyHandledValue First, DependencyHandledValue Second) ReturnsAllHandledTuple() => default;
+
+    public static Result<(DependencyHandledValue Handled, ClientResponse Client), ValidationResult> ReturnsWrappedHandledAndClientTuple() => null!;
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_is_server_handled_command_response_value/and_a_type_has_the_same_full_name_from_another_assembly.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_is_server_handled_command_response_value/and_a_type_has_the_same_full_name_from_another_assembly.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_checking_is_server_handled_command_response_value;
+
+public class and_a_type_has_the_same_full_name_from_another_assembly : Specification
+{
+    bool _result;
+
+    void Because()
+    {
+        _ = typeof(DependencyHandledValueHandler).Assembly;
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName($"Collision.{Guid.NewGuid():N}"), AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("Main");
+        var type = module.DefineType(typeof(DependencyHandledValue).FullName!, TypeAttributes.Public).CreateType()!;
+        _result = type.IsServerHandledCommandResponseValue();
+    }
+
+    [Fact] void should_not_treat_the_type_as_server_handled() => _result.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_an_import_statement/and_the_type_is_generic.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_an_import_statement/and_the_type_is_generic.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_an_import_statement;
+
+public class and_the_type_is_generic : Specification
+{
+    ImportStatement _result;
+
+    void Because() => _result = typeof(KeyValuePair<string, string>).GetImportStatement("/output", "Commands", 0);
+
+    [Fact] void should_use_the_arity_free_generated_file_name() => Assert.EndsWith("/KeyValuePair", _result.Module);
+    [Fact] void should_not_use_the_clr_generic_arity() => _result.Module.ShouldNotContain('`');
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_initializing_project_assemblies/and_a_dependency_declares_a_typed_command_response_handler.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_initializing_project_assemblies/and_a_dependency_declares_a_typed_command_response_handler.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_initializing_project_assemblies;
+
+public class and_a_dependency_declares_a_typed_command_response_handler : Specification
+{
+    bool _firstInitialization;
+    bool _secondInitialization;
+    bool _failureInitialization;
+    bool _metadataHandledAfterFirstInitialization;
+    bool _metadataCollectionHandledAfterFirstInitialization;
+    bool _markerOnlyValueHandledAfterFirstInitialization;
+    bool _dependencyContributesGeneratedTypeDiscoveryProvider;
+    bool _dependencyTypePresentAfterSecondInitialization;
+    bool _runtimeHandledAfterSecondInitialization;
+    bool _runtimePrimitiveCollectionAfterSecondInitialization;
+    bool _projectAssembliesEmptyAfterFailure;
+    int _rootAssemblyCountBeforeInitialization;
+    int _rootAssemblyCountAfterInitializations;
+    string _invalidAssemblyFile;
+    List<string> _errors;
+
+    void Establish()
+    {
+        _invalidAssemblyFile = Path.Combine(Path.GetTempPath(), $"proxy-generator-invalid-{Guid.NewGuid():N}.dll");
+        _errors = [];
+        _rootAssemblyCountBeforeInitialization = CountLoadedRootAssemblies();
+        File.WriteAllText(_invalidAssemblyFile, "not a managed assembly");
+    }
+
+    void Because()
+    {
+        _firstInitialization = TypeExtensions.TryInitializeProjectAssemblies(typeof(and_a_dependency_declares_a_typed_command_response_handler).Assembly.Location, _ => { }, _errors.Add);
+        using (TypeExtensions.OwnProjectAssemblies())
+        {
+            var graphAType = FindCurrentMetadataType(typeof(DependencyHandledValue).FullName!);
+            _metadataHandledAfterFirstInitialization = graphAType?.IsServerHandledCommandResponseValue() == true;
+            _metadataCollectionHandledAfterFirstInitialization = graphAType?.MakeArrayType().IsServerHandledCommandResponseValue() == true;
+            _markerOnlyValueHandledAfterFirstInitialization = FindCurrentMetadataType(typeof(MarkerOnlyValue).FullName!)?.IsServerHandledCommandResponseValue() == true;
+            _dependencyContributesGeneratedTypeDiscoveryProvider = typeof(DependencyHandledValue).Assembly.GetTypes()
+                .Any(_ => _.Name.Contains("GeneratedTypeDiscoveryProvider", StringComparison.Ordinal));
+        }
+
+        _secondInitialization = TypeExtensions.TryInitializeProjectAssemblies(typeof(CommandResult).Assembly.Location, _ => { }, _errors.Add);
+        using (TypeExtensions.OwnProjectAssemblies())
+        {
+            _dependencyTypePresentAfterSecondInitialization = FindCurrentMetadataType(typeof(DependencyHandledValue).FullName!) is not null;
+            _runtimeHandledAfterSecondInitialization = typeof(DependencyHandledValueHandler).Assembly
+                .GetType(typeof(DependencyHandledValueHandler).FullName!)!
+                .GetInterfaces()
+                .Single(_ => _.IsGenericType &&
+                             _.GetGenericTypeDefinition() == typeof(ICommandResponseValueHandler<>) &&
+                             _.GetGenericArguments()[0] == typeof(DependencyHandledValue))
+                .GetGenericArguments()[0]
+                .IsServerHandledCommandResponseValue();
+            _runtimePrimitiveCollectionAfterSecondInitialization = typeof(string[]).IsEnumerableOfPrimitiveOrConcept();
+        }
+
+        _failureInitialization = TypeExtensions.TryInitializeProjectAssemblies(_invalidAssemblyFile, _ => { }, _errors.Add);
+        _projectAssembliesEmptyAfterFailure = !TypeExtensions.Assemblies.Any();
+
+        _rootAssemblyCountAfterInitializations = CountLoadedRootAssemblies();
+    }
+
+    void Destroy() => File.Delete(_invalidAssemblyFile);
+
+    static Type? FindCurrentMetadataType(string fullName) =>
+        TypeExtensions.Assemblies
+            .SelectMany(_ => _.GetTypes())
+            .FirstOrDefault(_ => _.FullName == fullName);
+
+    static int CountLoadedRootAssemblies()
+    {
+        var rootPath = Path.GetFullPath(typeof(and_a_dependency_declares_a_typed_command_response_handler).Assembly.Location);
+        return AppDomain.CurrentDomain.GetAssemblies().Count(_ =>
+            !_.IsDynamic &&
+            !string.IsNullOrEmpty(_.Location) &&
+            string.Equals(Path.GetFullPath(_.Location), rootPath, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact] void should_initialize_the_real_metadata_graph() => Assert.True(_firstInitialization, string.Join(Environment.NewLine, _errors));
+    [Fact] void should_discover_the_dependency_handler() => _metadataHandledAfterFirstInitialization.ShouldBeTrue();
+    [Fact] void should_discover_the_dependency_collection_handler() => _metadataCollectionHandledAfterFirstInitialization.ShouldBeTrue();
+    [Fact] void should_ignore_a_typed_declaration_without_a_runtime_handler() => _markerOnlyValueHandledAfterFirstInitialization.ShouldBeFalse();
+    [Fact] void should_not_pollute_the_host_with_a_generated_type_discovery_provider() => _dependencyContributesGeneratedTypeDiscoveryProvider.ShouldBeFalse();
+    [Fact] void should_initialize_a_second_project_graph() => Assert.True(_secondInitialization, string.Join(Environment.NewLine, _errors));
+    [Fact] void should_clear_the_first_projects_handler_types() => _dependencyTypePresentAfterSecondInitialization.ShouldBeFalse();
+    [Fact] void should_resolve_runtime_handler_contracts_independently_of_the_current_metadata_graph() => _runtimeHandledAfterSecondInitialization.ShouldBeTrue();
+    [Fact] void should_resolve_runtime_collection_contracts_independently_of_the_current_metadata_graph() => _runtimePrimitiveCollectionAfterSecondInitialization.ShouldBeTrue();
+    [Fact] void should_report_invalid_input_as_a_failed_initialization() => _failureInitialization.ShouldBeFalse();
+    [Fact] void should_leave_no_project_assemblies_after_a_failed_initialization() => _projectAssembliesEmptyAfterFailure.ShouldBeTrue();
+    [Fact] void should_not_load_another_runtime_copy_of_the_root_assembly() => _rootAssemblyCountAfterInitializations.ShouldEqual(_rootAssemblyCountBeforeInitialization);
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Generator.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Generator.cs
@@ -71,7 +71,11 @@ public static class Generator
         TypeExtensions.SetExcludedTypes(excludedTypeNames ?? [], excludedNamespacePatterns ?? []);
         TypeExtensions.SetNamespaceRoots(namespaceRoots ?? []);
         TypeExtensions.SetTypeMappings(typeMappings ?? []);
-        TypeExtensions.InitializeProjectAssemblies(assemblyFile, message, errorMessage);
+        if (!TypeExtensions.TryInitializeProjectAssemblies(assemblyFile, message, errorMessage))
+        {
+            return false;
+        }
+        using var projectAssemblies = TypeExtensions.OwnProjectAssemblies();
 
         var commands = new List<CommandDescriptor>();
         var queries = new List<QueryDescriptor>();

--- a/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
@@ -129,10 +129,17 @@ public static class MethodInfoExtensions
 
     static (bool HasResponse, ModelDescriptor ResponseModel) GetResponseFromType(Type type)
     {
+        if (type.IsServerHandledCommandResponseValue())
+        {
+            return (false, ModelDescriptor.Empty);
+        }
+
         if (type.IsGenericType && type.FullName!.StartsWith("System.ValueTuple"))
         {
             var bestType = type.GetBestTupleType();
-            return (true, bestType.ToModelDescriptor());
+            return bestType is null
+                ? (false, ModelDescriptor.Empty)
+                : (true, bestType.ToModelDescriptor());
         }
 
         if (type.IsOneOf())

--- a/Source/DotNET/Tools/ProxyGenerator/ProxyGenerator.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator/ProxyGenerator.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <EmbeddedResource Include="$(MSBuildThisFileDirectory)/Templates/**/*.hbs" />
+        <InternalsVisibleTo Include="Cratis.Arc.ProxyGenerator.Specs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -36,6 +36,10 @@ public static class TypeExtensions
     internal static Type _voidType = typeof(void);
 #pragma warning restore SA1600 // Elements should be documented
 
+    const string CommandResponseValueHandlerTypeName = "Cratis.Arc.Commands.ICommandResponseValueHandler`1";
+    const string RuntimeCommandResponseValueHandlerTypeName = "Cratis.Arc.Commands.ICommandResponseValueHandler";
+    const string CommandResponseValueHandlerContractsAssemblyName = "Cratis.Arc.Core";
+
     static readonly TargetType _numberTargetType = new(typeof(int), "number", "Number");
     static readonly TargetType _dateTargetType = new(typeof(DateTimeOffset), "Date", "Date");
     static readonly TargetType _stringTargetType = new(typeof(string), "string", "String");
@@ -88,12 +92,6 @@ public static class TypeExtensions
 
     static readonly Dictionary<string, Assembly> _assembliesByName = [];
 
-    static readonly HashSet<string> _wellKnownTypeNames =
-    [
-        "Cratis.Arc.Validation.ValidationResult",
-        "Cratis.Arc.Authorization.AuthorizationResult"
-    ];
-
     static Dictionary<string, string> _assemblyPackageMappings = [];
     static Dictionary<string, TargetType> _typeMappings = [];
     static HashSet<string> _excludedTypeNames = [];
@@ -102,6 +100,8 @@ public static class TypeExtensions
 
     static MetadataAssemblyResolver? _assemblyResolver;
     static MetadataLoadContext? _metadataLoadContext;
+    static Func<AssemblyLoadContext, AssemblyName, Assembly?>? _assemblyResolvingHandler;
+    static HashSet<string>? _serverHandledCommandResponseValueTypeNames;
 
     /// <summary>
     /// Gets all assemblies gathered from the <see cref="InitializeProjectAssemblies(string, Action{string}, Action{string})"/> method.
@@ -205,89 +205,8 @@ public static class TypeExtensions
     /// <param name="message">Callback for outputting messages.</param>
     /// <param name="errorMessage">Callback for outputting error messages.</param>
     /// <returns>True if successful, false if not.</returns>
-    public static bool InitializeProjectAssemblies(string assemblyFile, Action<string> message, Action<string> errorMessage)
-    {
-        message($"  Gather all project referenced assemblies for {assemblyFile}");
-        var assemblyFolder = Path.GetDirectoryName(assemblyFile)!;
-
-        var assembly = Assembly.LoadFile(assemblyFile);
-        var dependencyContext = DependencyContext.Load(assembly);
-        if (dependencyContext is null)
-        {
-            errorMessage($"Could not load dependency context for assembly '{assemblyFile}'");
-            return false;
-        }
-
-        var root = RuntimeEnvironment.GetRuntimeDirectory();
-        root = Path.GetDirectoryName(root)!;
-        var version = Path.GetFileName(root)!;
-        var framework = Directory.GetParent(root)!;
-        var shared = Directory.GetParent(framework.FullName)!;
-        var aspNetCoreAppPath = Path.Combine(shared.FullName, "Microsoft.AspNetCore.App", version);
-
-        message($"  Runtime assemblies: {root}");
-        message($"  AspNetCoreApp assemblies: {aspNetCoreAppPath}");
-
-        var runtimeAssemblies = Directory.GetFiles(root, "*.dll");
-        var aspNetCoreAssemblies = Directory.GetFiles(aspNetCoreAppPath, "*.dll");
-        var appAssemblies = Directory.GetFiles(assemblyFolder, "*.dll");
-        string[] paths = [.. runtimeAssemblies, .. aspNetCoreAssemblies, .. appAssemblies];
-
-        var fundamentalsPackage = dependencyContext.RuntimeLibraries.SingleOrDefault(_ => _.Type == "package" && _.Name == "Cratis.Fundamentals");
-        if (fundamentalsPackage is not null)
-        {
-            var assetPaths = fundamentalsPackage.RuntimeAssemblyGroups
-                .SelectMany(_ => _.AssetPaths)
-                .ToArray();
-
-            var nugetCachePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                ".nuget",
-                "packages");
-
-            var fullPath = Path.Combine(nugetCachePath, fundamentalsPackage.Path!, assetPaths[0]);
-            if (File.Exists(fullPath))
-            {
-                paths = [.. paths, fullPath];
-            }
-        }
-
-        var filtered = paths.Distinct(new FileNameComparer()).ToArray();
-
-        _assemblyResolver = new PathAssemblyResolver(filtered);
-#pragma warning disable CA2000 // Dispose objects before losing scope
-        _metadataLoadContext = new MetadataLoadContext(_assemblyResolver);
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-        AssemblyLoadContext.Default.Resolving += (_, name) =>
-        {
-            // Caching the metadata-only assembly is the point here - IsAssignableTo<T> needs it to translate a
-            // runtime type into the metadata world. Handing it back is not: the default context accepts only runtime
-            // assemblies and throws "Resolved assembly must be a runtime Assembly object" on anything else, which
-            // would turn any genuine resolution miss into a hard failure.
-            if (_assemblyResolver.Resolve(_metadataLoadContext, name) is { } resolved)
-            {
-                _assembliesByName[name.Name!] = resolved;
-            }
-
-            return null;
-        };
-
-        Assemblies = [.. dependencyContext.RuntimeLibraries
-                                        .Where(_ => _.Type.Equals("project"))
-                                        .Select(_ => _metadataLoadContext.LoadFromAssemblyPath(Path.Join(assemblyFolder, $"{_.Name}.dll")))
-                                        .Where(_ => _ is not null)
-                                        .Distinct()];
-
-        foreach (var loadedAssembly in _metadataLoadContext.GetAssemblies())
-        {
-            _assembliesByName[loadedAssembly.GetName().Name!] = loadedAssembly;
-        }
-
-        InitializeWellKnownTypes();
-
-        return true;
-    }
+    public static bool InitializeProjectAssemblies(string assemblyFile, Action<string> message, Action<string> errorMessage) =>
+        TryInitializeProjectAssemblies(assemblyFile, message, errorMessage);
 
     /// <summary>
     /// Check if a type is a controller.
@@ -311,7 +230,8 @@ public static class TypeExtensions
     /// </summary>
     /// <param name="type">Type to check.</param>
     /// <returns>True if it is an async enumerable, false if not.</returns>
-    public static bool IsAsyncEnumerable(this Type type) => type.IsAssignableTo(_asyncEnumerableType);
+    public static bool IsAsyncEnumerable(this Type type) =>
+        EnumerateTypeAndContracts(type).Any(_ => IsGenericTypeDefinition(_, typeof(IAsyncEnumerable<>)));
 
     /// <summary>
     /// Check if a type is observable.
@@ -336,7 +256,7 @@ public static class TypeExtensions
     /// </summary>
     /// <param name="type"><see cref="Type"/> to check.</param>
     /// <returns>True if type is a string, false otherwise.</returns>
-    public static bool IsString(this Type type) => type == _stringType;
+    public static bool IsString(this Type type) => type.FullName == typeof(string).FullName;
 
     /// <summary>
     /// Check if a type is assignable to a specific type.
@@ -372,7 +292,7 @@ public static class TypeExtensions
 
         // Unwrap nullable types before checking the primitive map - Nullable<T> primitives
         // should be treated as known types since they map to TypeScript primitives
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == _nullableType)
+        if (IsGenericTypeDefinition(type, typeof(Nullable<>)))
         {
             type = type.GetGenericArguments()[0];
         }
@@ -398,7 +318,7 @@ public static class TypeExtensions
     /// <returns>True if it is, false if not.</returns>
     public static bool IsDictionary(this Type type)
     {
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == _dictionaryType)
+        if (IsGenericTypeDefinition(type, typeof(IDictionary<,>)))
         {
             return true;
         }
@@ -408,7 +328,7 @@ public static class TypeExtensions
             if (!i.IsGenericType) return false;
             try
             {
-                return i.GetGenericTypeDefinition() == _dictionaryType;
+                return IsGenericTypeDefinition(i, typeof(IDictionary<,>));
             }
             catch
             {
@@ -425,9 +345,9 @@ public static class TypeExtensions
     /// <returns>The key <see cref="Type"/>.</returns>
     public static Type GetDictionaryKeyType(this Type type)
     {
-        var dictionaryInterface = type.IsGenericType && type.GetGenericTypeDefinition() == _dictionaryType
+        var dictionaryInterface = IsGenericTypeDefinition(type, typeof(IDictionary<,>))
             ? type
-            : type.GetInterfaces().First(_ => _.IsGenericType && _.GetGenericTypeDefinition() == _dictionaryType);
+            : type.GetInterfaces().First(_ => IsGenericTypeDefinition(_, typeof(IDictionary<,>)));
         return dictionaryInterface.GetGenericArguments()[0];
     }
 
@@ -438,9 +358,9 @@ public static class TypeExtensions
     /// <returns>The value <see cref="Type"/>.</returns>
     public static Type GetDictionaryValueType(this Type type)
     {
-        var dictionaryInterface = type.IsGenericType && type.GetGenericTypeDefinition() == _dictionaryType
+        var dictionaryInterface = IsGenericTypeDefinition(type, typeof(IDictionary<,>))
             ? type
-            : type.GetInterfaces().First(_ => _.IsGenericType && _.GetGenericTypeDefinition() == _dictionaryType);
+            : type.GetInterfaces().First(_ => IsGenericTypeDefinition(_, typeof(IDictionary<,>)));
         return dictionaryInterface.GetGenericArguments()[1];
     }
 
@@ -545,7 +465,7 @@ public static class TypeExtensions
         // runtime reflection API that accesses private CLR implementation details. MetadataLoadContext types
         // are metadata-only and not backed by runtime CLR types, so Nullable.GetUnderlyingType returns null.
         // Instead, we use GetGenericArguments()[0] which works with metadata-only reflection.
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == _nullableType)
+        if (IsGenericTypeDefinition(type, typeof(Nullable<>)))
         {
             var underlyingType = type.GetGenericArguments()[0];
             return underlyingType.GetTargetType();
@@ -824,7 +744,14 @@ public static class TypeExtensions
             {
                 var fullPath = Path.Join(targetPath, relativePath);
                 var fullPathForType = Path.Join(targetPath, type.ResolveTargetPath(segmentsToSkip));
-                importPath = $"{Path.GetRelativePath(fullPath, fullPathForType)}/{type.Name}";
+                var typeName = type.Name;
+                var backtickIndex = typeName.IndexOf('`');
+                if (backtickIndex >= 0)
+                {
+                    typeName = typeName[..backtickIndex];
+                }
+
+                importPath = $"{Path.GetRelativePath(fullPath, fullPathForType)}/{typeName}";
             }
 
             if (!importPath.StartsWith('.') && !importPath.StartsWith('/'))
@@ -932,7 +859,10 @@ public static class TypeExtensions
     /// <returns>True if type is enumerable, false if not an enumerable.</returns>
     public static bool IsEnumerable(this Type type)
     {
-        return !type.IsAPrimitiveType() && type != _expandoObjectType && !type.IsString() && _enumerableType.IsAssignableFrom(type);
+        return !type.IsAPrimitiveType() &&
+               type.FullName != typeof(ExpandoObject).FullName &&
+               !type.IsString() &&
+               EnumerateTypeAndContracts(type).Any(_ => _.FullName == typeof(IEnumerable).FullName);
     }
 
     /// <summary>
@@ -970,8 +900,7 @@ public static class TypeExtensions
     {
         while (!type.Equals(typeof(object)))
         {
-            if (type.GetTypeInfo().IsGenericType &&
-               type.GetGenericTypeDefinition() == _nullableType)
+            if (IsGenericTypeDefinition(type, typeof(Nullable<>)))
             {
                 return true;
             }
@@ -999,14 +928,13 @@ public static class TypeExtensions
             return enumerableType.GetElementType()!;
         }
 
-        if (enumerableType.IsGenericType && enumerableType.GetGenericTypeDefinition() == _genericEnumerableType)
+        if (IsGenericTypeDefinition(enumerableType, typeof(IEnumerable<>)))
         {
             return enumerableType.GetGenericArguments()[0];
         }
 
         return enumerableType.GetInterfaces()
-            .Where(t => t.IsGenericType &&
-                t.GetGenericTypeDefinition() == _genericEnumerableType)
+            .Where(_ => IsGenericTypeDefinition(_, typeof(IEnumerable<>)))
             .Select(t => t.GenericTypeArguments[0]).FirstOrDefault()!;
     }
 
@@ -1035,14 +963,13 @@ public static class TypeExtensions
     /// <returns>The element type.</returns>
     public static Type GetAsyncEnumerableElementType(this Type asyncEnumerableType)
     {
-        if (asyncEnumerableType.IsGenericType && asyncEnumerableType.GetGenericTypeDefinition() == _asyncEnumerableType)
+        if (IsGenericTypeDefinition(asyncEnumerableType, typeof(IAsyncEnumerable<>)))
         {
             return asyncEnumerableType.GetGenericArguments()[0];
         }
 
         return asyncEnumerableType.GetInterfaces()
-            .Where(t => t.IsGenericType &&
-                t.GetGenericTypeDefinition() == _asyncEnumerableType)
+            .Where(_ => IsGenericTypeDefinition(_, typeof(IAsyncEnumerable<>)))
             .Select(t => t.GenericTypeArguments[0]).FirstOrDefault()!;
     }
 
@@ -1131,7 +1058,7 @@ public static class TypeExtensions
     /// <param name="type"><see cref="Type"/> to check.</param>
     /// <returns>True if type implements IEnumerable, false if not.</returns>
     public static bool ImplementsEnumerable(this Type type) =>
-        type.ImplementsOpenGeneric(_genericEnumerableType) || (type.IsGenericType && type.GetGenericTypeDefinition() == _genericEnumerableType);
+        EnumerateTypeAndContracts(type).Any(_ => IsGenericTypeDefinition(_, typeof(IEnumerable<>)));
 
     /// <summary>
     /// Check if a type implements IOneOf from the OneOf namespace.
@@ -1198,29 +1125,51 @@ public static class TypeExtensions
     }
 
     /// <summary>
-    /// Check if a type is a well-known type that should be ignored as a response type.
+    /// Check if a type is consumed by a declared server-side command response value handler.
     /// </summary>
     /// <param name="type"><see cref="Type"/> to check.</param>
-    /// <returns>True if the type is a well-known type to be ignored, false otherwise.</returns>
-    public static bool IsWellKnownType(this Type type) =>
-        type.FullName is not null && _wellKnownTypeNames.Contains(type.FullName);
+    /// <returns>True if the type is consumed on the server and should be ignored as a client response, false otherwise.</returns>
+    public static bool IsWellKnownType(this Type type) => type.IsServerHandledCommandResponseValue();
+
+    /// <summary>
+    /// Check if a command response value type is consumed by a server-side command response value handler.
+    /// </summary>
+    /// <param name="type">Type to check.</param>
+    /// <returns>True if the value is handled on the server and should not be exposed as a client response.</returns>
+    public static bool IsServerHandledCommandResponseValue(this Type type)
+    {
+        var isFromCurrentMetadataContext = _metadataLoadContext?.GetAssemblies().Contains(type.Assembly) == true;
+        var handledTypeIdentities = isFromCurrentMetadataContext
+            ? _serverHandledCommandResponseValueTypeNames ?? []
+            : FindServerHandledCommandResponseValueTypeNames(
+                AppDomain.CurrentDomain.GetAssemblies().Where(_ => !_.IsDynamic),
+                AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(_ => !_.IsDynamic && _.GetName().Name == CommandResponseValueHandlerContractsAssemblyName),
+                _ => { });
+
+        return EnumerateTypeAndContracts(type).Any(_ =>
+            _.AssemblyQualifiedName is not null && handledTypeIdentities.Contains(_.AssemblyQualifiedName));
+    }
 
     /// <summary>
     /// Get the best type from a tuple by selecting either a ConceptAs implementation or a primitive type.
     /// </summary>
     /// <param name="type">Tuple <see cref="Type"/> to inspect.</param>
-    /// <returns>The best type found, or the original tuple type if none match the criteria.</returns>
-    public static Type GetBestTupleType(this Type type)
+    /// <returns>The best type found, the original non-tuple type, or null when every tuple value is server-handled.</returns>
+    public static Type? GetBestTupleType(this Type type)
     {
         if (!type.IsGenericType || !(type.FullName?.StartsWith("System.ValueTuple") ?? false))
         {
             return type;
         }
 
-        var genericArguments = type.GetGenericArguments().Where(t => !t.IsWellKnownType()).ToArray();
+        var genericArguments = type.GetGenericArguments()
+            .Select(UnwrapType)
+            .Where(_ => _?.IsServerHandledCommandResponseValue() == false)
+            .Cast<Type>()
+            .ToArray();
         if (genericArguments.Length == 0)
         {
-            return type;
+            return null;
         }
 
         var conceptType = genericArguments.FirstOrDefault(t => t.IsConcept());
@@ -1252,7 +1201,7 @@ public static class TypeExtensions
         foreach (var arg in genericArguments)
         {
             var unwrappedType = UnwrapType(arg);
-            if (unwrappedType?.IsWellKnownType() == false)
+            if (unwrappedType?.IsServerHandledCommandResponseValue() == false)
             {
                 candidateTypes.Add(unwrappedType);
             }
@@ -1269,6 +1218,142 @@ public static class TypeExtensions
     }
 
     /// <summary>
+    /// Try to initialize the project assemblies.
+    /// </summary>
+    /// <param name="assemblyFile">Assembly file to start from.</param>
+    /// <param name="message">Callback for outputting messages.</param>
+    /// <param name="errorMessage">Callback for outputting error messages.</param>
+    /// <returns>True if successful, false if not.</returns>
+    internal static bool TryInitializeProjectAssemblies(string assemblyFile, Action<string> message, Action<string> errorMessage)
+    {
+        DetachProjectAssemblies(disposeMetadataLoadContext: true);
+        _serverHandledCommandResponseValueTypeNames = [];
+        message($"  Gather all project referenced assemblies for {assemblyFile}");
+        var assemblyFolder = Path.GetDirectoryName(assemblyFile)!;
+
+        Assembly assembly;
+        DependencyContext? dependencyContext;
+        try
+        {
+            assembly = LoadRuntimeAssembly(assemblyFile);
+            dependencyContext = DependencyContext.Load(assembly);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileLoadException or FileNotFoundException)
+        {
+            errorMessage($"Could not load project assembly '{assemblyFile}': {ex.Message}");
+            return false;
+        }
+
+        if (dependencyContext is null)
+        {
+            errorMessage($"Could not load dependency context for assembly '{assemblyFile}'");
+            return false;
+        }
+
+        var root = RuntimeEnvironment.GetRuntimeDirectory();
+        root = Path.GetDirectoryName(root)!;
+        var version = Path.GetFileName(root)!;
+        var framework = Directory.GetParent(root)!;
+        var shared = Directory.GetParent(framework.FullName)!;
+        var aspNetCoreAppPath = Path.Combine(shared.FullName, "Microsoft.AspNetCore.App", version);
+
+        message($"  Runtime assemblies: {root}");
+        message($"  AspNetCoreApp assemblies: {aspNetCoreAppPath}");
+
+        var runtimeAssemblies = Directory.GetFiles(root, "*.dll");
+        var aspNetCoreAssemblies = Directory.GetFiles(aspNetCoreAppPath, "*.dll");
+        var managedAppAssemblyPaths = dependencyContext.RuntimeLibraries
+            .SelectMany(_ => _.RuntimeAssemblyGroups)
+            .SelectMany(_ => _.AssetPaths)
+            .Select(Path.GetFileName)
+            .Where(_ => !string.IsNullOrEmpty(_))
+            .Select(_ => Path.Join(assemblyFolder, _))
+            .Append(assemblyFile)
+            .Where(File.Exists)
+            .Distinct(new FileNameComparer())
+            .ToArray();
+        string[] paths = [.. runtimeAssemblies, .. aspNetCoreAssemblies, .. managedAppAssemblyPaths];
+
+        var fundamentalsPackage = dependencyContext.RuntimeLibraries.SingleOrDefault(_ => _.Type == "package" && _.Name == "Cratis.Fundamentals");
+        if (fundamentalsPackage is not null)
+        {
+            var assetPaths = fundamentalsPackage.RuntimeAssemblyGroups
+                .SelectMany(_ => _.AssetPaths)
+                .ToArray();
+
+            var nugetCachePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget",
+                "packages");
+
+            var fullPath = Path.Combine(nugetCachePath, fundamentalsPackage.Path!, assetPaths[0]);
+            if (File.Exists(fullPath))
+            {
+                paths = [.. paths, fullPath];
+            }
+        }
+
+        var filtered = paths.Distinct(new FileNameComparer()).ToArray();
+
+        _assemblyResolver = new PathAssemblyResolver(filtered);
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        _metadataLoadContext = new MetadataLoadContext(_assemblyResolver);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+        _assemblyResolvingHandler = (_, name) =>
+        {
+            // Caching the metadata-only assembly is the point here - IsAssignableTo<T> needs it to translate a
+            // runtime type into the metadata world. Handing it back is not: the default context accepts only runtime
+            // assemblies and throws "Resolved assembly must be a runtime Assembly object" on anything else, which
+            // would turn any genuine resolution miss into a hard failure.
+            if (_assemblyResolver.Resolve(_metadataLoadContext, name) is { } resolved)
+            {
+                _assembliesByName[name.Name!] = resolved;
+            }
+
+            return null;
+        };
+        AssemblyLoadContext.Default.Resolving += _assemblyResolvingHandler;
+
+        try
+        {
+            Assemblies = [.. dependencyContext.RuntimeLibraries
+                                            .Where(_ => _.Type.Equals("project"))
+                                            .Select(_ => LoadMetadataAssembly(Path.Join(assemblyFolder, $"{_.Name}.dll")))
+                                            .Distinct()];
+
+            var commandResponseValueHandlerContractsAssembly = managedAppAssemblyPaths
+                .Where(_ => Path.GetFileNameWithoutExtension(_) == CommandResponseValueHandlerContractsAssemblyName)
+                .Select(LoadMetadataAssembly)
+                .SingleOrDefault();
+            _serverHandledCommandResponseValueTypeNames = FindServerHandledCommandResponseValueTypeNames(
+                managedAppAssemblyPaths.Select(LoadMetadataAssembly), commandResponseValueHandlerContractsAssembly, errorMessage);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileLoadException or FileNotFoundException)
+        {
+            errorMessage($"Could not load a managed project dependency for '{assemblyFile}': {ex.Message}");
+            DisposeUnpublishedMetadataLoadContext();
+            _serverHandledCommandResponseValueTypeNames = [];
+            return false;
+        }
+
+        foreach (var loadedAssembly in _metadataLoadContext.GetAssemblies())
+        {
+            _assembliesByName[loadedAssembly.GetName().Name!] = loadedAssembly;
+        }
+
+        InitializeWellKnownTypes();
+
+        return true;
+    }
+
+    /// <summary>
+    /// Creates an owner for the currently initialized project assemblies.
+    /// </summary>
+    /// <returns>An owner that releases the metadata graph when disposed.</returns>
+    internal static IDisposable OwnProjectAssemblies() => new ProjectAssembliesLifetime(_metadataLoadContext);
+
+    /// <summary>
     /// Unwrap a type to get the best response type candidate.
     /// Handles tuples and OneOf types recursively.
     /// </summary>
@@ -1276,6 +1361,11 @@ public static class TypeExtensions
     /// <returns>The unwrapped type, or null if the type should be skipped.</returns>
     static Type? UnwrapType(Type type)
     {
+        if (type.IsServerHandledCommandResponseValue())
+        {
+            return null;
+        }
+
         if (type.IsGenericType && (type.FullName?.StartsWith("System.ValueTuple") ?? false))
         {
             return type.GetBestTupleType();
@@ -1289,6 +1379,188 @@ public static class TypeExtensions
         return type;
     }
 
+    static HashSet<string> FindServerHandledCommandResponseValueTypeNames(
+        IEnumerable<Assembly> assemblies,
+        Assembly? commandResponseValueHandlerContractsAssembly,
+        Action<string> errorMessage) =>
+        assemblies
+            .SelectMany(_ => GetLoadableTypes(_, errorMessage))
+            .Where(_ => !_.IsAbstract && !_.IsInterface)
+            .Select(_ => GetLoadableInterfaces(_, errorMessage))
+            .SelectMany(_ => GetServerHandledCommandResponseValueTypeNames(_, commandResponseValueHandlerContractsAssembly))
+            .ToHashSet(StringComparer.Ordinal);
+
+    static IEnumerable<string> GetServerHandledCommandResponseValueTypeNames(
+        Type[] interfaces,
+        Assembly? commandResponseValueHandlerContractsAssembly)
+    {
+        if (commandResponseValueHandlerContractsAssembly is null ||
+            !interfaces.Any(_ => _.FullName == RuntimeCommandResponseValueHandlerTypeName &&
+                                 ReferenceEquals(_.Assembly, commandResponseValueHandlerContractsAssembly)))
+        {
+            return [];
+        }
+
+        return interfaces
+            .Where(_ => _.IsGenericType &&
+                        _.GetGenericTypeDefinition().FullName == CommandResponseValueHandlerTypeName &&
+                        ReferenceEquals(_.Assembly, commandResponseValueHandlerContractsAssembly))
+            .Select(_ => _.GetGenericArguments()[0].AssemblyQualifiedName)
+            .Where(_ => _ is not null)
+            .Cast<string>();
+    }
+
+    static Assembly LoadMetadataAssembly(string assemblyPath)
+    {
+        var normalizedPath = Path.GetFullPath(assemblyPath);
+        var loadedAssembly = _metadataLoadContext!.GetAssemblies()
+            .FirstOrDefault(_ => string.Equals(Path.GetFullPath(_.Location), normalizedPath, StringComparison.OrdinalIgnoreCase));
+        if (loadedAssembly is not null)
+        {
+            return loadedAssembly;
+        }
+
+        var assemblyName = AssemblyName.GetAssemblyName(normalizedPath);
+        loadedAssembly = _metadataLoadContext.GetAssemblies()
+            .FirstOrDefault(_ => string.Equals(_.FullName, assemblyName.FullName, StringComparison.Ordinal));
+
+        return loadedAssembly ?? _metadataLoadContext.LoadFromAssemblyPath(normalizedPath);
+    }
+
+    static Assembly LoadRuntimeAssembly(string assemblyPath)
+    {
+        var normalizedPath = Path.GetFullPath(assemblyPath);
+        var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(_ => !_.IsDynamic).ToArray();
+        var loadedAssembly = loadedAssemblies.FirstOrDefault(_ =>
+        {
+            try
+            {
+                return !string.IsNullOrEmpty(_.Location) &&
+                       string.Equals(Path.GetFullPath(_.Location), normalizedPath, StringComparison.OrdinalIgnoreCase);
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+        });
+        if (loadedAssembly is not null)
+        {
+            return loadedAssembly;
+        }
+
+        var assemblyName = AssemblyName.GetAssemblyName(normalizedPath);
+        loadedAssembly = loadedAssemblies.FirstOrDefault(_ =>
+        {
+            try
+            {
+                return string.IsNullOrEmpty(_.Location) && string.Equals(_.FullName, assemblyName.FullName, StringComparison.Ordinal);
+            }
+            catch (NotSupportedException)
+            {
+                return string.Equals(_.FullName, assemblyName.FullName, StringComparison.Ordinal);
+            }
+        });
+
+        return loadedAssembly ?? Assembly.LoadFile(normalizedPath);
+    }
+
+    static IEnumerable<Type> EnumerateTypeAndContracts(Type type)
+    {
+        yield return type;
+
+        foreach (var contract in type.GetInterfaces())
+        {
+            yield return contract;
+        }
+
+        var baseType = type.BaseType;
+        while (baseType is not null)
+        {
+            yield return baseType;
+            baseType = baseType.BaseType;
+        }
+    }
+
+    static bool IsGenericTypeDefinition(Type type, Type runtimeGenericTypeDefinition) =>
+        type.IsGenericType && type.GetGenericTypeDefinition().FullName == runtimeGenericTypeDefinition.FullName;
+
+    static IEnumerable<Type> GetLoadableTypes(Assembly assembly, Action<string> errorMessage)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            foreach (var loaderException in ex.LoaderExceptions.Where(_ => _ is not null))
+            {
+                errorMessage($"Could not load a type from managed dependency '{assembly.FullName}': {loaderException!.Message}");
+            }
+
+            return ex.Types.Where(_ => _ is not null).Cast<Type>();
+        }
+        catch (Exception ex) when (ex is FileLoadException or FileNotFoundException)
+        {
+            errorMessage($"Could not inspect managed dependency '{assembly.FullName}': {ex.Message}");
+            return [];
+        }
+    }
+
+    static Type[] GetLoadableInterfaces(Type type, Action<string> errorMessage)
+    {
+        try
+        {
+            return type.GetInterfaces();
+        }
+        catch (Exception ex) when (ex is FileLoadException or FileNotFoundException or TypeLoadException)
+        {
+            errorMessage($"Could not inspect managed type '{type.FullName}': {ex.Message}");
+            return [];
+        }
+    }
+
+    static void DetachProjectAssemblies(bool disposeMetadataLoadContext = false)
+    {
+        var metadataLoadContext = _metadataLoadContext;
+        Assemblies = [];
+        _assembliesByName.Clear();
+        _serverHandledCommandResponseValueTypeNames = null;
+        ResetWellKnownTypes();
+
+        if (_assemblyResolvingHandler is not null)
+        {
+            AssemblyLoadContext.Default.Resolving -= _assemblyResolvingHandler;
+            _assemblyResolvingHandler = null;
+        }
+
+        _metadataLoadContext = null;
+        _assemblyResolver = null;
+        if (disposeMetadataLoadContext)
+        {
+            metadataLoadContext?.Dispose();
+        }
+    }
+
+    static void ResetWellKnownTypes()
+    {
+        _conceptType = typeof(NoConcept);
+        _nullableType = typeof(Nullable<>);
+        _expandoObjectType = typeof(ExpandoObject);
+        _stringType = typeof(string);
+        _enumerableType = typeof(IEnumerable);
+        _genericEnumerableType = typeof(IEnumerable<>);
+        _dictionaryType = typeof(IDictionary<,>);
+        _asyncEnumerableType = typeof(IAsyncEnumerable<>);
+        _controllerBaseType = typeof(object);
+        _taskType = typeof(Task);
+        _voidType = typeof(void);
+    }
+
+    static void DisposeUnpublishedMetadataLoadContext()
+    {
+        DetachProjectAssemblies(disposeMetadataLoadContext: true);
+    }
+
 #pragma warning disable MA0009 // Add regex evaluation timeout
     static bool TypeNameIsReferenced(string propertyType, string importTypeName) =>
         propertyType == importTypeName ||
@@ -1297,16 +1569,15 @@ public static class TypeExtensions
 
     static void InitializeWellKnownTypes()
     {
-        var assembly = _metadataLoadContext!.CoreAssembly!;
-        _nullableType = assembly.GetType(typeof(Nullable<>).FullName!)!;
-        _expandoObjectType = assembly.GetType(typeof(ExpandoObject).FullName!)!;
-        _stringType = assembly.GetType(typeof(string).FullName!)!;
-        _enumerableType = assembly.GetType(typeof(IEnumerable).FullName!)!;
-        _genericEnumerableType = assembly.GetType(typeof(IEnumerable<>).FullName!)!;
-        _asyncEnumerableType = assembly.GetType(typeof(IAsyncEnumerable<>).FullName!)!;
-        _dictionaryType = assembly.GetType(typeof(IDictionary<,>).FullName!)!;
-        _taskType = assembly.GetType(typeof(Task).FullName!)!;
-        _voidType = assembly.GetType(typeof(void).FullName!)!;
+        _nullableType = GetMetadataType(typeof(Nullable<>));
+        _expandoObjectType = GetMetadataType(typeof(ExpandoObject));
+        _stringType = GetMetadataType(typeof(string));
+        _enumerableType = GetMetadataType(typeof(IEnumerable));
+        _genericEnumerableType = GetMetadataType(typeof(IEnumerable<>));
+        _asyncEnumerableType = GetMetadataType(typeof(IAsyncEnumerable<>));
+        _dictionaryType = GetMetadataType(typeof(IDictionary<,>));
+        _taskType = GetMetadataType(typeof(Task));
+        _voidType = GetMetadataType(typeof(void));
 
         try
         {
@@ -1321,6 +1592,11 @@ public static class TypeExtensions
         var aspNetCore = _metadataLoadContext.LoadFromAssemblyName("Microsoft.AspNetCore.Mvc.Core");
         _controllerBaseType = aspNetCore.GetType("Microsoft.AspNetCore.Mvc.ControllerBase")!;
     }
+
+    static Type GetMetadataType(Type runtimeType) =>
+        _metadataLoadContext!
+            .LoadFromAssemblyName(runtimeType.Assembly.GetName())
+            .GetType(runtimeType.FullName!)!;
 
     /// <summary>
     /// Match a namespace string against a glob pattern where <c>*</c> matches any sequence of characters.
@@ -1367,6 +1643,31 @@ public static class TypeExtensions
         }
 
         return false;
+    }
+
+    sealed class ProjectAssembliesLifetime(MetadataLoadContext? ownedMetadataLoadContext) : IDisposable
+    {
+        bool _disposed;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (ReferenceEquals(_metadataLoadContext, ownedMetadataLoadContext))
+            {
+                DetachProjectAssemblies(disposeMetadataLoadContext: true);
+            }
+            else
+            {
+                ownedMetadataLoadContext?.Dispose();
+            }
+
+            _disposed = true;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary

Command response value handlers can now declare the response type they consume, and the proxy generator uses these declarations to stop generating client response models for values that are handled on the server and never reach the client.

## Added

- `ICommandResponseValueHandler<TValue>`, an optional typed declaration that marks a command response value type as consumed on the server (#2537)

## Changed

- The proxy generator no longer generates client response models for server-consumed response types, whether returned directly or wrapped in `Result`, `OneOf`, tuples, or collections (#2537)
- Typed handler declarations are discovered from the application and its referenced packages, replacing the fixed built-in list of well-known types (#2537)
- All built-in Arc and Chronicle response value handlers declare their consumed types (#2537)

## Fixed

- Generated TypeScript import statements for generic types now reference the correct proxy file name
