### PR TITLE
Resolve waitForFirstResult on the initial query result, not the seed emission

### DIFF
--- a/Source/DotNET/Arc.Core/Arc.Core.csproj
+++ b/Source/DotNET/Arc.Core/Arc.Core.csproj
@@ -8,6 +8,7 @@
         <InternalsVisibleTo Include="Cratis.Arc" />
         <InternalsVisibleTo Include="Cratis.Arc.Core.Specs" />
         <InternalsVisibleTo Include="Cratis.Arc.MongoDB" />
+        <InternalsVisibleTo Include="Cratis.Arc.MongoDB.Specs" />
         <InternalsVisibleTo Include="Cratis.Arc.EntityFrameworkCore" />
         <InternalsVisibleTo Include="Cratis.Arc.EntityFrameworkCore.Specs" />
         <InternalsVisibleTo Include="Cratis.Arc.EntityFrameworkCore.SqlServer.Specs" />

--- a/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/ObservedDocument.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/ObservedDocument.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.MongoDB.for_MongoCollectionExtensions;
+
+public record ObservedDocument(Guid Id, string Name);

--- a/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/given/an_observed_collection.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/given/an_observed_collection.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using Cratis.Arc.Queries;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_MongoCollectionExtensions.given;
+
+public class an_observed_collection : Specification
+{
+    protected IMongoCollection<ObservedDocument> _collection;
+    protected List<ObservedDocument> _documents;
+    protected TaskCompletionSource _initialQueryGate;
+    protected CancellationTokenSource _changeStreamLifetime;
+
+    void Establish()
+    {
+        _documents = [new(Guid.NewGuid(), "First"), new(Guid.NewGuid(), "Second")];
+        _initialQueryGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        _changeStreamLifetime = new();
+
+        var queryContextManager = Substitute.For<IQueryContextManager>();
+        queryContextManager.Current.Returns(new QueryContext("ObservedDocuments", CorrelationId.New(), Paging.NotPaged, Sorting.None));
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(queryContextManager);
+        Internals.ServiceProvider = services.BuildServiceProvider();
+
+        _collection = Substitute.For<IMongoCollection<ObservedDocument>>();
+        _collection.CollectionNamespace.Returns(new CollectionNamespace("testdb", "observeddocument"));
+        _collection.Settings.Returns(new MongoCollectionSettings());
+
+        _collection
+            .CountDocumentsAsync(
+                Arg.Any<FilterDefinition<ObservedDocument>>(),
+                Arg.Any<CountOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult((long)_documents.Count));
+
+        // The initial find is gated so a spec can observe the subject both before and after the query completes —
+        // the whole point being that nothing is emitted until it has.
+        _collection
+            .FindAsync(
+                Arg.Any<FilterDefinition<ObservedDocument>>(),
+                Arg.Any<FindOptions<ObservedDocument, ObservedDocument>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                await _initialQueryGate.Task;
+                return CreateCursor(_documents);
+            });
+
+        // The change stream stays open for the lifetime of the spec, so the observable is never completed and
+        // disposed underneath a subscriber.
+        _collection
+            .WatchAsync(
+                Arg.Any<PipelineDefinition<ChangeStreamDocument<ObservedDocument>, ChangeStreamDocument<ObservedDocument>>>(),
+                Arg.Any<ChangeStreamOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(CreateChangeStreamCursor()));
+    }
+
+    void Destroy()
+    {
+        _initialQueryGate.TrySetResult();
+        _changeStreamLifetime.Cancel();
+        _changeStreamLifetime.Dispose();
+    }
+
+    protected static async Task<IEnumerable<ObservedDocument>> FirstEmission(
+        ISubject<IEnumerable<ObservedDocument>> subject,
+        TimeSpan timeout)
+    {
+        var emission = new TaskCompletionSource<IEnumerable<ObservedDocument>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = subject.Subscribe(documents => emission.TrySetResult(documents));
+        return await emission.Task.WaitAsync(timeout);
+    }
+
+    IChangeStreamCursor<ChangeStreamDocument<ObservedDocument>> CreateChangeStreamCursor()
+    {
+        var cursor = Substitute.For<IChangeStreamCursor<ChangeStreamDocument<ObservedDocument>>>();
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(async _ =>
+        {
+            await Task.Delay(Timeout.Infinite, _changeStreamLifetime.Token);
+            return false;
+        });
+        return cursor;
+    }
+
+    static IAsyncCursor<ObservedDocument> CreateCursor(IEnumerable<ObservedDocument> documents)
+    {
+        var list = documents.ToList();
+        var cursor = Substitute.For<IAsyncCursor<ObservedDocument>>();
+        cursor.Current.Returns(list);
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(true), Task.FromResult(false));
+        return cursor;
+    }
+}

--- a/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/when_observing/and_subscribing_after_the_initial_query.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/when_observing/and_subscribing_after_the_initial_query.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_MongoCollectionExtensions.when_observing;
+
+public class and_subscribing_after_the_initial_query : given.an_observed_collection
+{
+    ISubject<IEnumerable<ObservedDocument>> _subject;
+    IEnumerable<ObservedDocument> _firstEmission;
+
+    async Task Because()
+    {
+        _subject = _collection.Observe();
+        var initialEmission = FirstEmission(_subject, TimeSpan.FromSeconds(5));
+        _initialQueryGate.SetResult();
+        await initialEmission;
+
+        _firstEmission = await FirstEmission(_subject, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact] void should_replay_the_documents_from_the_initial_query() => _firstEmission.ShouldContainOnly(_documents);
+}

--- a/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/when_observing/and_the_initial_query_has_completed.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/when_observing/and_the_initial_query_has_completed.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_MongoCollectionExtensions.when_observing;
+
+public class and_the_initial_query_has_completed : given.an_observed_collection
+{
+    ISubject<IEnumerable<ObservedDocument>> _subject;
+    IEnumerable<ObservedDocument> _firstEmission;
+
+    async Task Because()
+    {
+        _subject = _collection.Observe();
+        var emission = FirstEmission(_subject, TimeSpan.FromSeconds(5));
+        _initialQueryGate.SetResult();
+        _firstEmission = await emission;
+    }
+
+    [Fact] void should_emit_the_documents_from_the_initial_query() => _firstEmission.ShouldContainOnly(_documents);
+}

--- a/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/when_observing/and_the_initial_query_has_not_completed.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoCollectionExtensions/when_observing/and_the_initial_query_has_not_completed.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_MongoCollectionExtensions.when_observing;
+
+public class and_the_initial_query_has_not_completed : given.an_observed_collection
+{
+    ISubject<IEnumerable<ObservedDocument>> _subject;
+    List<IEnumerable<ObservedDocument>> _emissions = [];
+
+    async Task Because()
+    {
+        _subject = _collection.Observe();
+        using var subscription = _subject.Subscribe(_emissions.Add);
+        await Task.Delay(100);
+    }
+
+    [Fact] void should_not_emit_anything() => _emissions.ShouldBeEmpty();
+}

--- a/Source/DotNET/MongoDB.Specs/for_MongoDBJoinedObserveBuilder/when_selecting/and_subscribing_after_the_initial_emission.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoDBJoinedObserveBuilder/when_selecting/and_subscribing_after_the_initial_emission.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Arc.MongoDB.for_MongoDBJoinedObserveBuilder.when_selecting;
+
+public class and_subscribing_after_the_initial_emission : given.a_joined_observe_builder
+{
+    ISubject<(IEnumerable<DocumentA> A, IEnumerable<DocumentB> B)> _subject;
+    (IEnumerable<DocumentA> A, IEnumerable<DocumentB> B) _emission;
+
+    async Task Because()
+    {
+        var firstEmit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _subject = _builder.Select((a, b) => (a, b));
+
+        // The initial subscription stays alive — the joined observable tears itself down once its last subscriber
+        // leaves, so this specifies a second subscriber arriving late, not one arriving after everyone left.
+        using var initialSubscription = _subject.Subscribe(_ => firstEmit.TrySetResult());
+        await firstEmit.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var lateEmit = new TaskCompletionSource<(IEnumerable<DocumentA> A, IEnumerable<DocumentB> B)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var lateSubscription = _subject.Subscribe(result => lateEmit.TrySetResult(result));
+        _emission = await lateEmit.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact] void should_replay_first_collection_documents() => _emission.A.ShouldContainOnly(_docs1);
+    [Fact] void should_replay_second_collection_documents() => _emission.B.ShouldContainOnly(_docs2);
+}

--- a/Source/DotNET/MongoDB/LifetimeAwareSubject.cs
+++ b/Source/DotNET/MongoDB/LifetimeAwareSubject.cs
@@ -17,14 +17,20 @@ internal sealed class LifetimeAwareSubject<T>(ISubject<T> inner, Action onNoSubs
     int _stopped;
 
     /// <summary>
-    /// Creates a new <see cref="LifetimeAwareSubject{T}"/> backed by a <see cref="Subject{T}"/>.
+    /// Creates a new <see cref="LifetimeAwareSubject{T}"/> backed by a <see cref="ReplaySubject{T}"/> holding the
+    /// single latest value.
     /// </summary>
     /// <param name="onNoSubscribers">The callback to invoke when the last subscriber unsubscribes.</param>
     /// <returns>A new <see cref="LifetimeAwareSubject{T}"/> instance.</returns>
+    /// <remarks>
+    /// The producers behind this subject run their initial query asynchronously. Replaying the latest value means a
+    /// subscriber arriving after that query completed still sees its result, without the subject carrying a value that
+    /// predates the query.
+    /// </remarks>
     public static LifetimeAwareSubject<T> Create(Action onNoSubscribers)
     {
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        return new LifetimeAwareSubject<T>(new Subject<T>(), onNoSubscribers);
+        return new LifetimeAwareSubject<T>(new ReplaySubject<T>(1), onNoSubscribers);
 #pragma warning restore CA2000 // Dispose objects before losing scope
     }
 

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -59,10 +59,9 @@ public static class MongoCollectionExtensions
         FindOptions? options = null)
     {
         filter ??= _ => true;
-        return collection.Observe(
+        return collection.Observe<TDocument, IEnumerable<TDocument>>(
             () => collection.Find(filter, options),
             filter,
-            documents => new BehaviorSubject<IEnumerable<TDocument>>(documents),
             (cursor, observable) => observable.OnNext([.. cursor]));
     }
 
@@ -97,10 +96,9 @@ public static class MongoCollectionExtensions
         FindOptions? options = null)
     {
         filter ??= FilterDefinition<TDocument>.Empty;
-        return collection.Observe(
+        return collection.Observe<TDocument, IEnumerable<TDocument>>(
             () => collection.Find(filter, options),
             filter,
-            documents => new BehaviorSubject<IEnumerable<TDocument>>(documents),
             (documents, observable) => observable.OnNext(documents));
     }
 
@@ -143,16 +141,6 @@ public static class MongoCollectionExtensions
         return collection.Observe<TDocument, TDocument>(
             findCall,
             filter,
-            documents =>
-            {
-                var result = documents.FirstOrDefault();
-                if (result is not null)
-                {
-                    return new BehaviorSubject<TDocument>(result);
-                }
-
-                return new Subject<TDocument>();
-            },
             (documents, observable) =>
             {
                 var result = documents.FirstOrDefault();
@@ -167,7 +155,6 @@ public static class MongoCollectionExtensions
         this IMongoCollection<TDocument> collection,
         Func<IFindFluent<TDocument, TDocument>> findCall,
         FilterDefinition<TDocument> filter,
-        Func<IEnumerable<TDocument>, ISubject<TResult>> createSubject,
         Action<IEnumerable<TDocument>, ISubject<TResult>> onNext)
     {
         var completedCleanup = false;
@@ -198,14 +185,19 @@ public static class MongoCollectionExtensions
 
     #pragma warning disable CA2000 // Dispose objects before losing scope
         var cancellationTokenSource = new CancellationTokenSource();
-    #pragma warning restore CA2000 // Dispose objects before losing scope
+
+        // The initial query runs asynchronously in Watch() below, so the subject must not carry a value before it
+        // completes. A subject seeded up front hands every subscriber — including a one-shot waitForFirstResult read —
+        // an empty emission that predates the query and is indistinguishable from a genuinely empty result. Replaying
+        // the single latest emission keeps a late subscriber from missing the initial query result instead.
         var subject = new LifetimeAwareSubject<TResult>(
-            createSubject([]),
+            new ReplaySubject<TResult>(1),
             () =>
             {
                 logger.ClientUnsubscribed();
                 cancellationTokenSource?.Cancel();
             });
+    #pragma warning restore CA2000 // Dispose objects before losing scope
         ISubject<TResult> observable = subject;
 
         var cancellationToken = cancellationTokenSource.Token;


### PR DESCRIPTION
# Summary

A one-shot HTTP read of a collection-backed observable query with `waitForFirstResult=true` returned the observable's empty seed value with `isReady: true`, deterministically and regardless of the timeout. Because the payload was a well-formed empty collection and the result reported itself as ready, a caller had no way to tell it apart from a genuinely empty read model. Anything that cannot hold a stream open was affected: cURL and scripted reads, readiness probes, integration specs, and server-to-server fetches.

## Fixed
- `waitForFirstResult=true` on a MongoDB collection-backed observable query now resolves on the initial query result instead of the empty seed emission that preceded it (#2535)
- A subscriber that connects to a MongoDB observable query after its initial query completed now receives that result, rather than waiting for the next change
