### PR TITLE
Say which formRef shapes attach once, and pin the in-flight reading

### DIFF
--- a/Documentation/frontend/react/command-form/form-lifecycle.md
+++ b/Documentation/frontend/react/command-form/form-lifecycle.md
@@ -309,9 +309,15 @@ function ProfilePanel() {
 }
 ```
 
-The handle is created once for the lifetime of the form, so a **callback ref** passed here is invoked
-exactly once on mount and once on unmount, however often the parent re-renders. Its state members are
-getters over live values, so a handle captured once never reports stale state.
+The handle object is created once for the lifetime of the form, so it never changes identity. React
+still re-attaches a ref whenever the **ref itself** changes identity, though — so pass a *stable* one.
+An object ref from `useRef`, or a callback wrapped in `useCallback` with no dependencies, attaches once
+on mount and detaches once on unmount however often the parent re-renders. An inline
+`formRef={handle => setHandle(handle)}` is a new function on every render and therefore re-attaches on
+every render; it still works, but it does redundant attach/detach work, and pairing it with a state
+setter is a re-render loop.
+
+Its state members are getters over live values, so a handle captured once never reports stale state.
 
 ### onStateChange — re-rendering the parent
 

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -80,10 +80,15 @@ export interface CommandFormProps<TCommand extends object, TResponse = object> {
      * read its state. Named rather than taken through `forwardRef`, because forwarding erases the
      * generic arguments and callers write `<CommandForm<TCommand, TResponse> ... />`.
      *
-     * The handle is created once for the lifetime of the form, so a callback ref passed here is
-     * invoked exactly once on mount and once on unmount, however often the parent re-renders. Its
-     * state members are getters over live values and are therefore never stale - but reading them
-     * does not re-render the parent. Use {@link CommandFormProps.onStateChange} for that.
+     * The handle object is created once for the lifetime of the form, so it never changes identity.
+     * React still re-attaches whenever the ref itself changes identity, though - so a *stable* ref
+     * (an object ref, or a callback wrapped in `useCallback` with no dependencies) attaches once on
+     * mount and detaches once on unmount however often the parent re-renders, while an inline
+     * `ref={h => ...}` is a new function every render and re-attaches every render. Prefer a stable
+     * ref; an inline one still works but does redundant attach/detach.
+     *
+     * Its state members are getters over live values and are therefore never stale - but reading
+     * them does not re-render the parent. Use {@link CommandFormProps.onStateChange} for that.
      */
     formRef?: React.Ref<CommandFormHandle>;
 

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_command_rejects.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_executing_the_command/and_the_command_rejects.ts
@@ -16,6 +16,7 @@ import { given } from '../../../../given';
 describe('when executing the command and the command rejects', given(a_command_form_being_executed, context => {
     const failure = new Error('the command could not be reached');
     let isExecuting = false;
+    let isExecutingInFlight = false;
     let contextValue: ReturnType<typeof useCommandFormContext> | null = null;
     let caught: unknown;
 
@@ -29,6 +30,7 @@ describe('when executing the command and the command rejects', given(a_command_f
         context.reset();
         contextValue = null;
         caught = undefined;
+        isExecutingInFlight = false;
 
         render(
             React.createElement(
@@ -46,12 +48,17 @@ describe('when executing the command and the command rejects', given(a_command_f
             pending = contextValue!.onExecute!().catch(reason => { caught = reason; });
         });
 
+        isExecutingInFlight = isExecuting;
+
         await act(async () => {
             context.executions[0].fail(failure);
             await pending;
         });
     });
 
+    // Read while the execution is still in flight. Without this, "stopped executing" is satisfied by an
+    // implementation that never started executing, and the finally could be deleted without a spec noticing.
+    it('should report executing while the command is in flight', () => isExecutingInFlight.should.be.true);
     it('should stop reporting executing', () => isExecuting.should.be.false);
     it('should let the rejection propagate unchanged', () => expect(caught).to.equal(failure));
 }));


### PR DESCRIPTION
## Added

- `useIsCommandExecuting` for reading whether a `CommandForm`'s command is currently executing (#2497)
- `formRef` on `CommandForm`, exposing `execute()` plus `isExecuting`, `isValid` and `isAuthorized` to a parent rendering its own submit control (#2497)
- `onStateChange` on `CommandForm`, notifying a parent when execution, validity or authorization changes (#2497)
- `isExecuting` on the command form context (#2497)

## Fixed

- `formRef` documentation no longer implies an inline callback ref attaches only once; it attaches on every render, so a stable ref is required (#2497)
