### PR TITLE
List every tenant resolver in the configuration reference

### DIFF
--- a/Documentation/backend/asp-net-core/configuration.md
+++ b/Documentation/backend/asp-net-core/configuration.md
@@ -54,11 +54,12 @@ Controls how correlation IDs are handled in HTTP requests.
 
 Controls how the active tenant is resolved on each request.
 
-- **ResolverType** (`TenantResolverType`, default: `Header`): How to resolve the tenant — `Header`, `Query`, `Claim`, or `Development`.
-- **HttpHeader** (string, default: `"x-cratis-tenant-id"`): The HTTP header used when `ResolverType` is `Header`.
+- **ResolverType** (`TenantResolverType`, default: `Header`): How to resolve the tenant — `Header`, `Query`, `Claim`, `Subdomain`, `Development`, or `Fixed`.
+- **HttpHeader** (string, default: `"x-cratis-tenant-id"`): The HTTP header used when `ResolverType` is `Header`, and the fallback header when it is `Subdomain`.
 - **QueryParameter** (string, default: `"tenantId"`): The query-string parameter used when `ResolverType` is `Query`.
 - **ClaimType** (string, default: `"tenant_id"`): The claim used when `ResolverType` is `Claim`.
-- **DevelopmentTenantId** (string, default: `"development"`): The fixed tenant used when `ResolverType` is `Development`.
+- **FixedTenantId** (string, default: `"development"`): The tenant every request resolves to when `ResolverType` is `Fixed` or `Development`. Prefer `Fixed` for a single-tenant production deployment — `Development` resolves identically but is named for an environment it does not check.
+- **DevelopmentTenantId** (string, default: `"development"`): The same value under its original name — reading or writing either key sets both. Supply only one; if both are present the binder's property order decides.
 
 #### GeneratedApis
 

--- a/Documentation/backend/configuration/index.md
+++ b/Documentation/backend/configuration/index.md
@@ -38,11 +38,12 @@ builder.AddCratisArc(options =>
 | Option | Type | Default | What it controls |
 | --- | --- | --- | --- |
 | `CorrelationId.HttpHeader` | `string` | `X-Correlation-ID` | The header carrying the correlation ID. |
-| `Tenancy.ResolverType` | `TenantResolverType` | `Header` | How the tenant is resolved: `Header`, `Query`, `Claim`, or `Development`. |
-| `Tenancy.HttpHeader` | `string` | `x-cratis-tenant-id` | The header used when `ResolverType` is `Header`. |
+| `Tenancy.ResolverType` | `TenantResolverType` | `Header` | How the tenant is resolved: `Header`, `Query`, `Claim`, `Subdomain`, `Development`, or `Fixed`. |
+| `Tenancy.HttpHeader` | `string` | `x-cratis-tenant-id` | The header used when `ResolverType` is `Header`, and the fallback header when it is `Subdomain`. |
 | `Tenancy.QueryParameter` | `string` | `tenantId` | The query parameter used when `ResolverType` is `Query`. |
 | `Tenancy.ClaimType` | `string` | `tenant_id` | The claim used when `ResolverType` is `Claim`. |
-| `Tenancy.DevelopmentTenantId` | `string` | `development` | The fixed tenant used when `ResolverType` is `Development`. |
+| `Tenancy.FixedTenantId` | `string` | `development` | The tenant every request resolves to when `ResolverType` is `Fixed` or `Development`. |
+| `Tenancy.DevelopmentTenantId` | `string` | `development` | The same value under its original name — reading or writing either key sets both. Supply only one; if both are present the binder's property order decides. |
 | `GeneratedApis.RoutePrefix` | `string` | `api` | Base prefix for generated command and query routes. |
 | `GeneratedApis.SegmentsToSkipForRoute` | `int` | `0` | Namespace segments to drop when building a route. |
 | `GeneratedApis.IncludeCommandNameInRoute` | `bool` | `true` | Append the command name as the last route segment. |


### PR DESCRIPTION
## Changed

- The tenancy configuration reference now lists every resolver, including `Subdomain` and `Fixed`, and documents `Tenancy.FixedTenantId` (#2478)
