### PR TITLE
Prune proxy generator handler discovery to relevant assemblies

### DIFF
--- a/Documentation/backend/commands/response-value-handlers.md
+++ b/Documentation/backend/commands/response-value-handlers.md
@@ -118,6 +118,10 @@ The typed interface is a declaration for tooling; it does not replace the runtim
 handler whose accepted types are determined dynamically at runtime should implement only the runtime interface,
 because declaring an overly broad type such as `object` would hide legitimate client response models.
 
+Declarations are discovered from the application and every package it references. Only assemblies referencing
+`Cratis.Arc.Core` are inspected, and both contracts are matched on assembly identity rather than on name, so a
+look-alike interface declared elsewhere cannot claim a value and suppress its client response.
+
 ## Response Object Availability
 
 When implementing a command response value handler, the `CommandContext.Response` property contains the response object returned by the command handler, **if any**. This property can be `null` in the following scenarios:

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/CommandResponseHandlerDependency/CommandResponseHandlerDependency.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <AssemblyName>Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency</AssemblyName>
         <RootNamespace>Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency</RootNamespace>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="../../../../Arc.Core/Arc.Core.csproj" />

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/FakeCommandResponseHandlerDependency/FakeCommandResponseHandlerDependency.csproj
@@ -2,6 +2,5 @@
     <PropertyGroup>
         <AssemblyName>Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency</AssemblyName>
         <RootNamespace>Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency</RootNamespace>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 </Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_an_assembly_can_declare_command_response_value_handlers/and_the_assembly_does_not_reference_the_contracts.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_an_assembly_can_declare_command_response_value_handlers/and_the_assembly_does_not_reference_the_contracts.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias FakeContracts;
+
+using FakeHandledValueHandler = FakeContracts::Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency.FakeHandledValueHandler;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_checking_if_an_assembly_can_declare_command_response_value_handlers;
+
+public class and_the_assembly_does_not_reference_the_contracts : Specification
+{
+    bool _counterfeitContracts;
+    bool _unrelated;
+
+    void Because()
+    {
+        _counterfeitContracts = TypeExtensions.CanDeclareCommandResponseValueHandlers(typeof(FakeHandledValueHandler).Assembly);
+        _unrelated = TypeExtensions.CanDeclareCommandResponseValueHandlers(typeof(object).Assembly);
+    }
+
+    [Fact] void should_skip_a_dependency_shipping_counterfeit_contracts() => _counterfeitContracts.ShouldBeFalse();
+    [Fact] void should_skip_an_unrelated_assembly() => _unrelated.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_an_assembly_can_declare_command_response_value_handlers/and_the_assembly_references_the_contracts.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_an_assembly_can_declare_command_response_value_handlers/and_the_assembly_references_the_contracts.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_checking_if_an_assembly_can_declare_command_response_value_handlers;
+
+public class and_the_assembly_references_the_contracts : Specification
+{
+    bool _contracts;
+    bool _dependency;
+
+    void Because()
+    {
+        _contracts = TypeExtensions.CanDeclareCommandResponseValueHandlers(typeof(ICommandResponseValueHandler).Assembly);
+        _dependency = TypeExtensions.CanDeclareCommandResponseValueHandlers(typeof(DependencyHandledValueHandler).Assembly);
+    }
+
+    [Fact] void should_inspect_the_contracts_assembly() => _contracts.ShouldBeTrue();
+    [Fact] void should_inspect_a_dependency_that_references_the_contracts() => _dependency.ShouldBeTrue();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_server_handled_command_response_value_type_names/and_the_handler_implements_counterfeit_contracts.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_server_handled_command_response_value_type_names/and_the_handler_implements_counterfeit_contracts.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias FakeContracts;
+
+using Cratis.Arc.Commands;
+using FakeHandledValueHandler = FakeContracts::Cratis.Arc.ProxyGenerator.Specs.FakeCommandResponseHandlerDependency.FakeHandledValueHandler;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_server_handled_command_response_value_type_names;
+
+public class and_the_handler_implements_counterfeit_contracts : Specification
+{
+    string[] _result;
+
+    void Because() => _result = [.. TypeExtensions.GetServerHandledCommandResponseValueTypeNames(
+        typeof(FakeHandledValueHandler).GetInterfaces(),
+        typeof(ICommandResponseValueHandler).Assembly)];
+
+    [Fact] void should_not_declare_any_value_as_server_handled() => _result.ShouldBeEmpty();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_server_handled_command_response_value_type_names/and_the_handler_implements_the_genuine_contracts.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_server_handled_command_response_value_type_names/and_the_handler_implements_the_genuine_contracts.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.ProxyGenerator.Specs.CommandResponseHandlerDependency;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_server_handled_command_response_value_type_names;
+
+public class and_the_handler_implements_the_genuine_contracts : Specification
+{
+    string[] _result;
+
+    void Because() => _result = [.. TypeExtensions.GetServerHandledCommandResponseValueTypeNames(
+        typeof(DependencyHandledValueHandler).GetInterfaces(),
+        typeof(ICommandResponseValueHandler).Assembly)];
+
+    [Fact] void should_declare_the_handled_value() =>
+        _result.ShouldContain(typeof(DependencyHandledValue).AssemblyQualifiedName);
+
+    [Fact] void should_declare_the_handled_collection() =>
+        _result.ShouldContain(typeof(IEnumerable<DependencyHandledValue>).AssemblyQualifiedName);
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -24,13 +24,6 @@ public static class TypeExtensions
 
 #pragma warning disable SA1600 // Elements should be documented
     internal static Type _conceptType = typeof(NoConcept);
-    internal static Type _nullableType = typeof(Nullable<>);
-    internal static Type _expandoObjectType = typeof(ExpandoObject);
-    internal static Type _stringType = typeof(string);
-    internal static Type _enumerableType = typeof(IEnumerable);
-    internal static Type _genericEnumerableType = typeof(IEnumerable<>);
-    internal static Type _dictionaryType = typeof(IDictionary<,>);
-    internal static Type _asyncEnumerableType = typeof(IAsyncEnumerable<>);
     internal static Type _controllerBaseType = typeof(object);
     internal static Type _taskType = typeof(Task);
     internal static Type _voidType = typeof(void);
@@ -1544,13 +1537,6 @@ public static class TypeExtensions
     static void ResetWellKnownTypes()
     {
         _conceptType = typeof(NoConcept);
-        _nullableType = typeof(Nullable<>);
-        _expandoObjectType = typeof(ExpandoObject);
-        _stringType = typeof(string);
-        _enumerableType = typeof(IEnumerable);
-        _genericEnumerableType = typeof(IEnumerable<>);
-        _dictionaryType = typeof(IDictionary<,>);
-        _asyncEnumerableType = typeof(IAsyncEnumerable<>);
         _controllerBaseType = typeof(object);
         _taskType = typeof(Task);
         _voidType = typeof(void);
@@ -1569,13 +1555,6 @@ public static class TypeExtensions
 
     static void InitializeWellKnownTypes()
     {
-        _nullableType = GetMetadataType(typeof(Nullable<>));
-        _expandoObjectType = GetMetadataType(typeof(ExpandoObject));
-        _stringType = GetMetadataType(typeof(string));
-        _enumerableType = GetMetadataType(typeof(IEnumerable));
-        _genericEnumerableType = GetMetadataType(typeof(IEnumerable<>));
-        _asyncEnumerableType = GetMetadataType(typeof(IAsyncEnumerable<>));
-        _dictionaryType = GetMetadataType(typeof(IDictionary<,>));
         _taskType = GetMetadataType(typeof(Task));
         _voidType = GetMetadataType(typeof(void));
 

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -1347,6 +1347,71 @@ public static class TypeExtensions
     internal static IDisposable OwnProjectAssemblies() => new ProjectAssembliesLifetime(_metadataLoadContext);
 
     /// <summary>
+    /// Find the identities of every response value type declared as consumed on the server.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to inspect.</param>
+    /// <param name="commandResponseValueHandlerContractsAssembly">The assembly defining the genuine handler contracts.</param>
+    /// <param name="errorMessage">Callback for outputting error messages.</param>
+    /// <returns>The assembly qualified names of the declared types.</returns>
+    /// <remarks>
+    /// Only assemblies that reference the contracts assembly are inspected. Declaring a handler requires implementing
+    /// its contracts, so an assembly without that reference cannot contribute a declaration, and skipping it avoids
+    /// materializing the type metadata of every unrelated dependency.
+    /// </remarks>
+    internal static HashSet<string> FindServerHandledCommandResponseValueTypeNames(
+        IEnumerable<Assembly> assemblies,
+        Assembly? commandResponseValueHandlerContractsAssembly,
+        Action<string> errorMessage) =>
+        commandResponseValueHandlerContractsAssembly is null
+            ? []
+            : assemblies
+                .Where(CanDeclareCommandResponseValueHandlers)
+                .SelectMany(_ => GetLoadableTypes(_, errorMessage))
+                .Where(_ => !_.IsAbstract && !_.IsInterface)
+                .Select(_ => GetLoadableInterfaces(_, errorMessage))
+                .SelectMany(_ => GetServerHandledCommandResponseValueTypeNames(_, commandResponseValueHandlerContractsAssembly))
+                .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Check whether an assembly could possibly declare a command response value handler.
+    /// </summary>
+    /// <param name="assembly">Assembly to check.</param>
+    /// <returns>True if the assembly defines or references the handler contracts, false if not.</returns>
+    internal static bool CanDeclareCommandResponseValueHandlers(Assembly assembly) =>
+        assembly.GetName().Name == CommandResponseValueHandlerContractsAssemblyName ||
+        assembly.GetReferencedAssemblies().Any(_ => _.Name == CommandResponseValueHandlerContractsAssemblyName);
+
+    /// <summary>
+    /// Get the response value types a handler declares as consumed on the server.
+    /// </summary>
+    /// <param name="interfaces">The interfaces implemented by the candidate handler.</param>
+    /// <param name="commandResponseValueHandlerContractsAssembly">The assembly defining the genuine handler contracts.</param>
+    /// <returns>The assembly qualified names of the declared types.</returns>
+    /// <remarks>
+    /// Both contracts are matched on assembly identity rather than name, so a dependency shipping look-alike
+    /// interfaces in the same namespace cannot claim a value and have its client response suppressed.
+    /// </remarks>
+    internal static IEnumerable<string> GetServerHandledCommandResponseValueTypeNames(
+        Type[] interfaces,
+        Assembly? commandResponseValueHandlerContractsAssembly)
+    {
+        if (commandResponseValueHandlerContractsAssembly is null ||
+            !interfaces.Any(_ => _.FullName == RuntimeCommandResponseValueHandlerTypeName &&
+                                 ReferenceEquals(_.Assembly, commandResponseValueHandlerContractsAssembly)))
+        {
+            return [];
+        }
+
+        return interfaces
+            .Where(_ => _.IsGenericType &&
+                        _.GetGenericTypeDefinition().FullName == CommandResponseValueHandlerTypeName &&
+                        ReferenceEquals(_.Assembly, commandResponseValueHandlerContractsAssembly))
+            .Select(_ => _.GetGenericArguments()[0].AssemblyQualifiedName)
+            .Where(_ => _ is not null)
+            .Cast<string>();
+    }
+
+    /// <summary>
     /// Unwrap a type to get the best response type candidate.
     /// Handles tuples and OneOf types recursively.
     /// </summary>
@@ -1370,37 +1435,6 @@ public static class TypeExtensions
         }
 
         return type;
-    }
-
-    static HashSet<string> FindServerHandledCommandResponseValueTypeNames(
-        IEnumerable<Assembly> assemblies,
-        Assembly? commandResponseValueHandlerContractsAssembly,
-        Action<string> errorMessage) =>
-        assemblies
-            .SelectMany(_ => GetLoadableTypes(_, errorMessage))
-            .Where(_ => !_.IsAbstract && !_.IsInterface)
-            .Select(_ => GetLoadableInterfaces(_, errorMessage))
-            .SelectMany(_ => GetServerHandledCommandResponseValueTypeNames(_, commandResponseValueHandlerContractsAssembly))
-            .ToHashSet(StringComparer.Ordinal);
-
-    static IEnumerable<string> GetServerHandledCommandResponseValueTypeNames(
-        Type[] interfaces,
-        Assembly? commandResponseValueHandlerContractsAssembly)
-    {
-        if (commandResponseValueHandlerContractsAssembly is null ||
-            !interfaces.Any(_ => _.FullName == RuntimeCommandResponseValueHandlerTypeName &&
-                                 ReferenceEquals(_.Assembly, commandResponseValueHandlerContractsAssembly)))
-        {
-            return [];
-        }
-
-        return interfaces
-            .Where(_ => _.IsGenericType &&
-                        _.GetGenericTypeDefinition().FullName == CommandResponseValueHandlerTypeName &&
-                        ReferenceEquals(_.Assembly, commandResponseValueHandlerContractsAssembly))
-            .Select(_ => _.GetGenericArguments()[0].AssemblyQualifiedName)
-            .Where(_ => _ is not null)
-            .Cast<string>();
     }
 
     static Assembly LoadMetadataAssembly(string assemblyPath)

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -1134,10 +1134,7 @@ public static class TypeExtensions
         var isFromCurrentMetadataContext = _metadataLoadContext?.GetAssemblies().Contains(type.Assembly) == true;
         var handledTypeIdentities = isFromCurrentMetadataContext
             ? _serverHandledCommandResponseValueTypeNames ?? []
-            : FindServerHandledCommandResponseValueTypeNames(
-                AppDomain.CurrentDomain.GetAssemblies().Where(_ => !_.IsDynamic),
-                AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(_ => !_.IsDynamic && _.GetName().Name == CommandResponseValueHandlerContractsAssemblyName),
-                _ => { });
+            : FindRuntimeServerHandledCommandResponseValueTypeNames();
 
         return EnumerateTypeAndContracts(type).Any(_ =>
             _.AssemblyQualifiedName is not null && handledTypeIdentities.Contains(_.AssemblyQualifiedName));
@@ -1321,6 +1318,13 @@ public static class TypeExtensions
                 .SingleOrDefault();
             _serverHandledCommandResponseValueTypeNames = FindServerHandledCommandResponseValueTypeNames(
                 managedAppAssemblyPaths.Select(LoadMetadataAssembly), commandResponseValueHandlerContractsAssembly, errorMessage);
+
+            foreach (var loadedAssembly in _metadataLoadContext.GetAssemblies())
+            {
+                _assembliesByName[loadedAssembly.GetName().Name!] = loadedAssembly;
+            }
+
+            InitializeWellKnownTypes();
         }
         catch (Exception ex) when (ex is BadImageFormatException or FileLoadException or FileNotFoundException)
         {
@@ -1329,13 +1333,12 @@ public static class TypeExtensions
             _serverHandledCommandResponseValueTypeNames = [];
             return false;
         }
-
-        foreach (var loadedAssembly in _metadataLoadContext.GetAssemblies())
+        catch
         {
-            _assembliesByName[loadedAssembly.GetName().Name!] = loadedAssembly;
+            DisposeUnpublishedMetadataLoadContext();
+            _serverHandledCommandResponseValueTypeNames = [];
+            throw;
         }
-
-        InitializeWellKnownTypes();
 
         return true;
     }
@@ -1435,6 +1438,24 @@ public static class TypeExtensions
         }
 
         return type;
+    }
+
+    /// <summary>
+    /// Find the declared server-handled response value identities from the assemblies loaded into the runtime.
+    /// </summary>
+    /// <returns>The assembly qualified names of the declared types.</returns>
+    /// <remarks>
+    /// Used for types outside the current metadata graph. More than one copy of the contracts assembly can be loaded
+    /// when the generator is hosted rather than run as a tool; picking the first only narrows what is recognized as
+    /// server-handled, which leaves the response generated rather than wrongly suppressed.
+    /// </remarks>
+    static HashSet<string> FindRuntimeServerHandledCommandResponseValueTypeNames()
+    {
+        var runtimeAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(_ => !_.IsDynamic).ToArray();
+        return FindServerHandledCommandResponseValueTypeNames(
+            runtimeAssemblies,
+            Array.Find(runtimeAssemblies, _ => _.GetName().Name == CommandResponseValueHandlerContractsAssemblyName),
+            _ => { });
     }
 
     static Assembly LoadMetadataAssembly(string assemblyPath)


### PR DESCRIPTION
# Summary

Follow-up cleanup to the command response value handler declarations. Build-time handler discovery no longer materializes the type metadata of every dependency an application references, which is work every Release build paid for.

## Changed

- The proxy generator only inspects assemblies referencing `Cratis.Arc.Core` when discovering declared response value handlers, instead of every managed dependency of the application

## Fixed

- The proxy generator releases its metadata load context when initialization fails part way through, instead of leaking it and its assembly resolving handler until the next run
- The proxy generator no longer fails when more than one copy of `Cratis.Arc.Core` is loaded while resolving handler declarations outside the current project graph
