### PR TITLE
Do not capture what a specification declares

### DIFF
--- a/Source/DotNET/Screenplay.Specs/for_ArtifactCatalog/when_a_specification_declares_a_fixture.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArtifactCatalog/when_a_specification_declares_a_fixture.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
-using Cratis.Arc.Screenplay.Model;
 
 namespace Cratis.Arc.Screenplay.for_ArtifactCatalog;
 
 /// <summary>
 /// A specification that declares a projection to assert something about a contract, alongside the real one for
-/// the same read model — the shape a capture of a real application actually meets.
+/// the same read model - the shape a capture of a real application actually meets.
 /// </summary>
 /// <remarks>
 /// Both halves matter. The fixture must not be captured, because it ships only in Debug and the application
@@ -22,11 +21,8 @@ namespace Cratis.Arc.Screenplay.for_ArtifactCatalog;
 /// </remarks>
 public class when_a_specification_declares_a_fixture : Specification
 {
-    ApplicationModelAnalysis _analysis = null!;
-
-    void Because() => _analysis = Analyzed.Source(
-        Analyzed.Root,
-        ("Library/Feature/Slice/Slice.cs", """
+    const string Slice = """
+        using Cratis.Chronicle.Events;
         using Cratis.Chronicle.Projections;
         using Cratis.Chronicle.ReadModels;
 
@@ -42,8 +38,9 @@ public class when_a_specification_declares_a_fixture : Specification
 
         [EventType]
         public record Deposited(int Amount);
-        """),
-        ("Library/Feature/Inspection/when_the_contract_is_inspected.cs", """
+        """;
+
+    const string Inspection = """
         using Cratis.Chronicle.Projections;
         using Cratis.Specifications;
         using Library.Feature.Slice;
@@ -57,7 +54,14 @@ public class when_a_specification_declares_a_fixture : Specification
                 public void Define(IProjectionBuilderFor<Balance> builder) => builder.From<Deposited>(_ => _);
             }
         }
-        """));
+        """;
+
+    ApplicationModelAnalysis _analysis = null!;
+
+    void Because() => _analysis = Analyzed.Source(
+        Analyzed.Root,
+        ("Library/Feature/Slice/Slice.cs", Slice),
+        ("Library/Feature/Inspection/when_the_contract_is_inspected.cs", Inspection));
 
     [Fact] void should_capture_the_projection_the_application_ships() =>
         Projections().ShouldContain("Library.Feature.Slice.BalanceProjection");
@@ -65,8 +69,10 @@ public class when_a_specification_declares_a_fixture : Specification
     [Fact] void should_not_capture_the_fixture_the_specification_declares() =>
         Projections().Any(projection => projection.EndsWith("SpecificationProjection", StringComparison.Ordinal)).ShouldBeFalse();
 
-    // The read model would otherwise be built twice, which is not legal Screenplay - the document stops
-    // compiling and nothing downstream can read it.
+    /// <summary>
+    /// The read model would otherwise be built twice, which is not legal Screenplay - the document stops
+    /// compiling and nothing downstream can read it.
+    /// </summary>
     [Fact] void should_build_the_read_model_exactly_once() =>
         Projections().Count(projection => projection.Contains("Balance", StringComparison.Ordinal)).ShouldEqual(1);
 

--- a/Source/DotNET/Screenplay.Specs/for_ArtifactCatalog/when_a_specification_declares_a_fixture.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArtifactCatalog/when_a_specification_declares_a_fixture.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ArtifactCatalog;
+
+/// <summary>
+/// A specification that declares a projection to assert something about a contract, alongside the real one for
+/// the same read model — the shape a capture of a real application actually meets.
+/// </summary>
+/// <remarks>
+/// Both halves matter. The fixture must not be captured, because it ships only in Debug and the application
+/// nobody debugs does not have it; and capturing it makes the document say a read model is built twice, which is
+/// not legal Screenplay, so the document stops compiling and cannot be imported anywhere.
+/// <para>
+/// The specification here has no <c>Because</c>, deliberately: a specification that only inspects a contract
+/// never needs one, and those are precisely the ones that declare a fixture. A rule written around the members a
+/// specification usually holds would not recognise this as one.
+/// </para>
+/// </remarks>
+public class when_a_specification_declares_a_fixture : Specification
+{
+    ApplicationModelAnalysis _analysis = null!;
+
+    void Because() => _analysis = Analyzed.Source(
+        Analyzed.Root,
+        ("Library/Feature/Slice/Slice.cs", """
+        using Cratis.Chronicle.Projections;
+        using Cratis.Chronicle.ReadModels;
+
+        namespace Library.Feature.Slice;
+
+        [ReadModel]
+        public record Balance(int Total);
+
+        public class BalanceProjection : IProjectionFor<Balance>
+        {
+            public void Define(IProjectionBuilderFor<Balance> builder) => builder.From<Deposited>(_ => _);
+        }
+
+        [EventType]
+        public record Deposited(int Amount);
+        """),
+        ("Library/Feature/Inspection/when_the_contract_is_inspected.cs", """
+        using Cratis.Chronicle.Projections;
+        using Cratis.Specifications;
+        using Library.Feature.Slice;
+
+        namespace Library.Feature.Inspection;
+
+        public class when_the_contract_is_inspected : Specification
+        {
+            sealed class SpecificationProjection : IProjectionFor<Balance>
+            {
+                public void Define(IProjectionBuilderFor<Balance> builder) => builder.From<Deposited>(_ => _);
+            }
+        }
+        """));
+
+    [Fact] void should_capture_the_projection_the_application_ships() =>
+        Projections().ShouldContain("Library.Feature.Slice.BalanceProjection");
+
+    [Fact] void should_not_capture_the_fixture_the_specification_declares() =>
+        Projections().Any(projection => projection.EndsWith("SpecificationProjection", StringComparison.Ordinal)).ShouldBeFalse();
+
+    // The read model would otherwise be built twice, which is not legal Screenplay - the document stops
+    // compiling and nothing downstream can read it.
+    [Fact] void should_build_the_read_model_exactly_once() =>
+        Projections().Count(projection => projection.Contains("Balance", StringComparison.Ordinal)).ShouldEqual(1);
+
+    IEnumerable<string> Projections() =>
+        _analysis.Model.Slices.SelectMany(slice => slice.Projections).Select(projection => projection.Identifier);
+}

--- a/Source/DotNET/Screenplay/Analysis/ArtifactCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactCatalog.cs
@@ -74,17 +74,53 @@ public class ArtifactCatalog
     }
 
     /// <summary>
-    /// Collects a type and everything nested within it.
+    /// Collects a type and everything nested within it, stopping at a specification.
     /// </summary>
     /// <param name="type">The type to collect.</param>
     /// <param name="types">The types collected so far.</param>
+    /// <remarks>
+    /// A specification is collected - the catalogue is where specifications are read from - but nothing nested
+    /// inside one is. A fixture a specification declares to assert something about a contract is written to be
+    /// examined, not to run: it ships only in Debug and is stripped from the application anyone deploys. Capturing
+    /// it emits an artifact the application does not have, and where the fixture stands in for a real one - a
+    /// second projection over a read model that already has one - the captured document contradicts itself and no
+    /// longer compiles.
+    /// </remarks>
     static void Collect(INamedTypeSymbol type, List<INamedTypeSymbol> types)
     {
         types.Add(type);
+
+        if (IsSpecification(type))
+        {
+            return;
+        }
 
         foreach (var nested in type.GetTypeMembers())
         {
             Collect(nested, types);
         }
+    }
+
+    /// <summary>
+    /// Whether a type is a specification, by what it derives from.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type derives from the specification base class.</returns>
+    /// <remarks>
+    /// Deliberately the base class rather than the shape of its members: a specification that only inspects a
+    /// contract has no <c>Because</c>, so a rule written around the members it usually holds does not recognise
+    /// one - and those are exactly the specifications that declare a fixture worth not capturing.
+    /// </remarks>
+    static bool IsSpecification(INamedTypeSymbol type)
+    {
+        for (var candidate = type.BaseType; candidate is not null; candidate = candidate.BaseType)
+        {
+            if (string.Equals(candidate.ToDisplayString(), WellKnownTypeNames.Specification, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
@@ -81,6 +81,9 @@ public static class WellKnownTypeNames
     /// <summary>The interface a fluent projection implements.</summary>
     public const string ProjectionFor = "Cratis.Chronicle.Projections.IProjectionFor`1";
 
+    /// <summary>The base class a specification derives from.</summary>
+    public const string Specification = "Cratis.Specifications.Specification";
+
     /// <summary>The attribute configuring a projection.</summary>
     public const string ProjectionAttribute = "Cratis.Chronicle.Projections.ProjectionAttribute";
 


### PR DESCRIPTION
## Fixed

- A type a specification declares is no longer captured as an artifact the application ships. A fixture declared to assert something about a contract is Debug-only and stripped from any deployed build, and where it stands in for a real artifact — a second projection over a read model that already has one — the captured document said the read model was built twice, which is not legal Screenplay, so the document did not compile and nothing downstream could read it.
