### PR TITLE
Support populating CommandForm from a query at startup

### DIFF
--- a/Documentation/frontend/react/command-form/data-loading.md
+++ b/Documentation/frontend/react/command-form/data-loading.md
@@ -90,6 +90,51 @@ function LocationForm() {
 }
 ```
 
+## Populating a Form from a Query
+
+The examples above load data for a *field's options* - the form's own values still come from `initialValues`/`currentValues`, fetched by hand. `CommandForm` can fetch its initial values itself instead, from a single-instance query:
+
+```tsx
+import { CommandForm, InputTextField } from '@cratis/arc.react/commands';
+import { GetUserProfile } from './queries';
+import { UpdateProfile } from './commands';
+
+function ProfileEditor({ userId }: { userId: string }) {
+    return (
+        <CommandForm
+            command={UpdateProfile}
+            populateFromQuery={GetUserProfile}
+            populateFromQueryArgs={{ userId }}
+        >
+            <InputTextField<UpdateProfile> value={c => c.firstName} title="First name" />
+            <InputTextField<UpdateProfile> value={c => c.lastName} title="Last name" />
+            <InputTextField<UpdateProfile> value={c => c.email} title="Email" />
+        </CommandForm>
+    );
+}
+```
+
+Each field is matched onto the query's result by property name - the command's `firstName` is seeded from the query result's `firstName`, and so on. `GetUserProfile` must be a **single-instance query** - a query returning multiple instances throws. For an observable query, use `populateFromObservableQuery` instead; both read their arguments from `populateFromQueryArgs`.
+
+The resolved data becomes the form's **baseline**, not just a one-time overlay - `command.hasChanges` reads `false` right after the query resolves, and only an edit the user actually makes flips it to `true`. Validation reruns only when the resolved data itself changes, not on every unrelated re-render - so a query that happens to return the same value twice does not re-trigger validation.
+
+### Per-field control
+
+Two field props refine what a query populates:
+
+| Prop | Effect |
+|---|---|
+| `noInitialValue` | Skips this field entirely, even if the query result has a same-named property. |
+| `initialValue` | Overrides how the field's value is derived from the query result - either a property accessor matched by name, or an arbitrary function that composes a value from the whole result. |
+
+```tsx
+<InputTextField<UpdateProfile>
+    value={c => c.displayName}
+    initialValue={(profile: UserProfile) => `${profile.firstName} ${profile.lastName}`}
+    title="Display name"
+/>
+```
+
 ## See Also
 
 - [CommandForm Overview](./index.md)

--- a/Documentation/frontend/react/commands/data-binding.md
+++ b/Documentation/frontend/react/commands/data-binding.md
@@ -162,7 +162,7 @@ export const ProfileEditor = () => {
 
 ## Loading Data from Queries
 
-A common pattern is loading data from a query and using it to initialize a command:
+A common pattern is loading data from a query and using it to initialize a command. If you are building the form with [CommandForm](../command-form/index.md), it can do this fetch-and-seed itself - see [Populating a Form from a Query](../command-form/data-loading.md#populating-a-form-from-a-query). The manual pattern below is what to reach for outside `CommandForm`, or when you need full control over the fetch:
 
 ```typescript
 import { GetUserProfile } from './generated/queries';

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -8,13 +8,17 @@ import { useCommand, SetCommandValues } from '../useCommand';
 import { ICommandResult } from '@cratis/arc/commands';
 import { Command } from '@cratis/arc/commands';
 import { ValidationResult } from '@cratis/arc/validation';
+import { IObservableQueryFor, IQueryFor } from '@cratis/arc/queries';
+import { deepEqual } from '@cratis/arc';
 import React, { useMemo, useState, useCallback, useImperativeHandle } from 'react';
 import type { CommandFormFieldProps } from './CommandFormField';
 import { getPropertyNameFromAccessor } from './getPropertyNameFromAccessor';
+import { extractPopulatedValues } from './extractPopulatedValues';
 import { memberMatchesField } from './memberMatchesField';
 import { runCommandValidation } from './runCommandValidation';
 import { useIdentity } from '../../identity';
 import { isCommandFormColumn, isCommandFormField, markAsCommandFormColumn } from './commandFormMarkers';
+import { usePopulateFromObservableQuery, usePopulateFromQuery } from './usePopulateFromQuery';
 import { withoutUndefinedValues } from './withoutUndefinedValues';
 
 // Re-export for backwards compatibility
@@ -47,6 +51,30 @@ export interface CommandFormProps<TCommand extends object, TResponse = object> {
      * clear the property. Only a key that is absent altogether is left alone.
      */
     currentValues?: Partial<TCommand> | undefined;
+
+    /**
+     * A single-instance query whose result seeds the form's initial values once it resolves, matched
+     * onto the command's properties by name - override per field with a {@link BaseCommandFormFieldProps.initialValue}
+     * accessor, or opt a field out entirely with {@link BaseCommandFormFieldProps.noInitialValue}.
+     *
+     * This feeds the same baseline {@link CommandFormProps.initialValues} does - via the command's
+     * change tracking - so a field an editor has not touched yet reports no change, and validation
+     * only reruns once the resolved data actually differs from what was seeded before. Optional: omit
+     * it when initial values come from {@link CommandFormProps.initialValues}/{@link CommandFormProps.currentValues}
+     * instead. Must be a single-instance (non-enumerable) query - a query returning multiple instances
+     * throws. For an observable query, use {@link CommandFormProps.populateFromObservableQuery} instead.
+     */
+    populateFromQuery?: Constructor<IQueryFor<Partial<TCommand>>>;
+
+    /** The observable-query counterpart to {@link CommandFormProps.populateFromQuery}. */
+    populateFromObservableQuery?: Constructor<IObservableQueryFor<Partial<TCommand>>>;
+
+    /**
+     * Arguments for {@link CommandFormProps.populateFromQuery}/{@link CommandFormProps.populateFromObservableQuery},
+     * when either needs them.
+     */
+    populateFromQueryArgs?: object;
+
     onFieldValidate?: (command: TCommand, fieldName: string, oldValue: unknown, newValue: unknown) => string | undefined;
     onFieldChange?: (command: TCommand, fieldName: string, oldValue: unknown, newValue: unknown, validationInfo?: FieldValidationInfo) => void;
     onBeforeExecute?: BeforeExecuteCallback<TCommand>;
@@ -199,15 +227,28 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
         return extracted;
     }, [props.currentValues, props.command]);
 
-    // Merge initialValues prop with values extracted from field currentValue props and currentValues.
-    // The two seed layers skip undefined, the reactive one does not - see CommandFormProps. A field's
-    // currentValue is skipped where it is extracted (nothing to seed), and props.initialValues here,
-    // so neither of them spreads an undefined over a value currentValues has already resolved.
+    // A single-instance query (or observable query) result, matched onto the command's properties by
+    // name per field - the query-driven counterpart to props.currentValues. Only one of the two hooks
+    // is ever actually enabled (see usePopulateFromQuery), so at most one resolves.
+    const queryPopulatedSource = usePopulateFromQuery(props.populateFromQuery, props.populateFromQueryArgs);
+    const observableQueryPopulatedSource = usePopulateFromObservableQuery(props.populateFromObservableQuery, props.populateFromQueryArgs);
+    const populatedSource = queryPopulatedSource ?? observableQueryPopulatedSource;
+    const populatedValues = useMemo(
+        () => extractPopulatedValues<TCommand>(fieldsOrColumns, populatedSource),
+        [fieldsOrColumns, populatedSource]
+    );
+
+    // Merge initialValues prop with values extracted from field currentValue props, currentValues and
+    // a populate query's result. The seed layers skip undefined, the reactive ones do not - see
+    // CommandFormProps. A field's currentValue is skipped where it is extracted (nothing to seed), and
+    // props.initialValues here, so neither of them spreads an undefined over a value currentValues or
+    // a populate query has already resolved.
     const mergedInitialValues = useMemo(() => ({
         ...valuesFromCurrentValues,
+        ...populatedValues,
         ...initialValuesFromFields,
         ...withoutUndefinedValues(props.initialValues)
-    }), [valuesFromCurrentValues, initialValuesFromFields, props.initialValues]);
+    }), [valuesFromCurrentValues, populatedValues, initialValuesFromFields, props.initialValues]);
 
     // useCommand returns [instance, setter, clearer] for the typed command. Provide generics so commandInstance is TCommand.
     // Using type assertion through unknown to work around generic constraint mismatch
@@ -275,13 +316,26 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
     }, [commandInstance, props.autoServerValidate, beginSilentValidation, applySilentValidationResult]);
 
     // Update command values when mergedInitialValues changes (e.g., when data loads asynchronously)
-    // When using currentValues, always update when they change (reactive mode for editing)
-    // When using initialValues only, set values once on mount
+    // When using currentValues or a populate query, always update when they change (reactive mode for
+    // editing). When using initialValues only, set values once on mount.
+    const previousPopulatedSourceRef = React.useRef<object | undefined>(undefined);
     React.useEffect(() => {
         const hasCurrentValues = props.currentValues !== undefined && props.currentValues !== null;
-        
-        if (hasCurrentValues) {
-            // Reactive mode: update whenever currentValues changes
+        const hasPopulatedSource = populatedSource !== undefined;
+        const populatedSourceChanged = hasPopulatedSource && !deepEqual(previousPopulatedSourceRef.current, populatedSource);
+        if (hasPopulatedSource) {
+            previousPopulatedSourceRef.current = populatedSource;
+        }
+
+        if (populatedSourceChanged) {
+            // A populate query's result becomes the new baseline, not just an overlay - change
+            // tracking then measures an editor's own edits against it, rather than against the
+            // empty state the form mounted with.
+            (commandInstance as unknown as Command).setInitialValues(populatedValues as object);
+        }
+
+        if (hasCurrentValues || hasPopulatedSource) {
+            // Reactive mode: update whenever currentValues or the populated source changes
             if (mergedInitialValues && Object.keys(mergedInitialValues).length > 0) {
                 setCommandValues(mergedInitialValues as TCommand);
             }
@@ -290,17 +344,19 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
             setCommandValues(mergedInitialValues as TCommand);
         }
 
-        // Always run silent client validation on init and after currentValues changes to determine if the form is valid.
-        // This ensures isValid reflects the real validity state from the first render,
-        // even when no error messages are shown yet.
-        // Error messages are only rendered (via commandResult) when validateOnInit is true.
+        // Always run silent client validation on init and after currentValues/populated source
+        // changes to determine if the form is valid. This ensures isValid reflects the real validity
+        // state from the first render, even when no error messages are shown yet. A populate query
+        // only re-triggers validation when its resolved data actually changed, not on every
+        // unrelated re-render. Error messages are only rendered (via commandResult) when
+        // validateOnInit is true.
         if (!initializedRef.current) {
             initializedRef.current = true;
             void validateSilently(props.validateOnInit ?? false);
-        } else if (hasCurrentValues) {
+        } else if (hasCurrentValues || populatedSourceChanged) {
             void validateSilently(props.validateOnInit ?? false);
         }
-    }, [mergedInitialValues, props.validateOnInit, props.currentValues, setCommandValues, validateSilently]);
+    }, [mergedInitialValues, populatedSource, populatedValues, props.validateOnInit, props.currentValues, commandInstance, setCommandValues, validateSilently]);
 
     // isValid is driven exclusively by silentValidationResult which is updated on mount and
     // after every field value change. commandResult only controls error message display.

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormField.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormField.tsx
@@ -13,7 +13,7 @@ import { markAsCommandFormField } from './commandFormMarkers';
  *
  *   <CommandFormField<MyCommand> value={c => c.name} />
  */
-export interface CommandFormFieldProps<TCommand = unknown> {
+export interface CommandFormFieldProps<TCommand = unknown, TSource = unknown> {
     icon?: React.ReactElement;
     /** Accessor function that selects a property on the command, e.g. c => c.name */
     value?(instance: TCommand): unknown;
@@ -27,6 +27,10 @@ export interface CommandFormFieldProps<TCommand = unknown> {
     description?: string;
     propertyDescriptor?: unknown;
     fieldName?: string;
+    /** Skips this field when a command's initial values are populated from a query or a plain source object. */
+    noInitialValue?: boolean;
+    /** Overrides how this field's initial value is derived from the population source. */
+    initialValue?(source: TSource): unknown;
 }
 
 export const CommandFormField = <TCommand = unknown,>(_props: CommandFormFieldProps<TCommand>) => {

--- a/Source/JavaScript/Arc.React/commands/CommandForm/asCommandFormField.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/asCommandFormField.tsx
@@ -27,12 +27,28 @@ export interface InjectedCommandFormFieldProps {
  *
  *   <MyField<MyCommand> value={c => c.name} />
  */
-export interface BaseCommandFormFieldProps<TCommand = unknown> {
+export interface BaseCommandFormFieldProps<TCommand = unknown, TSource = unknown> {
     icon?: React.ReactElement;
     value(instance: TCommand): unknown;
     required?: boolean;
     title?: string;
     description?: string;
+
+    /**
+     * Skips this field when a command's initial values are populated from a query or a plain source
+     * object - e.g. via {@link CommandFormProps.populateFromQuery}. Has no effect on
+     * {@link CommandFormProps.initialValues}/{@link CommandFormProps.currentValues}, which are
+     * explicit values a caller already chose to seed.
+     */
+    noInitialValue?: boolean;
+
+    /**
+     * Overrides how this field's initial value is derived from the population source. Accepts either
+     * a property accessor matched onto the source by name (mirroring {@link value}), or an arbitrary
+     * function that composes a value from the whole source object. Defaults to matching {@link value}'s
+     * own property name on the source when omitted.
+     */
+    initialValue?(source: TSource): unknown;
 }
 
 /**

--- a/Source/JavaScript/Arc.React/commands/CommandForm/extractPopulatedValues.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/extractPopulatedValues.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { ColumnInfo } from './CommandFormFields';
+import { getPropertyNameFromAccessor } from './getPropertyNameFromAccessor';
+
+/**
+ * Extracts a command's initial values from a population source (a query result, or a plain object),
+ * matching each field onto the source by the property name its accessor resolves to - unless the
+ * field opts out with `noInitialValue`, or overrides the derivation with `initialValue`.
+ * @template TCommand Type of the command the fields belong to.
+ * @param fieldsOrColumns The fields (or column groups of fields) a `CommandForm` renders.
+ * @param source The population source, or `undefined` when none has resolved yet.
+ * @returns The command's initial values derived from `source`.
+ */
+export function extractPopulatedValues<TCommand>(
+    fieldsOrColumns: React.ReactElement[] | ColumnInfo[],
+    source: object | undefined
+): Partial<TCommand> {
+    if (!source) {
+        return {};
+    }
+
+    const fields = fieldsOrColumns.length > 0 && 'fields' in fieldsOrColumns[0]
+        ? (fieldsOrColumns as ColumnInfo[]).flatMap(column => column.fields)
+        : fieldsOrColumns as React.ReactElement[];
+
+    const values: Record<string, unknown> = {};
+    for (const field of fields) {
+        const fieldProps = field.props as Record<string, unknown>;
+        if (fieldProps.noInitialValue) {
+            continue;
+        }
+
+        const propertyAccessor = fieldProps.value as ((instance: unknown) => unknown) | undefined;
+        const propertyName = propertyAccessor ? getPropertyNameFromAccessor(propertyAccessor) : '';
+        if (!propertyName) {
+            continue;
+        }
+
+        const initialValue = fieldProps.initialValue as ((source: unknown) => unknown) | undefined;
+        if (initialValue) {
+            values[propertyName] = initialValue(source);
+        } else if (Object.prototype.hasOwnProperty.call(source, propertyName)) {
+            values[propertyName] = (source as Record<string, unknown>)[propertyName];
+        }
+    }
+
+    return values as Partial<TCommand>;
+}

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_a_field_opts_out_of_population.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_a_field_opts_out_of_population.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { CommandForm, useCommandInstance } from '../CommandForm';
+import { asCommandFormField } from '../asCommandFormField';
+import { TestCommand } from './TestCommand';
+import { a_command_form_context } from './given/a_command_form_context';
+import { given } from '../../../given';
+import { FakePopulateQuery } from '../for_usePopulateFromQuery/FakePopulateQuery';
+
+const SimpleTextField = asCommandFormField<{ value: string; onChange: (value: unknown) => void; onBlur?: () => void; invalid: boolean; required: boolean; errors: string[] }>(
+    (props) => React.createElement('input', { type: 'text', value: props.value, onChange: props.onChange, 'data-testid': 'field' }),
+    { defaultValue: '', extractValue: (e: unknown) => (e as React.ChangeEvent<HTMLInputElement>).target.value }
+);
+
+describe('when a field opts out of population', given(a_command_form_context, context => {
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+    let capturedCommand: TestCommand | null = null;
+
+    beforeEach(async () => {
+        fetchHelper = createFetchHelper();
+        fetchHelper.stubFetch().resolves({
+            json: async () => ({
+                data: { name: 'Jane Austen', email: 'jane@example.com' },
+                isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false,
+                validationResults: [], exceptionMessages: [], exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+            })
+        } as Response);
+
+        const TestComponent = () => {
+            capturedCommand = useCommandInstance<TestCommand>();
+            return React.createElement('div');
+        };
+
+        render(
+            React.createElement(
+                CommandForm,
+                { command: TestCommand, populateFromQuery: FakePopulateQuery },
+                React.createElement(TestComponent),
+                React.createElement(SimpleTextField, { value: (c: TestCommand) => c.name, title: 'Name' }),
+                React.createElement(SimpleTextField, { value: (c: TestCommand) => c.email, title: 'Email', noInitialValue: true })
+            ),
+            { wrapper: context.createWrapper() }
+        );
+
+        await waitFor(() => (capturedCommand!.name === 'Jane Austen').should.be.true);
+    });
+
+    afterEach(() => fetchHelper.restore());
+
+    it('should leave the opted-out field unset', () => {
+        (capturedCommand!.email === undefined).should.be.true;
+    });
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_a_field_overrides_its_population.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_a_field_overrides_its_population.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { CommandForm, useCommandInstance } from '../CommandForm';
+import { asCommandFormField } from '../asCommandFormField';
+import { TestCommand } from './TestCommand';
+import { a_command_form_context } from './given/a_command_form_context';
+import { given } from '../../../given';
+import { FakePopulateQuery, FakePopulateQueryResult } from '../for_usePopulateFromQuery/FakePopulateQuery';
+
+const SimpleTextField = asCommandFormField<{ value: string; onChange: (value: unknown) => void; onBlur?: () => void; invalid: boolean; required: boolean; errors: string[] }>(
+    (props) => React.createElement('input', { type: 'text', value: props.value, onChange: props.onChange, 'data-testid': 'field' }),
+    { defaultValue: '', extractValue: (e: unknown) => (e as React.ChangeEvent<HTMLInputElement>).target.value }
+);
+
+describe('when a field overrides its population', given(a_command_form_context, context => {
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+    let capturedCommand: TestCommand | null = null;
+
+    beforeEach(async () => {
+        fetchHelper = createFetchHelper();
+        fetchHelper.stubFetch().resolves({
+            json: async () => ({
+                data: { name: 'Jane Austen', email: 'jane@example.com' },
+                isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false,
+                validationResults: [], exceptionMessages: [], exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+            })
+        } as Response);
+
+        const TestComponent = () => {
+            capturedCommand = useCommandInstance<TestCommand>();
+            return React.createElement('div');
+        };
+
+        render(
+            React.createElement(
+                CommandForm,
+                { command: TestCommand, populateFromQuery: FakePopulateQuery },
+                React.createElement(TestComponent),
+                React.createElement(SimpleTextField, {
+                    value: (c: TestCommand) => c.name,
+                    title: 'Name',
+                    initialValue: (source: FakePopulateQueryResult) => source.name.toUpperCase()
+                })
+            ),
+            { wrapper: context.createWrapper() }
+        );
+
+        await waitFor(() => (capturedCommand!.name === 'JANE AUSTEN').should.be.true);
+    });
+
+    afterEach(() => fetchHelper.restore());
+
+    it('should apply the composed value instead of the matched-by-name one', () => {
+        capturedCommand!.name!.should.equal('JANE AUSTEN');
+    });
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_populating_from_a_query.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_populating_from_a_query.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { CommandForm, useCommandInstance } from '../CommandForm';
+import { asCommandFormField } from '../asCommandFormField';
+import { TestCommand } from './TestCommand';
+import { a_command_form_context } from './given/a_command_form_context';
+import { given } from '../../../given';
+import { FakePopulateQuery } from '../for_usePopulateFromQuery/FakePopulateQuery';
+
+const SimpleTextField = asCommandFormField<{ value: string; onChange: (value: unknown) => void; onBlur?: () => void; invalid: boolean; required: boolean; errors: string[] }>(
+    (props) => React.createElement('input', {
+        type: 'text',
+        value: props.value,
+        onChange: props.onChange,
+        'data-testid': `field-${props.value}`
+    }),
+    { defaultValue: '', extractValue: (e: unknown) => (e as React.ChangeEvent<HTMLInputElement>).target.value }
+);
+
+describe('when populating from a query', given(a_command_form_context, context => {
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+    let capturedCommand: TestCommand | null = null;
+
+    beforeEach(async () => {
+        fetchHelper = createFetchHelper();
+        fetchHelper.stubFetch().resolves({
+            json: async () => ({
+                data: { name: 'Jane Austen', email: 'jane@example.com' },
+                isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false,
+                validationResults: [], exceptionMessages: [], exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+            })
+        } as Response);
+
+        const TestComponent = () => {
+            capturedCommand = useCommandInstance<TestCommand>();
+            return React.createElement('div');
+        };
+
+        render(
+            React.createElement(
+                CommandForm,
+                { command: TestCommand, populateFromQuery: FakePopulateQuery },
+                React.createElement(TestComponent),
+                React.createElement(SimpleTextField, { value: (c: TestCommand) => c.name, title: 'Name' }),
+                React.createElement(SimpleTextField, { value: (c: TestCommand) => c.email, title: 'Email' })
+            ),
+            { wrapper: context.createWrapper() }
+        );
+
+        await waitFor(() => (capturedCommand!.name === 'Jane Austen').should.be.true);
+    });
+
+    afterEach(() => fetchHelper.restore());
+
+    it('should populate the name field by matching property name', () => {
+        capturedCommand!.name!.should.equal('Jane Austen');
+    });
+
+    it('should populate the email field by matching property name', () => {
+        capturedCommand!.email!.should.equal('jane@example.com');
+    });
+
+    it('should not report any changes right after populating', () => {
+        (capturedCommand! as unknown as { hasChanges: boolean }).hasChanges.should.be.false;
+    });
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/FakePopulateQuery.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/FakePopulateQuery.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryFor } from '@cratis/arc/queries';
+import { ParameterDescriptor } from '@cratis/arc/reflection';
+
+export interface FakePopulateQueryResult {
+    name: string;
+    email: string;
+}
+
+export class FakePopulateQuery extends QueryFor<FakePopulateQueryResult> {
+    readonly route = '/api/fake-populate-query';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    defaultValue: FakePopulateQueryResult = {} as FakePopulateQueryResult;
+
+    constructor() {
+        super(Object, false);
+    }
+}
+
+export class FakeEnumerablePopulateQuery extends QueryFor<FakePopulateQueryResult[]> {
+    readonly route = '/api/fake-enumerable-populate-query';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    defaultValue: FakePopulateQueryResult[] = [];
+
+    constructor() {
+        super(Object, true);
+    }
+}

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/when_no_query_is_given.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/when_no_query_is_given.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import sinon from 'sinon';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { ArcContext, ArcConfiguration } from '../../../ArcContext';
+import { usePopulateFromQuery } from '../usePopulateFromQuery';
+
+describe('when no query is given', () => {
+    let fetchStub: sinon.SinonStub;
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        fetchStub = fetchHelper.stubFetch();
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(ArcContext.Provider, { value: config }, children);
+
+    it('should not fetch anything', async () => {
+        renderHook(() => usePopulateFromQuery(undefined, undefined), { wrapper });
+        await new Promise(resolve => setTimeout(resolve, 50));
+        fetchStub.called.should.be.false;
+    });
+
+    it('should return undefined', () => {
+        const { result } = renderHook(() => usePopulateFromQuery(undefined, undefined), { wrapper });
+        (result.current === undefined).should.be.true;
+    });
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/when_the_query_resolves.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/when_the_query_resolves.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { ArcContext, ArcConfiguration } from '../../../ArcContext';
+import { usePopulateFromQuery } from '../usePopulateFromQuery';
+import { FakePopulateQuery, FakePopulateQueryResult } from './FakePopulateQuery';
+
+describe('when the query resolves', () => {
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        fetchHelper.stubFetch().resolves({
+            json: async () => ({
+                data: { name: 'Jane Austen', email: 'jane@example.com' },
+                isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false,
+                validationResults: [], exceptionMessages: [], exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+            })
+        } as Response);
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(ArcContext.Provider, { value: config }, children);
+
+    it('should return the resolved data', async () => {
+        const { result } = renderHook(() => usePopulateFromQuery<FakePopulateQueryResult, FakePopulateQuery>(FakePopulateQuery), { wrapper });
+        await waitFor(() => (result.current !== undefined).should.be.true);
+        result.current!.name.should.equal('Jane Austen');
+        result.current!.email.should.equal('jane@example.com');
+    });
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/when_the_query_returns_multiple_instances.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_usePopulateFromQuery/when_the_query_returns_multiple_instances.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { ArcContext, ArcConfiguration } from '../../../ArcContext';
+import { usePopulateFromQuery } from '../usePopulateFromQuery';
+import { FakeEnumerablePopulateQuery, FakePopulateQueryResult } from './FakePopulateQuery';
+
+describe('when the query returns multiple instances', () => {
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(ArcContext.Provider, { value: config }, children);
+
+    it('should throw', () => {
+        (() => renderHook(
+            () => usePopulateFromQuery<FakePopulateQueryResult[], FakeEnumerablePopulateQuery>(FakeEnumerablePopulateQuery),
+            { wrapper })
+        ).should.throw('returns multiple instances');
+    });
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/index.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/index.ts
@@ -7,5 +7,6 @@ export * from './CommandForm';
 export * from './CommandFormContext';
 export * from './CommandFormField';
 export * from './CommandFormFields';
+export * from './usePopulateFromQuery';
 export * from './ValidationMessage';
 export * from './fields';

--- a/Source/JavaScript/Arc.React/commands/CommandForm/usePopulateFromQuery.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/usePopulateFromQuery.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IObservableQueryFor, IQueryFor, ObservableQueryFor, QueryFor } from '@cratis/arc/queries';
+import { ParameterDescriptor } from '@cratis/arc/reflection';
+import { Constructor } from '@cratis/fundamentals';
+import { useMemo } from 'react';
+import { useObservableQuery } from '../../queries/useObservableQuery';
+import { useQuery } from '../../queries/useQuery';
+import { QueryReturnsMultipleInstances } from '../../queries/QueryReturnsMultipleInstances';
+
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+class NoPopulationQuery extends QueryFor<Record<string, never>> {
+    readonly route = '';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+    defaultValue: Record<string, never> = {};
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    constructor() {
+        super(Object, false);
+    }
+}
+
+class NoPopulationObservableQuery extends ObservableQueryFor<Record<string, never>> {
+    readonly route = '';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+    readonly defaultValue: Record<string, never> = {};
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    constructor() {
+        super(Object, false);
+    }
+}
+/* eslint-enable @typescript-eslint/no-empty-object-type */
+
+function guardSingleInstance(query: Constructor<{ enumerable?: boolean }> | undefined) {
+    if (!query) {
+        return;
+    }
+
+    const probe = new query();
+    if (probe.enumerable) {
+        throw new QueryReturnsMultipleInstances(query.name);
+    }
+}
+
+/**
+ * Populates a command's initial values from a single-instance query, matched onto the command's
+ * properties by name - the same population source a {@link CommandFormProps.populateFromQuery} prop
+ * uses. The query is optional: omit it and the hook is a no-op.
+ * @template TDataType Type of data the query returns.
+ * @template TQuery Type of query to use.
+ * @template TArguments Optional: arguments for the query, if any.
+ * @param query Optional: the query type constructor. Must be a single-instance (non-enumerable) query.
+ * @param args Optional: arguments for the query, if any.
+ * @returns The query's resolved data, or `undefined` while it has not resolved yet or no query was given.
+ */
+export function usePopulateFromQuery<TDataType extends object, TQuery extends IQueryFor<TDataType>, TArguments = object>(
+    query?: Constructor<TQuery>,
+    args?: TArguments
+): TDataType | undefined {
+    useMemo(() => guardSingleInstance(query as unknown as Constructor<{ enumerable?: boolean }> | undefined), [query]);
+
+    const [result] = useQuery<TDataType, TQuery, TArguments>(
+        query ?? (NoPopulationQuery as unknown as Constructor<TQuery>),
+        args,
+        undefined,
+        query !== undefined
+    );
+
+    return query !== undefined && result.hasData ? result.data : undefined;
+}
+
+/**
+ * Populates a command's initial values from a single-instance observable query, matched onto the
+ * command's properties by name - the same population source a
+ * {@link CommandFormProps.populateFromObservableQuery} prop uses. The query is optional: omit it and
+ * the hook is a no-op.
+ * @template TDataType Type of data the query returns.
+ * @template TQuery Type of query to use.
+ * @template TArguments Optional: arguments for the query, if any.
+ * @param query Optional: the observable query type constructor. Must be a single-instance (non-enumerable) query.
+ * @param args Optional: arguments for the query, if any.
+ * @returns The query's resolved data, or `undefined` while it has not resolved yet or no query was given.
+ */
+export function usePopulateFromObservableQuery<TDataType extends object, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(
+    query?: Constructor<TQuery>,
+    args?: TArguments
+): TDataType | undefined {
+    useMemo(() => guardSingleInstance(query as unknown as Constructor<{ enumerable?: boolean }> | undefined), [query]);
+
+    const [result] = useObservableQuery<TDataType, TQuery, TArguments>(
+        query ?? (NoPopulationObservableQuery as unknown as Constructor<TQuery>),
+        args,
+        undefined,
+        query !== undefined
+    );
+
+    return query !== undefined && result.hasData ? result.data : undefined;
+}

--- a/Source/JavaScript/Arc.React/queries/QueryReturnsMultipleInstances.ts
+++ b/Source/JavaScript/Arc.React/queries/QueryReturnsMultipleInstances.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The exception that is thrown when a query used to populate a command's initial values returns
+ * multiple instances instead of a single one.
+ */
+export class QueryReturnsMultipleInstances extends Error {
+    /**
+     * Creates a new instance of {@link QueryReturnsMultipleInstances}.
+     * @param queryName The name of the query type that returns multiple instances.
+     */
+    constructor(readonly queryName: string) {
+        super(`Query '${queryName}' returns multiple instances and cannot be used to populate a command's initial values - it must be a single-instance query`);
+        this.name = 'QueryReturnsMultipleInstances';
+        Object.setPrototypeOf(this, QueryReturnsMultipleInstances.prototype);
+    }
+}

--- a/Source/JavaScript/Arc.React/queries/index.ts
+++ b/Source/JavaScript/Arc.React/queries/index.ts
@@ -7,6 +7,7 @@ export * from './QueryBoundary';
 export * from './QueryErrorBoundary';
 export * from './QueryFailed';
 export * from './QueryInstanceCacheContext';
+export * from './QueryReturnsMultipleInstances';
 export * from './QueryScope';
 export * from './QueryScopeImplementation';
 export * from './QueryUnauthorized';


### PR DESCRIPTION
## Added

- `CommandForm` accepts `populateFromQuery`/`populateFromObservableQuery` (plus shared `populateFromQueryArgs`) to seed its initial values from a single-instance query's result, matched onto the command's properties by name.
- `usePopulateFromQuery`/`usePopulateFromObservableQuery` - the underlying hooks, usable directly outside `CommandForm`.
- Two new field props (available on every field type, since they flow through `asCommandFormField`): `noInitialValue` skips a field entirely; `initialValue` overrides how a field's value is derived from the population source - either a property accessor matched by name, or a function composing a value from the whole source.
- A query that turns out to return multiple instances throws `QueryReturnsMultipleInstances` - a form's initial values only ever come from one instance.
- The resolved data becomes the form's baseline through the command's own change tracking, not just a value overlay - `hasChanges` reads `false` right after population, and validation only reruns when the resolved data itself changes.
- New "Populating a Form from a Query" documentation section, cross-linked from the existing manual fetch-and-seed pattern.

(#2549)

## Notes for reviewers

The issue asks for a single mechanism supporting both regular and observable queries. React's Rules of Hooks make one unified prop that auto-detects regular-vs-observable at runtime genuinely hard, without resorting to a synthetic fallback query class that carries its own risk. This PR exposes two explicit props instead (`populateFromQuery` / `populateFromObservableQuery`) - the caller picks whichever matches their query's actual type at the type level, with no runtime branching required.