### PR TITLE
Fix useObservableQuery dependency arrays masking argument changes

### DIFF
--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeObservableQueryWithOptionalArguments.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeObservableQueryWithOptionalArguments.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ObservableQueryFor, QueryResult, ObservableQuerySubscription, OnNextResult } from '@cratis/arc/queries';
+import { ParameterDescriptor } from '@cratis/arc/reflection';
+
+export interface FakeObservableQueryWithOptionalArgumentsResult {
+    id: string;
+    name: string;
+}
+
+export interface FakeObservableQueryWithOptionalArgumentsArguments {
+    topicId?: string;
+}
+
+export type SubscribeCallback = OnNextResult<QueryResult<FakeObservableQueryWithOptionalArgumentsResult[]>>;
+
+export class FakeObservableQueryWithOptionalArguments extends ObservableQueryFor<FakeObservableQueryWithOptionalArgumentsResult[]> {
+    readonly route = '/api/fake-observable-query-with-optional-arguments';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    static subscribedArgs: (object | undefined)[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    defaultValue: FakeObservableQueryWithOptionalArgumentsResult[] = [];
+
+    constructor() {
+        super(Object, true);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    subscribe(callback: SubscribeCallback, args?: object): ObservableQuerySubscription<FakeObservableQueryWithOptionalArgumentsResult[]> {
+        FakeObservableQueryWithOptionalArguments.subscribedArgs.push(args);
+        return {
+            unsubscribe: () => { }
+        } as ObservableQuerySubscription<FakeObservableQueryWithOptionalArgumentsResult[]>;
+    }
+
+    static reset() {
+        FakeObservableQueryWithOptionalArguments.subscribedArgs = [];
+    }
+}

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_arguments_change_key_count_across_renders.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_arguments_change_key_count_across_renders.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { useObservableQuery } from '../useObservableQuery';
+import {
+    FakeObservableQueryWithOptionalArguments,
+    FakeObservableQueryWithOptionalArgumentsArguments
+} from './FakeObservableQueryWithOptionalArguments';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { QueryInstanceCache } from '@cratis/arc/queries';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+type Props = { args?: FakeObservableQueryWithOptionalArgumentsArguments };
+
+describe('when arguments change key count across renders', () => {
+    let cache: QueryInstanceCache;
+
+    beforeEach(() => {
+        FakeObservableQueryWithOptionalArguments.reset();
+        cache = new QueryInstanceCache();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        React.createElement(
+            QueryInstanceCacheContext.Provider,
+            { value: cache },
+            React.createElement(ArcContext.Provider, { value: config }, children)
+        )
+    );
+
+    it('should establish a new subscription when arguments go from undefined to an object', async () => {
+        const { rerender } = renderHook(
+            ({ args }: Props) => useObservableQuery(FakeObservableQueryWithOptionalArguments, args),
+            {
+                wrapper,
+                initialProps: { args: undefined } as Props
+            }
+        );
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        FakeObservableQueryWithOptionalArguments.subscribedArgs.should.have.lengthOf(1);
+
+        rerender({ args: { topicId: 'A' } });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        FakeObservableQueryWithOptionalArguments.subscribedArgs.should.have.lengthOf(2);
+        FakeObservableQueryWithOptionalArguments.subscribedArgs[1]!.should.deep.equal({ topicId: 'A' });
+    });
+
+    it('should keep establishing new subscriptions across further key-count round trips', async () => {
+        const { rerender } = renderHook(
+            ({ args }: Props) => useObservableQuery(FakeObservableQueryWithOptionalArguments, args),
+            {
+                wrapper,
+                initialProps: { args: { topicId: 'A' } } as Props
+            }
+        );
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        rerender({ args: { topicId: 'B' } });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        rerender({ args: undefined });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        rerender({ args: { topicId: 'C' } });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        FakeObservableQueryWithOptionalArguments.subscribedArgs.should.have.lengthOf(4);
+        FakeObservableQueryWithOptionalArguments.subscribedArgs[3]!.should.deep.equal({ topicId: 'C' });
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
@@ -121,6 +121,34 @@ function deserializeResponseData<TDataType>(data: unknown, modelType: Constructo
     return deserializeItems(modelType, data) as TDataType;
 }
 
+/**
+ * Derives a stable, constant-shape dependency value from query arguments for use in a React
+ * dependency array.
+ *
+ * Spreading `Object.values(args)` positionally makes the dependency array's length track the
+ * argument object's key count. React's `areHookInputsEqual` only compares the overlapping prefix
+ * when a dependency array's length changes between renders, so a render where `args` goes from
+ * `undefined` to `{ key: value }` (or vice versa) can have its memo/effect report "no change" even
+ * though the arguments did change. Collapsing `args` into one sorted, serialized string keeps the
+ * dependency array a constant length regardless of `args`' shape.
+ * @param {object} [args] The query arguments to serialize.
+ * @returns {string} A stable string dependency, empty when there are no arguments.
+ */
+function serializeArgsForDependency(args?: object): string {
+    if (!args || Object.keys(args).length === 0) {
+        return '';
+    }
+
+    const sorted = Object.keys(args)
+        .sort()
+        .reduce<Record<string, unknown>>((accumulator, key) => {
+            accumulator[key] = (args as Record<string, unknown>)[key];
+            return accumulator;
+        }, {});
+
+    return JSON.stringify(sorted);
+}
+
 function hasAllRequiredArguments(requiredRequestParameters: string[], args?: object): boolean {
     if (requiredRequestParameters.length === 0) {
         return true;
@@ -145,6 +173,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
     const cacheKeyRef = useRef<string>('');
     const ownerRef = useRef<string | undefined>(owner);
     ownerRef.current = owner;
+    const argsDependency = serializeArgsForDependency(args as object | undefined);
 
     const queryInstance = useMemo(() => {
         // Create the instance first to read queryName, which is a hardcoded fully-qualified
@@ -170,7 +199,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
         }
 
         return instance as TQuery;
-    }, [currentPaging, currentSorting, arc.microservice, arc.apiBasePath, arc.origin, ...(args ? Object.values(args) : [])]);
+    }, [currentPaging, currentSorting, arc.microservice, arc.apiBasePath, arc.origin, argsDependency]);
 
     const cachedResult = queryCache.getLastResult<TDataType>(cacheKeyRef.current);
 
@@ -191,7 +220,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
     // when the microservice, API base path, or origin changes.
     // Include queryVersion so that reconnectQueries() forces all hooks to re-subscribe
     // through fresh transport connections.
-    const effectDeps = [...(args ? Object.values(args) : []), currentPaging, currentSorting, isEnabled, hasAllRequiredArgumentsSet, arc.microservice, arc.apiBasePath, arc.origin, arc.queryVersion];
+    const effectDeps = [argsDependency, currentPaging, currentSorting, isEnabled, hasAllRequiredArgumentsSet, arc.microservice, arc.apiBasePath, arc.origin, arc.queryVersion];
 
     useEffect(() => {
         const key = cacheKeyRef.current;


### PR DESCRIPTION
# Summary
`useObservableQuery`/`useObservableQueryWithPaging` could silently keep observing a stale query subscription instead of switching when a call site's `args` changed shape between renders (e.g. `undefined` ↔ `{ someKey: value }`), because React only compares the overlapping prefix of a `useMemo`/`useEffect` dependency array when its length changes between renders.

## Fixed
- `useObservableQuery` and `useObservableQueryWithPaging` now always establish a fresh subscription when a query's arguments change, even when the argument object's key count changes between renders (e.g. going from no arguments to an object, or back) (#2551)