### PR TITLE
Add decorator-free proxy metadata registration

### DIFF
--- a/Documentation/backend/proxy-generation/Configuration/basic.md
+++ b/Documentation/backend/proxy-generation/Configuration/basic.md
@@ -68,8 +68,42 @@ AccountCommands/
 
 > **Note:** This feature requires PDB debug symbols alongside the compiled assembly. Without PDB information the generator falls back to one file per type.
 
+Generate proxies during development with a Debug build (`dotnet build -c Debug`), then commit the generated TypeScript. Release and publish builds can consume those committed proxies without regenerating them. This is a recommended workflow rather than a Release restriction: the generator still runs in Release whenever `CratisProxiesOutputPath` is configured.
+
 ### CLI
 
 ```bash
 proxygenerator assembly.dll output-path --use-source-file-as-output-file
+```
+
+## Metadata Registration
+
+For web projects, keep the default output: generated types use `@field(...)` property decorators and `@derivedType(...)` class decorators. This keeps the serialization metadata beside the type and property it describes.
+
+If your frontend toolchain does not support the legacy decorator transforms, opt into explicit metadata registration:
+
+```xml
+<PropertyGroup>
+    <CratisProxiesUseExplicitMetadataRegistration>true</CratisProxiesUseExplicitMetadataRegistration>
+</PropertyGroup>
+```
+
+The generated class properties no longer carry decorators. Instead, the generator emits ordinary registration calls after the class declaration:
+
+```typescript
+import { field } from '@cratis/fundamentals';
+
+export class Location {
+    longitude!: number;
+}
+
+field(Number)(Location.prototype, 'longitude');
+```
+
+Derived types use the equivalent `derivedType(...)(Type)` call. The metadata remains the same, but the generated file no longer requires legacy decorator transforms. This mode is useful for React Native and Expo applications running on Hermes, where those transforms may be unavailable or order-sensitive.
+
+When invoking the proxy generator CLI directly, add the corresponding flag:
+
+```bash
+proxygenerator assembly.dll output-path --use-explicit-metadata-registration
 ```

--- a/Documentation/backend/proxy-generation/Configuration/index.md
+++ b/Documentation/backend/proxy-generation/Configuration/index.md
@@ -2,7 +2,7 @@
 
 The proxy generator is configured through MSBuild properties and item groups in your `.csproj` file. Configuration is split into the following topics:
 
-- [Basic Options](basic.md) — output path, segments to skip, source file output
+- [Basic Options](basic.md) — output path, segments to skip, source file output, metadata registration
 - [Library Mode](library-mode.md) — generate TypeScript for every public type in the assembly
 - [Type Exclusions](type-exclusions.md) — exclude specific types or namespaces from generation
 - [Namespace Roots](namespace-roots.md) — pin a namespace as the folder root
@@ -17,6 +17,7 @@ The proxy generator is configured through MSBuild properties and item groups in 
 | `CratisProxiesOutputPath` | *(required)* | [Basic](basic.md) |
 | `CratisProxiesSegmentsToSkip` | `0` | [Basic](basic.md) |
 | `CratisProxiesUseSourceFileAsOutputFile` | `false` | [Basic](basic.md) |
+| `CratisProxiesUseExplicitMetadataRegistration` | `false` | [Basic](basic.md) |
 | `CratisProxiesLibraryMode` | `false` | [Library Mode](library-mode.md) |
 | `<ExcludeType TypeName="..."/>` | — | [Type Exclusions](type-exclusions.md) |
 | `<ExcludeNamespace Namespace="..."/>` | — | [Type Exclusions](type-exclusions.md) |

--- a/Documentation/backend/proxy-generation/type-mapping.md
+++ b/Documentation/backend/proxy-generation/type-mapping.md
@@ -4,7 +4,7 @@ The proxy generator translates the .NET types on your commands, queries and read
 
 ## Primitive and common types
 
-| .NET type | TypeScript type | `@field` constructor | Imported from |
+| .NET type | TypeScript type | Metadata constructor | Imported from |
 |---|---|---|---|
 | `bool` | `boolean` | `Boolean` | — |
 | `string`, `char`, `Uri` | `string` | `String` | — |
@@ -16,6 +16,8 @@ The proxy generator translates the .NET types on your commands, queries and read
 | `TimeSpan` | `TimeSpan` | `TimeSpan` | `@cratis/fundamentals` |
 | `Cratis.Geospatial.Point`, `LineString`, `Polygon` | same name | same name | `@cratis/fundamentals` |
 | `object`, `JsonNode`, `JsonObject`, `JsonArray`, `JsonDocument` | `Record<string, unknown>` | `Object` | — |
+
+The metadata constructor is passed to the default `@field(...)` decorator or, when explicit metadata registration is enabled, to the equivalent `field(...)(...)` call. Both output modes use the same type mapping.
 
 An enum becomes a TypeScript `enum` and travels as its underlying number. A `ConceptAs<T>` is unwrapped to `T` and mapped by this same table. A `Nullable<T>` is unwrapped to `T` and the generated property is declared optional.
 

--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.props
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.props
@@ -9,5 +9,6 @@
         <CratisProxiesSkipQueryNameInRoute>false</CratisProxiesSkipQueryNameInRoute>
         <CratisProxiesApiPrefix>api</CratisProxiesApiPrefix>
         <CratisProxiesSkipFileIndexTracking>false</CratisProxiesSkipFileIndexTracking>
+        <CratisProxiesUseExplicitMetadataRegistration Condition="'$(CratisProxiesUseExplicitMetadataRegistration)' == ''">false</CratisProxiesUseExplicitMetadataRegistration>
     </PropertyGroup>
 </Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
@@ -33,6 +33,7 @@
             <SkipFileIndexTracking Condition=" '$(CratisProxiesSkipFileIndexTracking)' == 'true' ">--skip-file-index-tracking</SkipFileIndexTracking>
             <SkipIndexGeneration Condition=" '$(CratisProxiesSkipIndexGeneration)' == 'true' ">--skip-index-generation</SkipIndexGeneration>
             <UseSourceFileAsOutputFile Condition=" '$(CratisProxiesUseSourceFileAsOutputFile)' == 'true' ">--use-source-file-as-output-file</UseSourceFileAsOutputFile>
+            <UseExplicitMetadataRegistration Condition=" '$(CratisProxiesUseExplicitMetadataRegistration)' == 'true' ">--use-explicit-metadata-registration</UseExplicitMetadataRegistration>
             <AssemblyPackageMappings>@(AssemblyToPackageMapping -> '--assembly-to-package=%(Assembly)=%(Package)', ' ')</AssemblyPackageMappings>
             <ExcludeTypes>@(ExcludeType -> '--exclude-type=%(TypeName)', ' ')</ExcludeTypes>
             <ExcludeNamespaces>@(ExcludeNamespace -> '--exclude-namespace=%(Namespace)', ' ')</ExcludeNamespaces>
@@ -46,7 +47,7 @@
         </PropertyGroup>
 
         <Exec ConsoleToMsBuild="true"
-            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(LibraryMode) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile) $(AssemblyPackageMappings) $(ExcludeTypes) $(ExcludeNamespaces) $(NamespaceRoots) $(TypeMappings)"
+            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(LibraryMode) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile) $(UseExplicitMetadataRegistration) $(AssemblyPackageMappings) $(ExcludeTypes) $(ExcludeNamespaces) $(NamespaceRoots) $(TypeMappings)"
             WorkingDirectory="$(CratisProxyGeneratorAssemblyDirectory)" />
     </Target>
 </Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
@@ -47,11 +47,15 @@ public sealed class JavaScriptRuntime : IDisposable
     /// Transpiles TypeScript code to JavaScript.
     /// </summary>
     /// <param name="typeScriptCode">The TypeScript code to transpile.</param>
+    /// <param name="experimentalDecorators">Whether the legacy TypeScript decorator transform is enabled.</param>
     /// <returns>The transpiled JavaScript code.</returns>
-    public string TranspileTypeScript(string typeScriptCode)
+    public string TranspileTypeScript(string typeScriptCode, bool experimentalDecorators = true)
     {
         var escapedCode = EscapeForTemplateLiteral(typeScriptCode);
-        var result = Evaluate($"ts.transpile(`{escapedCode}`, {{ target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS, experimentalDecorators: true, emitDecoratorMetadata: true }})");
+        var decoratorOptions = experimentalDecorators
+            ? "experimentalDecorators: true, emitDecoratorMetadata: true"
+            : "experimentalDecorators: false";
+        var result = Evaluate($"ts.transpile(`{escapedCode}`, {{ target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS, {decoratorOptions} }})");
         return result?.ToString() ?? string.Empty;
     }
 
@@ -59,16 +63,20 @@ public sealed class JavaScriptRuntime : IDisposable
     /// Gets the syntactic diagnostics the TypeScript compiler reports for a piece of code.
     /// </summary>
     /// <param name="typeScriptCode">The TypeScript code to check.</param>
+    /// <param name="experimentalDecorators">Whether the legacy TypeScript decorator transform is enabled.</param>
     /// <returns>The diagnostic messages; empty when the code parses cleanly.</returns>
     /// <remarks>
     /// <see cref="TranspileTypeScript"/> emits best-effort output even for code that does not parse, so a non-empty
     /// transpilation proves nothing. This surfaces what the compiler actually objects to, so a spec can assert on an
     /// empty collection and show the offending messages when it fails.
     /// </remarks>
-    public IReadOnlyList<string> GetSyntacticDiagnostics(string typeScriptCode)
+    public IReadOnlyList<string> GetSyntacticDiagnostics(string typeScriptCode, bool experimentalDecorators = true)
     {
         var escapedCode = EscapeForTemplateLiteral(typeScriptCode);
-        var result = Evaluate($"JSON.stringify((ts.transpileModule(`{escapedCode}`, {{ compilerOptions: {{ target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS, experimentalDecorators: true, emitDecoratorMetadata: true }}, reportDiagnostics: true }}).diagnostics || []).map(diagnostic => ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')))");
+        var decoratorOptions = experimentalDecorators
+            ? "experimentalDecorators: true, emitDecoratorMetadata: true"
+            : "experimentalDecorators: false";
+        var result = Evaluate($"JSON.stringify((ts.transpileModule(`{escapedCode}`, {{ compilerOptions: {{ target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS, {decoratorOptions} }}, reportDiagnostics: true }}).diagnostics || []).map(diagnostic => ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')))");
         return JsonSerializer.Deserialize<string[]>(result?.ToString() ?? "[]") ?? [];
     }
 

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/DerivedTypeAttribute.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/DerivedTypeAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Serialization;
+
+/// <summary>
+/// Marks a generated-proxy fixture type as a derived type without adding product dependencies to the fixture assembly.
+/// </summary>
+/// <param name="identifier">The derived type identifier.</param>
+[AttributeUsage(AttributeTargets.Class)]
+sealed class DerivedTypeAttribute(string identifier) : Attribute
+{
+    /// <summary>
+    /// Gets the derived type identifier.
+    /// </summary>
+    public string Identifier { get; } = identifier;
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/GeneratedMetadataCircle.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/GeneratedMetadataCircle.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+
+namespace Cratis.Arc.ProxyGenerator.Specs.SourceFileResolverFixture;
+
+/// <summary>
+/// A generated-proxy fixture circle.
+/// </summary>
+[DerivedType("9b8f7ef8-b16d-4e2c-bec9-20930f04f687")]
+public class GeneratedMetadataCircle : IGeneratedMetadataShape
+{
+    /// <inheritdoc/>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the radius.
+    /// </summary>
+    public int Radius { get; set; }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/GeneratedMetadataDrawing.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/GeneratedMetadataDrawing.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Specs.SourceFileResolverFixture;
+
+/// <summary>
+/// A drawing whose generated proxy requires enumerable interface metadata.
+/// </summary>
+public class GeneratedMetadataDrawing
+{
+    /// <summary>
+    /// Gets or sets the shapes in the drawing.
+    /// </summary>
+    public IEnumerable<IGeneratedMetadataShape> Shapes { get; set; } = [];
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/GeneratedMetadataRectangle.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/GeneratedMetadataRectangle.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+
+namespace Cratis.Arc.ProxyGenerator.Specs.SourceFileResolverFixture;
+
+/// <summary>
+/// A generated-proxy fixture rectangle.
+/// </summary>
+[DerivedType("60c89a76-2848-4513-8cf1-d89ee32f1953")]
+public class GeneratedMetadataRectangle : IGeneratedMetadataShape
+{
+    /// <inheritdoc/>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the width.
+    /// </summary>
+    public int Width { get; set; }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/IGeneratedMetadataShape.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/TestArtifacts/SourceFileResolverFixture/IGeneratedMetadataShape.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Specs.SourceFileResolverFixture;
+
+/// <summary>
+/// A shape contract used to verify explicit derivative metadata.
+/// </summary>
+public interface IGeneratedMetadataShape
+{
+    /// <summary>
+    /// Gets or sets the shape name.
+    /// </summary>
+    string Name { get; set; }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_Generator/when_generating_with_explicit_metadata_registration_from_the_command_line.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_Generator/when_generating_with_explicit_metadata_registration_from_the_command_line.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Specs.SourceFileResolverFixture;
+
+namespace Cratis.Arc.ProxyGenerator.for_Generator;
+
+public class when_generating_with_explicit_metadata_registration_from_the_command_line : Specification, IDisposable
+{
+    const string CircleIdentifier = "9b8f7ef8-b16d-4e2c-bec9-20930f04f687";
+    const string RectangleIdentifier = "60c89a76-2848-4513-8cf1-d89ee32f1953";
+
+    JavaScriptRuntime _runtime = null!;
+    string _outputPath = null!;
+    string _generatedDrawing = string.Empty;
+    string _registeredFieldName = string.Empty;
+    string _registeredDerivativeNames = string.Empty;
+    string _deserializedShapeNames = string.Empty;
+    string _deserializedShapeValues = string.Empty;
+    int _exitCode = -1;
+    bool _registeredFieldIsEnumerable;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+        _outputPath = Path.Combine(Path.GetTempPath(), $"arc-explicit-metadata-{Guid.NewGuid():N}");
+    }
+
+    async Task Because()
+    {
+        var generatorAssembly = typeof(Generator).Assembly.Location;
+        var specificationsAssembly = typeof(GeneratedMetadataDrawing).Assembly.Location;
+        var typesToGenerate = new HashSet<Type>
+        {
+            typeof(GeneratedMetadataDrawing),
+            typeof(IGeneratedMetadataShape),
+            typeof(GeneratedMetadataCircle),
+            typeof(GeneratedMetadataRectangle)
+        };
+        var excludedTypeNames = typeof(GeneratedMetadataDrawing).Assembly.GetTypes()
+            .Where(type => !typesToGenerate.Contains(type) && type.FullName is not null)
+            .Select(type => type.FullName!)
+            .Order(StringComparer.Ordinal);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(generatorAssembly);
+        startInfo.ArgumentList.Add(specificationsAssembly);
+        startInfo.ArgumentList.Add(_outputPath);
+        startInfo.ArgumentList.Add("0");
+        startInfo.ArgumentList.Add("--library-mode");
+        startInfo.ArgumentList.Add("--skip-index-generation");
+        startInfo.ArgumentList.Add("--use-explicit-metadata-registration");
+        foreach (var typeName in excludedTypeNames)
+        {
+            startInfo.ArgumentList.Add($"--exclude-type={typeName}");
+        }
+
+        using var process = Process.Start(startInfo)!;
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        await Task.WhenAll(standardOutput, standardError);
+        _exitCode = process.ExitCode;
+        if (_exitCode != 0)
+        {
+            return;
+        }
+
+        var drawing = ReadGeneratedType(nameof(GeneratedMetadataDrawing));
+        var shape = ReadGeneratedType(nameof(IGeneratedMetadataShape));
+        var circle = ReadGeneratedType(nameof(GeneratedMetadataCircle));
+        var rectangle = ReadGeneratedType(nameof(GeneratedMetadataRectangle));
+        _generatedDrawing = drawing;
+
+        var combined = TypeScriptContentCombiner.Combine([drawing, shape, circle, rectangle]);
+        var javaScript = _runtime.TranspileTypeScript(combined, experimentalDecorators: false);
+        _runtime.Execute(javaScript);
+        _runtime.Execute(
+            $"globalThis.{nameof(GeneratedMetadataDrawing)} = exports.{nameof(GeneratedMetadataDrawing)};" +
+            $"globalThis.{nameof(GeneratedMetadataCircle)} = exports.{nameof(GeneratedMetadataCircle)};" +
+            $"globalThis.{nameof(GeneratedMetadataRectangle)} = exports.{nameof(GeneratedMetadataRectangle)};");
+
+        _registeredFieldName = _runtime.Evaluate<string>(
+            $"Fields.getFieldsForType(globalThis.{nameof(GeneratedMetadataDrawing)})[0].name")!;
+        _registeredFieldIsEnumerable = _runtime.Evaluate<bool>(
+            $"Fields.getFieldsForType(globalThis.{nameof(GeneratedMetadataDrawing)})[0].enumerable");
+        _registeredDerivativeNames = _runtime.Evaluate<string>(
+            $"Fields.getFieldsForType(globalThis.{nameof(GeneratedMetadataDrawing)})[0].derivatives.map(type => type.name).join(',')")!;
+
+        _runtime.Execute(
+            $"globalThis.__generatedMetadataDrawing = JsonSerializer.deserializeFromInstance(globalThis.{nameof(GeneratedMetadataDrawing)}, {{" +
+            $"shapes: [{{ _derivedTypeId: '{CircleIdentifier}', name: 'Circle', radius: 3 }}, " +
+            $"{{ _derivedTypeId: '{RectangleIdentifier}', name: 'Rectangle', width: 4 }}] }});");
+        _deserializedShapeNames = _runtime.Evaluate<string>(
+            "globalThis.__generatedMetadataDrawing.shapes.map(shape => shape.constructor.name).join(',')")!;
+        _deserializedShapeValues = _runtime.Evaluate<string>(
+            "`${globalThis.__generatedMetadataDrawing.shapes[0].name}:${globalThis.__generatedMetadataDrawing.shapes[0].radius}," +
+            "${globalThis.__generatedMetadataDrawing.shapes[1].name}:${globalThis.__generatedMetadataDrawing.shapes[1].width}`")!;
+    }
+
+    [Fact] void should_run_the_generator_successfully() => _exitCode.ShouldEqual(0);
+    [Fact] void should_emit_imperative_metadata_registration() => _generatedDrawing.ShouldContain($"field({nameof(IGeneratedMetadataShape)}, true, [{nameof(GeneratedMetadataCircle)}, {nameof(GeneratedMetadataRectangle)}])");
+    [Fact] void should_not_emit_decorator_syntax() => _generatedDrawing.ShouldNotContain("@field(");
+    [Fact] void should_register_the_collection_field() => _registeredFieldName.ShouldEqual("shapes");
+    [Fact] void should_register_the_field_as_enumerable() => _registeredFieldIsEnumerable.ShouldBeTrue();
+    [Fact] void should_register_the_interface_derivatives() => _registeredDerivativeNames.ShouldEqual($"{nameof(GeneratedMetadataCircle)},{nameof(GeneratedMetadataRectangle)}");
+    [Fact] void should_deserialize_each_collection_item_to_its_derived_type() => _deserializedShapeNames.ShouldEqual($"{nameof(GeneratedMetadataCircle)},{nameof(GeneratedMetadataRectangle)}");
+    [Fact] void should_deserialize_the_derived_type_fields() => _deserializedShapeValues.ShouldEqual("Circle:3,Rectangle:4");
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        if (Directory.Exists(_outputPath))
+        {
+            Directory.Delete(_outputPath, true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    string ReadGeneratedType(string typeName)
+    {
+        var path = Directory.GetFiles(_outputPath, $"{typeName}.ts", SearchOption.AllDirectories).Single();
+        var content = File.ReadAllText(path);
+        var metadataLineEnd = content.IndexOf('\n');
+        return metadataLineEnd < 0 ? content : content[(metadataLineEnd + 1)..];
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TemplateTypes/when_generating_type/with_explicit_metadata_registration.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TemplateTypes/when_generating_type/with_explicit_metadata_registration.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_TemplateTypes.when_generating_type;
+
+public class with_explicit_metadata_registration : Specification, IDisposable
+{
+    JavaScriptRuntime _runtime = null!;
+    TypeDescriptor _descriptor = null!;
+    string _result = null!;
+    string _transpiledResult = null!;
+    IReadOnlyList<string> _diagnostics = null!;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        PropertyDescriptor[] properties =
+        [
+            new(typeof(string), "Name", "string", "String", string.Empty, false, false, true, null),
+            new(typeof(int[]), "Scores", "number", "Number", string.Empty, true, false, true, null),
+            new(typeof(ExplicitRegistrationStatus), "Status", "ExplicitRegistrationStatus", "Number", string.Empty, false, false, false, null),
+            new(typeof(DateTime), "OccurredAt", "Date", "Date", string.Empty, false, false, true, null),
+            new(typeof(ExplicitRegistrationNestedType), "Nested", "ExplicitRegistrationNestedType", "ExplicitRegistrationNestedType", string.Empty, false, false, false, null),
+            new(typeof(ExplicitRegistrationNestedType[]), "NestedItems", "ExplicitRegistrationNestedType", "ExplicitRegistrationNestedType", string.Empty, true, false, false, null),
+            new(typeof(IExplicitRegistrationShape), "Shape", "IExplicitRegistrationShape", "IExplicitRegistrationShape", string.Empty, false, false, false, null, "ExplicitRegistrationCircle, ExplicitRegistrationRectangle"),
+            new(typeof(IExplicitRegistrationShape[]), "Shapes", "IExplicitRegistrationShape", "IExplicitRegistrationShape", string.Empty, true, false, false, null, "ExplicitRegistrationCircle, ExplicitRegistrationRectangle")
+        ];
+
+        ImportStatement[] imports =
+        [
+            new(typeof(ExplicitRegistrationStatus), nameof(ExplicitRegistrationStatus), $"./{nameof(ExplicitRegistrationStatus)}"),
+            new(typeof(ExplicitRegistrationNestedType), nameof(ExplicitRegistrationNestedType), $"./{nameof(ExplicitRegistrationNestedType)}"),
+            new(typeof(IExplicitRegistrationShape), nameof(IExplicitRegistrationShape), $"./{nameof(IExplicitRegistrationShape)}"),
+            new(typeof(ExplicitRegistrationCircle), nameof(ExplicitRegistrationCircle), $"./{nameof(ExplicitRegistrationCircle)}"),
+            new(typeof(ExplicitRegistrationRectangle), nameof(ExplicitRegistrationRectangle), $"./{nameof(ExplicitRegistrationRectangle)}")
+        ];
+
+        _descriptor = new TypeDescriptor(
+            typeof(TypeWithExplicitMetadataRegistration),
+            "TypeWithExplicitMetadataRegistration",
+            properties,
+            imports.OrderBy(_ => _.Module),
+            [],
+            UseExplicitMetadataRegistration: true);
+    }
+
+    void Because()
+    {
+        _result = TemplateTypes.Type(_descriptor);
+        _transpiledResult = _runtime.TranspileTypeScript(_result, experimentalDecorators: false);
+        _diagnostics = _runtime.GetSyntacticDiagnostics(_result, experimentalDecorators: false);
+    }
+
+    [Fact] void should_import_the_field_factory() => _result.ShouldContain("import { field } from '@cratis/fundamentals';");
+    [Fact] void should_not_emit_field_decorator_syntax() => _result.ShouldNotContain("@field(");
+    [Fact] void should_not_emit_derived_type_decorator_syntax() => _result.ShouldNotContain("@derivedType(");
+    [Fact] void should_declare_the_primitive_property() => _result.ShouldContain("name!: string;");
+    [Fact] void should_register_the_primitive_field() => _result.ShouldContain("field(String)(TypeWithExplicitMetadataRegistration.prototype, 'name');");
+    [Fact] void should_declare_the_collection_as_an_array() => _result.ShouldContain("scores!: number[];");
+    [Fact] void should_register_the_collection_as_enumerable() => _result.ShouldContain("field(Number, true)(TypeWithExplicitMetadataRegistration.prototype, 'scores');");
+    [Fact] void should_declare_the_enum_property() => _result.ShouldContain("status!: ExplicitRegistrationStatus;");
+    [Fact] void should_register_the_enum_with_its_numeric_constructor() => _result.ShouldContain("field(Number)(TypeWithExplicitMetadataRegistration.prototype, 'status');");
+    [Fact] void should_declare_the_date_property() => _result.ShouldContain("occurredAt!: Date;");
+    [Fact] void should_register_the_date_field() => _result.ShouldContain("field(Date)(TypeWithExplicitMetadataRegistration.prototype, 'occurredAt');");
+    [Fact] void should_declare_the_typed_property() => _result.ShouldContain("nested!: ExplicitRegistrationNestedType;");
+    [Fact] void should_register_the_typed_field() => _result.ShouldContain("field(ExplicitRegistrationNestedType)(TypeWithExplicitMetadataRegistration.prototype, 'nested');");
+    [Fact] void should_declare_the_typed_collection_as_an_array() => _result.ShouldContain("nestedItems!: ExplicitRegistrationNestedType[];");
+    [Fact] void should_register_the_typed_collection_as_enumerable() => _result.ShouldContain("field(ExplicitRegistrationNestedType, true)(TypeWithExplicitMetadataRegistration.prototype, 'nestedItems');");
+    [Fact] void should_register_the_interface_field_with_its_derivatives() => _result.ShouldContain("field(IExplicitRegistrationShape, false, [ExplicitRegistrationCircle, ExplicitRegistrationRectangle])(TypeWithExplicitMetadataRegistration.prototype, 'shape');");
+    [Fact] void should_register_the_interface_collection_with_its_derivatives() => _result.ShouldContain("field(IExplicitRegistrationShape, true, [ExplicitRegistrationCircle, ExplicitRegistrationRectangle])(TypeWithExplicitMetadataRegistration.prototype, 'shapes');");
+    [Fact] void should_import_the_typed_field() => _result.ShouldContain($"import {{ {nameof(ExplicitRegistrationNestedType)} }} from './{nameof(ExplicitRegistrationNestedType)}';");
+    [Fact] void should_import_the_interface_derivatives() => _result.ShouldContain($"import {{ {nameof(ExplicitRegistrationCircle)} }} from './{nameof(ExplicitRegistrationCircle)}';");
+    [Fact] void should_transpile_with_experimental_decorators_disabled() => _transpiledResult.ShouldNotBeEmpty();
+    [Fact] void should_produce_no_typescript_diagnostics_with_experimental_decorators_disabled() => _diagnostics.ShouldBeEmpty();
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}
+
+public class TypeWithExplicitMetadataRegistration;
+
+public class ExplicitRegistrationNestedType;
+
+public interface IExplicitRegistrationShape;
+
+public class ExplicitRegistrationCircle : IExplicitRegistrationShape;
+
+public class ExplicitRegistrationRectangle : IExplicitRegistrationShape;
+
+public enum ExplicitRegistrationStatus
+{
+    Unknown = 0,
+    Active = 1
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TemplateTypes/when_generating_type/with_explicit_metadata_registration_and_user_defined_base.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TemplateTypes/when_generating_type/with_explicit_metadata_registration_and_user_defined_base.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_TemplateTypes.when_generating_type;
+
+public class with_explicit_metadata_registration_and_user_defined_base : Specification, IDisposable
+{
+    const string DerivedIdentifier = "explicit-derived-type";
+
+    JavaScriptRuntime _runtime = null!;
+    TypeDescriptor _baseDescriptor = null!;
+    TypeDescriptor _derivedDescriptor = null!;
+    string _derivedResult = null!;
+    string _registeredDerivedIdentifier = null!;
+    string _registeredFieldNames = null!;
+    bool _derivedTypeWasRegisteredForBase;
+    bool _deserializedInstanceIsDerived;
+    string _deserializedValues = null!;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        PropertyDescriptor[] baseProperties =
+        [
+            new(typeof(string), "BaseValue", "string", "String", string.Empty, false, false, true, null)
+        ];
+        _baseDescriptor = new TypeDescriptor(
+            typeof(ExplicitMetadataBaseType),
+            nameof(ExplicitMetadataBaseType),
+            baseProperties,
+            Enumerable.Empty<ImportStatement>().OrderBy(_ => _.Module),
+            [],
+            UseExplicitMetadataRegistration: true);
+
+        PropertyDescriptor[] derivedProperties =
+        [
+            new(typeof(int), "DerivedValue", "number", "Number", string.Empty, false, false, true, null)
+        ];
+        ImportStatement[] imports =
+        [
+            new(typeof(ExplicitMetadataBaseType), nameof(ExplicitMetadataBaseType), $"./{nameof(ExplicitMetadataBaseType)}")
+        ];
+        _derivedDescriptor = new TypeDescriptor(
+            typeof(ExplicitMetadataDerivedType),
+            nameof(ExplicitMetadataDerivedType),
+            derivedProperties,
+            imports.OrderBy(_ => _.Module),
+            [],
+            DerivedTypeId: DerivedIdentifier,
+            BaseTypeName: nameof(ExplicitMetadataBaseType),
+            UseExplicitMetadataRegistration: true);
+    }
+
+    void Because()
+    {
+        var baseResult = TemplateTypes.Type(_baseDescriptor);
+        _derivedResult = TemplateTypes.Type(_derivedDescriptor);
+
+        ExecuteTypeScriptModule(baseResult, nameof(ExplicitMetadataBaseType));
+        ExecuteTypeScriptModule(_derivedResult, nameof(ExplicitMetadataDerivedType));
+
+        _registeredDerivedIdentifier = _runtime.Evaluate<string>(
+            $"require('@cratis/fundamentals').DerivedType.get(globalThis.{nameof(ExplicitMetadataDerivedType)})")!;
+        _derivedTypeWasRegisteredForBase = _runtime.Evaluate<bool>(
+            $"require('@cratis/fundamentals').DerivedType.getDerivedTypesFor(globalThis.{nameof(ExplicitMetadataBaseType)}).includes(globalThis.{nameof(ExplicitMetadataDerivedType)})");
+        _registeredFieldNames = _runtime.Evaluate<string>(
+            $"require('@cratis/fundamentals').Fields.getFieldsForType(globalThis.{nameof(ExplicitMetadataDerivedType)}).map(field => field.name).join(',')")!;
+        _runtime.Execute(
+            $"globalThis.__explicitMetadataResult = require('@cratis/fundamentals').JsonSerializer.deserializeFromInstance(globalThis.{nameof(ExplicitMetadataDerivedType)}, {{ baseValue: 'base', derivedValue: 42 }});");
+        _deserializedInstanceIsDerived = _runtime.Evaluate<bool>(
+            $"globalThis.__explicitMetadataResult instanceof globalThis.{nameof(ExplicitMetadataDerivedType)}");
+        _deserializedValues = _runtime.Evaluate<string>(
+            "`${globalThis.__explicitMetadataResult.baseValue}:${globalThis.__explicitMetadataResult.derivedValue}`")!;
+    }
+
+    [Fact] void should_import_both_metadata_factories() => _derivedResult.ShouldContain("import { field, derivedType } from '@cratis/fundamentals';");
+    [Fact] void should_extend_the_user_defined_base() => _derivedResult.ShouldContain($"export class {nameof(ExplicitMetadataDerivedType)} extends {nameof(ExplicitMetadataBaseType)}");
+    [Fact] void should_register_the_derived_type_imperatively() => _derivedResult.ShouldContain($"derivedType('{DerivedIdentifier}')({nameof(ExplicitMetadataDerivedType)});");
+    [Fact] void should_not_emit_derived_type_decorator_syntax() => _derivedResult.ShouldNotContain("@derivedType(");
+    [Fact] void should_preserve_the_derived_type_identifier_at_runtime() => _registeredDerivedIdentifier.ShouldEqual(DerivedIdentifier);
+    [Fact] void should_register_the_derived_type_with_its_base_at_runtime() => _derivedTypeWasRegisteredForBase.ShouldBeTrue();
+    [Fact] void should_make_base_and_derived_fields_available_at_runtime() => _registeredFieldNames.ShouldEqual("baseValue,derivedValue");
+    [Fact] void should_deserialize_to_the_derived_type() => _deserializedInstanceIsDerived.ShouldBeTrue();
+    [Fact] void should_deserialize_base_and_derived_fields() => _deserializedValues.ShouldEqual("base:42");
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    void ExecuteTypeScriptModule(string typeScript, string exportedTypeName)
+    {
+        var javaScript = _runtime.TranspileTypeScript(typeScript, experimentalDecorators: false);
+#pragma warning disable MA0136 // Raw String contains an implicit end of line character
+        _runtime.Execute(
+            $$"""
+            (() => {
+                const module = { exports: {} };
+                const exports = module.exports;
+                const require = globalThis.require;
+                {{javaScript}}
+                globalThis.{{exportedTypeName}} = module.exports.{{exportedTypeName}};
+            })();
+            """);
+#pragma warning restore MA0136 // Raw String contains an implicit end of line character
+    }
+}
+
+public class ExplicitMetadataBaseType
+{
+    public string BaseValue { get; set; } = string.Empty;
+}
+
+public class ExplicitMetadataDerivedType : ExplicitMetadataBaseType
+{
+    public int DerivedValue { get; set; }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TemplateTypes/when_generating_type/with_properties.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TemplateTypes/when_generating_type/with_properties.cs
@@ -6,11 +6,14 @@ using Cratis.Arc.ProxyGenerator.Templates;
 namespace Cratis.Arc.ProxyGenerator.for_TemplateTypes.when_generating_type;
 
 /// <summary>
-/// Specification for verifying that types with properties include the field import.
+/// Specification for verifying that types with properties continue to use decorator metadata by default.
 /// </summary>
 public class with_properties : Specification
 {
-    string _result;
+    const string DerivedTypeIdentifier = "default-derived-type";
+
+    TypeDescriptor _descriptor = null!;
+    string _result = null!;
 
     void Establish()
     {
@@ -19,18 +22,22 @@ public class with_properties : Specification
             new PropertyDescriptor(typeof(string), "Name", "string", "String", string.Empty, false, false, true, null)
         };
 
-        var descriptor = new TypeDescriptor(
+        _descriptor = new TypeDescriptor(
             typeof(TypeWithProperties),
             "TypeWithProperties",
             properties,
             Enumerable.Empty<ImportStatement>().OrderBy(_ => _.Module),
-            []);
-
-        _result = TemplateTypes.Type(descriptor);
+            [],
+            DerivedTypeId: DerivedTypeIdentifier);
     }
 
-    [Fact] void should_contain_field_import() => _result.ShouldContain("import { field } from '@cratis/fundamentals';");
+    void Because() => _result = TemplateTypes.Type(_descriptor);
+
+    [Fact] void should_contain_metadata_imports() => _result.ShouldContain("import { field, derivedType } from '@cratis/fundamentals';");
     [Fact] void should_contain_field_decorator() => _result.ShouldContain("@field(String)");
+    [Fact] void should_contain_derived_type_decorator() => _result.ShouldContain($"@derivedType('{DerivedTypeIdentifier}')");
+    [Fact] void should_not_contain_imperative_field_registration() => _result.ShouldNotContain("field(String)(TypeWithProperties.prototype, 'name');");
+    [Fact] void should_not_contain_imperative_derived_type_registration() => _result.ShouldNotContain($"derivedType('{DerivedTypeIdentifier}')(TypeWithProperties);");
     [Fact] void should_contain_property() => _result.ShouldContain("name!: string;");
 }
 

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeScriptContentCombiner/when_combining/with_a_field_call_mentioned_only_in_jsdoc.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeScriptContentCombiner/when_combining/with_a_field_call_mentioned_only_in_jsdoc.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeScriptContentCombiner.when_combining;
+
+public class with_a_field_call_mentioned_only_in_jsdoc : Specification
+{
+#pragma warning disable MA0136 // Raw String contains an implicit end of line character
+    const string ParentContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        import { field } from '@cratis/fundamentals';
+        import { ChildType } from './ChildType';
+
+        export class ParentType {
+            child!: ChildType;
+        }
+        field(ChildType)(ParentType.prototype, 'child');
+        """;
+
+    const string ChildContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        import { field } from '@cratis/fundamentals';
+
+        /**
+         * Mentioning field(ParentType) here documents an example; it does not register metadata.
+         */
+        export class ChildType {
+            name!: string;
+        }
+        field(String)(ChildType.prototype, 'name');
+        """;
+#pragma warning restore MA0136 // Raw String contains an implicit end of line character
+
+    string _result = null!;
+
+    void Because() => _result = TypeScriptContentCombiner.Combine([ParentContent, ChildContent]);
+
+    [Fact] void should_declare_the_child_before_the_parent() =>
+        _result.IndexOf("export class ChildType", StringComparison.Ordinal)
+            .ShouldBeLessThan(_result.IndexOf("export class ParentType", StringComparison.Ordinal));
+    [Fact] void should_keep_the_documentation() => _result.ShouldContain("Mentioning field(ParentType) here documents an example");
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeScriptContentCombiner/when_combining/with_forward_references_through_explicit_registrations.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeScriptContentCombiner/when_combining/with_forward_references_through_explicit_registrations.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeScriptContentCombiner.when_combining;
+
+public class with_forward_references_through_explicit_registrations : Specification, IDisposable
+{
+    const string ParentTypeName = "Drawing";
+    const string BaseTypeName = "Shape";
+    const string FirstDerivativeTypeName = "Circle";
+    const string SecondDerivativeTypeName = "Rectangle";
+
+#pragma warning disable MA0136 // Raw String contains an implicit end of line character
+    const string ParentContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        // eslint-disable-next-line header/header
+        import { field } from '@cratis/fundamentals';
+        import { Shape } from './Shape';
+        import { Circle } from './Circle';
+        import { Rectangle } from './Rectangle';
+
+        export class Drawing {
+            selectedShape!: Shape;
+            shapes!: Shape[];
+        }
+        field(Shape, false, [Circle, Rectangle])(Drawing.prototype, 'selectedShape');
+        field(Shape, true, [Circle, Rectangle])(Drawing.prototype, 'shapes');
+        """;
+
+    const string CircleContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        // eslint-disable-next-line header/header
+        import { field, derivedType } from '@cratis/fundamentals';
+        import { Shape } from './Shape';
+
+        export class Circle extends Shape {
+            radius!: number;
+        }
+        field(Number)(Circle.prototype, 'radius');
+        derivedType('circle')(Circle);
+        """;
+
+    const string RectangleContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        // eslint-disable-next-line header/header
+        import { field, derivedType } from '@cratis/fundamentals';
+        import { Shape } from './Shape';
+
+        export class Rectangle extends Shape {
+            width!: number;
+        }
+        field(Number)(Rectangle.prototype, 'width');
+        derivedType('rectangle')(Rectangle);
+        """;
+
+    const string ShapeContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        // eslint-disable-next-line header/header
+        import { field } from '@cratis/fundamentals';
+
+        export class Shape {
+            name!: string;
+        }
+        field(String)(Shape.prototype, 'name');
+        """;
+#pragma warning restore MA0136 // Raw String contains an implicit end of line character
+
+    JavaScriptRuntime _runtime = null!;
+    string _result = null!;
+    IReadOnlyList<string> _diagnostics = null!;
+
+    void Establish() => _runtime = new JavaScriptRuntime();
+
+    void Because()
+    {
+        _result = TypeScriptContentCombiner.Combine([ParentContent, CircleContent, RectangleContent, ShapeContent]);
+        _diagnostics = _runtime.GetSyntacticDiagnostics(_result, experimentalDecorators: false);
+    }
+
+    [Fact] void should_declare_the_base_before_the_parent() => IndexOfType(BaseTypeName).ShouldBeLessThan(IndexOfType(ParentTypeName));
+    [Fact] void should_declare_the_first_derivative_before_the_parent() => IndexOfType(FirstDerivativeTypeName).ShouldBeLessThan(IndexOfType(ParentTypeName));
+    [Fact] void should_declare_the_second_derivative_before_the_parent() => IndexOfType(SecondDerivativeTypeName).ShouldBeLessThan(IndexOfType(ParentTypeName));
+    [Fact] void should_keep_the_derivative_constructor_array() => _result.ShouldContain("field(Shape, true, [Circle, Rectangle])(Drawing.prototype, 'shapes');");
+    [Fact] void should_merge_the_fundamentals_imports() => _result.ShouldContain("import { field, derivedType } from '@cratis/fundamentals';");
+    [Fact] void should_only_emit_one_fundamentals_import() => _result.Split("from '@cratis/fundamentals';").Length.ShouldEqual(2);
+    [Fact] void should_remove_the_internal_base_import() => _result.ShouldNotContain("import { Shape } from './Shape';");
+    [Fact] void should_remove_the_internal_derivative_imports() => _result.ShouldNotContain("import { Circle } from './Circle';");
+    [Fact] void should_keep_registration_after_its_class_declaration() => _result.IndexOf("derivedType('circle')(Circle);", StringComparison.Ordinal).ShouldBeGreaterThan(IndexOfType(FirstDerivativeTypeName));
+    [Fact] void should_not_contain_decorator_syntax() => _result.ShouldNotContain("@field(");
+    [Fact] void should_compile_with_experimental_decorators_disabled() => _diagnostics.ShouldBeEmpty();
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    int IndexOfType(string typeName) => _result.IndexOf($"export class {typeName}", StringComparison.Ordinal);
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Generator.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Generator.cs
@@ -33,6 +33,7 @@ public static class Generator
     /// <param name="excludedNamespacePatterns">Namespace glob patterns (supports <c>*</c> as wildcard) whose matching types are excluded from generation.</param>
     /// <param name="namespaceRoots">Pairs of (namespace, base folder) used as roots. When a type's namespace begins with a root the root is stripped and the remainder is placed under the base folder.</param>
     /// <param name="typeMappings">Triples of (fully qualified type name, TypeScript type, package) declaring how a type crosses the wire. Consulted ahead of the built-in map, so it can correct an existing mapping as well as add an unknown one.</param>
+    /// <param name="useExplicitMetadataRegistration">Whether to register generated field and derived-type metadata with imperative factory calls instead of decorators.</param>
     /// <returns>True if successful, false if not.</returns>
     public static async Task<bool> Generate(
         string assemblyFile,
@@ -51,7 +52,8 @@ public static class Generator
         IReadOnlyCollection<string>? excludedTypeNames = null,
         IReadOnlyCollection<string>? excludedNamespacePatterns = null,
         IReadOnlyCollection<(string Namespace, string Folder)>? namespaceRoots = null,
-        IReadOnlyCollection<(string TypeName, string TsType, string Package)>? typeMappings = null)
+        IReadOnlyCollection<(string TypeName, string TsType, string Package)>? typeMappings = null,
+        bool useExplicitMetadataRegistration = false)
     {
         assemblyFile = Path.GetFullPath(assemblyFile);
         if (!File.Exists(assemblyFile))
@@ -153,7 +155,10 @@ public static class Generator
         typesInvolved = [.. typesInvolved.Distinct()];
         var enums = typesInvolved.Where(_ => _.IsEnum).ToList();
 
-        var typeDescriptors = typesInvolved.Where(_ => !enums.Contains(_) && !_.IsFromMappedAssembly()).ToList().ConvertAll(_ => _.ToTypeDescriptor(outputPath, segmentsToSkip));
+        var typeDescriptors = typesInvolved
+            .Where(_ => !enums.Contains(_) && !_.IsFromMappedAssembly())
+            .ToList()
+            .ConvertAll(_ => _.ToTypeDescriptor(outputPath, segmentsToSkip, useExplicitMetadataRegistration));
         await typeDescriptors.Write(outputPath, typesInvolved, TemplateTypes.Type, directories, segmentsToSkip, "types", message, errorMessage, generatedFiles, descriptorOrigins, sourceFileMap, pendingContent);
 
         var regularEnumDescriptors = enums

--- a/Source/DotNET/Tools/ProxyGenerator/Program.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Program.cs
@@ -9,7 +9,7 @@ Console.WriteLine("Cratis Proxy Generator\n");
 if (args.Length < 2)
 {
     Console.WriteLine("Usage: ");
-    Console.WriteLine("  Cratis.ProxyGenerator <assembly> <output-path> [segments-to-skip] [--library-mode] [--skip-output-deletion] [--skip-command-name-in-route] [--skip-query-name-in-route] [--api-prefix=<prefix>] [--skip-index-generation] [--use-source-file-as-output-file] [--assembly-to-package=<Assembly>=<Package>]... [--exclude-type=<FullyQualifiedTypeName>]... [--exclude-namespace=<Pattern>]... [--namespace-root=<Namespace>=<Folder>]... [--type-to-ts=<FullyQualifiedTypeName>=<TsType>[=<Package>]]...");
+    Console.WriteLine("  Cratis.ProxyGenerator <assembly> <output-path> [segments-to-skip] [--library-mode] [--skip-output-deletion] [--skip-command-name-in-route] [--skip-query-name-in-route] [--api-prefix=<prefix>] [--skip-index-generation] [--use-source-file-as-output-file] [--use-explicit-metadata-registration] [--assembly-to-package=<Assembly>=<Package>]... [--exclude-type=<FullyQualifiedTypeName>]... [--exclude-namespace=<Pattern>]... [--namespace-root=<Namespace>=<Folder>]... [--type-to-ts=<FullyQualifiedTypeName>=<TsType>[=<Package>]]...");
     return 1;
 }
 var assemblyFile = Normalize(Path.GetFullPath(args[0]));
@@ -23,6 +23,7 @@ var apiPrefixArg = args.FirstOrDefault(_ => _.StartsWith("--api-prefix="));
 var apiPrefix = apiPrefixArg is null ? "api" : apiPrefixArg.Split('=')[^1];
 var skipIndexGeneration = args.Any(_ => _ == "--skip-index-generation");
 var useSourceFileAsOutputFile = args.Any(_ => _ == "--use-source-file-as-output-file");
+var useExplicitMetadataRegistration = args.Any(_ => _ == "--use-explicit-metadata-registration");
 
 var assemblyPackageMappings = new Dictionary<string, string>();
 foreach (var mapping in args.Where(_ => _.StartsWith("--assembly-to-package=")).Select(_ => _["--assembly-to-package=".Length..]))
@@ -92,6 +93,7 @@ Console.WriteLine($"Skip query name in route: {skipQueryNameInRoute}");
 Console.WriteLine($"API prefix: {apiPrefix}");
 Console.WriteLine($"Skip index generation: {skipIndexGeneration}");
 Console.WriteLine($"Use source file as output file: {useSourceFileAsOutputFile}");
+Console.WriteLine($"Use explicit metadata registration: {useExplicitMetadataRegistration}");
 if (assemblyPackageMappings.Count > 0)
 {
     Console.WriteLine("Assembly-to-package mappings:");
@@ -143,5 +145,6 @@ var result = await Generator.Generate(
     excludedTypeNames,
     excludedNamespacePatterns,
     namespaceRoots,
-    typeMappings);
+    typeMappings,
+    useExplicitMetadataRegistration);
 return result ? 0 : 1;

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Type.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Type.hbs
@@ -21,7 +21,9 @@ import { {{{Type}}} } from '{{Module}}';
  */
 {{/if}}
 {{#if DerivedTypeId}}
+{{#unless UseExplicitMetadataRegistration}}
 @derivedType('{{DerivedTypeId}}')
+{{/unless}}
 {{/if}}
 export class {{Name}}{{#if BaseTypeName}} extends {{BaseTypeName}}{{/if}} {
     {{#Properties}}
@@ -31,16 +33,12 @@ export class {{Name}}{{#if BaseTypeName}} extends {{BaseTypeName}}{{/if}} {
      * {{Documentation}}
      */
     {{/if}}
+    {{#unless ../UseExplicitMetadataRegistration}}
     {{#if IsEnumerable}}
     {{#if Derivatives}}
     @field({{Constructor}}, true, [{{Derivatives}}])
     {{else}}
     @field({{Constructor}}, true)
-    {{/if}}
-    {{#if IsNullable}}
-    {{camelcase Name}}?: {{{Type}}}[];
-    {{else}}
-    {{camelcase Name}}!: {{{Type}}}[];
     {{/if}}
     {{else}}
     {{#if Derivatives}}
@@ -48,6 +46,15 @@ export class {{Name}}{{#if BaseTypeName}} extends {{BaseTypeName}}{{/if}} {
     {{else}}
     @field({{Constructor}})
     {{/if}}
+    {{/if}}
+    {{/unless}}
+    {{#if IsEnumerable}}
+    {{#if IsNullable}}
+    {{camelcase Name}}?: {{{Type}}}[];
+    {{else}}
+    {{camelcase Name}}!: {{{Type}}}[];
+    {{/if}}
+    {{else}}
     {{#if IsNullable}}
     {{camelcase Name}}?: {{{Type}}};
     {{else}}
@@ -56,3 +63,23 @@ export class {{Name}}{{#if BaseTypeName}} extends {{BaseTypeName}}{{/if}} {
     {{/if}}
     {{/Properties}}
 }
+{{#if UseExplicitMetadataRegistration}}
+{{#Properties}}
+{{#if IsEnumerable}}
+{{#if Derivatives}}
+field({{Constructor}}, true, [{{Derivatives}}])({{../Name}}.prototype, '{{camelcase Name}}');
+{{else}}
+field({{Constructor}}, true)({{../Name}}.prototype, '{{camelcase Name}}');
+{{/if}}
+{{else}}
+{{#if Derivatives}}
+field({{Constructor}}, false, [{{Derivatives}}])({{../Name}}.prototype, '{{camelcase Name}}');
+{{else}}
+field({{Constructor}})({{../Name}}.prototype, '{{camelcase Name}}');
+{{/if}}
+{{/if}}
+{{/Properties}}
+{{#if DerivedTypeId}}
+derivedType('{{DerivedTypeId}}')({{Name}});
+{{/if}}
+{{/if}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/TypeDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/TypeDescriptor.cs
@@ -14,6 +14,7 @@ namespace Cratis.Arc.ProxyGenerator.Templates;
 /// <param name="Documentation">JSDoc documentation for the type.</param>
 /// <param name="DerivedTypeId">The derived type identifier GUID string if this type carries a <c>DerivedTypeAttribute</c>, otherwise null.</param>
 /// <param name="BaseTypeName">The TypeScript name of the base type to extend, or null if there is no applicable base type.</param>
+/// <param name="UseExplicitMetadataRegistration">Whether to emit imperative metadata registration calls instead of decorators.</param>
 public record TypeDescriptor(
     Type Type,
     string Name,
@@ -22,4 +23,5 @@ public record TypeDescriptor(
     IEnumerable<Type> TypesInvolved,
     string? Documentation = null,
     string? DerivedTypeId = null,
-    string? BaseTypeName = null) : IDescriptor;
+    string? BaseTypeName = null,
+    bool UseExplicitMetadataRegistration = false) : IDescriptor;

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -497,8 +497,9 @@ public static class TypeExtensions
     /// <param name="type">Type to convert.</param>
     /// <param name="targetPath">The target path the proxies are generated to.</param>
     /// <param name="segmentsToSkip">Number of segments to skip from the namespace when generating the output path.</param>
+    /// <param name="useExplicitMetadataRegistration">Whether to emit imperative metadata registration calls instead of decorators.</param>
     /// <returns>Converted <see cref="TypeDescriptor"/>.</returns>
-    public static TypeDescriptor ToTypeDescriptor(this Type type, string targetPath, int segmentsToSkip)
+    public static TypeDescriptor ToTypeDescriptor(this Type type, string targetPath, int segmentsToSkip, bool useExplicitMetadataRegistration = false)
     {
         var typesInvolved = new List<Type>();
 
@@ -607,7 +608,8 @@ public static class TypeExtensions
             typesInvolved,
             documentation,
             derivedTypeId,
-            baseTypeName);
+            baseTypeName,
+            useExplicitMetadataRegistration);
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/TypeScriptContentCombiner.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeScriptContentCombiner.cs
@@ -251,8 +251,11 @@ public static partial class TypeScriptContentCombiner
     [GeneratedRegex(@"import\s+\{\s*(?<names>[^}]+)\s*\}\s+from\s+", RegexOptions.NonBacktracking)]
     private static partial Regex ImportedTypeRegex();
 
-    [GeneratedRegex(@"@field\(\s*(?<type>[A-Z]\w*)", RegexOptions.NonBacktracking)]
-    private static partial Regex FieldDecoratorReferenceRegex();
+    [GeneratedRegex(@"^[ \t]*(?:@field\((?<arguments>[^)\r\n]*)\)|field\((?<arguments>[^)\r\n]*)\)\([\w$]+\.prototype,\s*'[^'\r\n]+'\);)[ \t]*$", RegexOptions.Multiline | RegexOptions.NonBacktracking)]
+    private static partial Regex FieldRegistrationRegex();
+
+    [GeneratedRegex(@"\b(?<type>[A-Z]\w*)\b", RegexOptions.NonBacktracking)]
+    private static partial Regex RegistrationTypeReferenceRegex();
 
     [GeneratedRegex(@"[!?]\s*:\s*(?<type>[A-Z]\w*)", RegexOptions.NonBacktracking)]
     private static partial Regex PropertyTypeAnnotationRegex();
@@ -261,7 +264,7 @@ public static partial class TypeScriptContentCombiner
     private static partial Regex ExtendsClauseRegex();
 
     /// <summary>
-    /// Topologically sorts body sections so that types referenced by <c>@field</c> decorators
+    /// Topologically sorts body sections so that types referenced by field metadata registrations
     /// in other bodies appear before the bodies that reference them. This prevents forward
     /// reference errors at runtime since TypeScript classes are not hoisted.
     /// </summary>
@@ -275,14 +278,15 @@ public static partial class TypeScriptContentCombiner
         }
 
         var exportPattern = ExportDeclarationRegex();
-        var fieldPattern = FieldDecoratorReferenceRegex();
+        var fieldPattern = FieldRegistrationRegex();
+        var registrationTypePattern = RegistrationTypeReferenceRegex();
         var extendsPattern = ExtendsClauseRegex();
         var builtInTypes = new HashSet<string>(StringComparer.Ordinal)
         {
             "String", "Number", "Boolean", "Date", "Object"
         };
 
-        // Map each body to its exported type names and the custom types it references via @field.
+        // Map each body to its exported type names and the custom types it references through field metadata.
         var bodyExports = new List<HashSet<string>>();
         var bodyDependencies = new List<HashSet<string>>();
         var annotationPattern = PropertyTypeAnnotationRegex();
@@ -296,7 +300,13 @@ public static partial class TypeScriptContentCombiner
             }
 
             var dependencies = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var typeName in fieldPattern.Matches(body).Select(match => match.Groups["type"].Value).Where(typeName => !builtInTypes.Contains(typeName) && !exports.Contains(typeName)))
+            var registeredTypeNames = fieldPattern
+                .Matches(body)
+                .SelectMany(match => registrationTypePattern.Matches(match.Groups["arguments"].Value))
+                .Select(match => match.Groups["type"].Value)
+                .Where(typeName => !builtInTypes.Contains(typeName) && !exports.Contains(typeName));
+
+            foreach (var typeName in registeredTypeNames)
             {
                 dependencies.Add(typeName);
             }


### PR DESCRIPTION
# Summary

Generated TypeScript proxies can now preserve Arc serialization metadata in environments that cannot run legacy decorator transforms, while web projects retain decorator-based output by default.

## Added

- Added opt-in decorator-free metadata registration for generated TypeScript proxies, enabling React Native, Expo, Hermes, and toolchains without legacy decorator transforms. (#2440)