### PR TITLE
Preserved orphaned work: CommandScenario specs for the Unique constraint (do not merge)

### DIFF
--- a/Source/DotNET/Chronicle.Specs/Chronicle.Specs.csproj
+++ b/Source/DotNET/Chronicle.Specs/Chronicle.Specs.csproj
@@ -9,5 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <ProjectReference Include="../Chronicle/Chronicle.csproj" />
+        <ProjectReference Include="../Chronicle.Testing/Chronicle.Testing.csproj" />
     </ItemGroup>
 </Project>

--- a/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/given/a_command_that_appends_an_event_of_a_unique_event_type.cs
+++ b/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/given/a_command_that_appends_an_event_of_a_unique_event_type.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Arc.Chronicle.for_CommandScenario_with_UniqueConstraint.given;
+
+public class a_command_that_appends_an_event_of_a_unique_event_type : Specification
+{
+    protected CommandScenario<ACommandWithUniqueEventTypeEvent> _scenario;
+    protected EventSourceId _eventSourceId;
+
+    [Unique("unique-event-type-spec-constraint")]
+    [EventType]
+    public record AUniqueEventType(string Name);
+
+    [Command]
+    public class ACommandWithUniqueEventTypeEvent
+    {
+        public EventSourceId EventSourceId { get; init; } = EventSourceId.Unspecified;
+        public string Name { get; init; } = string.Empty;
+
+        AUniqueEventType Handle() => new(Name);
+    }
+
+    async Task Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<ACommandWithUniqueEventTypeEvent>();
+        await _scenario.EventScenario.Given.ForEventSource(_eventSourceId).Events(new AUniqueEventType("Bob"));
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/given/a_command_that_appends_an_event_with_a_unique_property.cs
+++ b/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/given/a_command_that_appends_an_event_with_a_unique_property.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Arc.Chronicle.for_CommandScenario_with_UniqueConstraint.given;
+
+public class a_command_that_appends_an_event_with_a_unique_property : Specification
+{
+    protected CommandScenario<ACommandWithUniquePropertyEvent> _scenario;
+    protected EventSourceId _firstEventSourceId;
+    protected EventSourceId _secondEventSourceId;
+
+    [EventType]
+    public record AnEventWithUniqueProperty([property: Unique("unique-name-spec-constraint")] string Name);
+
+    [Command]
+    public class ACommandWithUniquePropertyEvent
+    {
+        public EventSourceId EventSourceId { get; init; } = EventSourceId.Unspecified;
+        public string Name { get; init; } = string.Empty;
+
+        AnEventWithUniqueProperty Handle() => new(Name);
+    }
+
+    async Task Establish()
+    {
+        _firstEventSourceId = EventSourceId.New();
+        _secondEventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<ACommandWithUniquePropertyEvent>();
+        await _scenario.Execute(new ACommandWithUniquePropertyEvent { EventSourceId = _firstEventSourceId, Name = "Alice" });
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/when_executing_command/and_the_unique_event_type_already_exists.cs
+++ b/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/when_executing_command/and_the_unique_event_type_already_exists.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Chronicle.for_CommandScenario_with_UniqueConstraint.when_executing_command;
+
+public class and_the_unique_event_type_already_exists : given.a_command_that_appends_an_event_of_a_unique_event_type
+{
+    CommandResult _result;
+
+    async Task Because() => _result = await _scenario.Execute(new ACommandWithUniqueEventTypeEvent
+    {
+        EventSourceId = _eventSourceId,
+        Name = "Bob"
+    });
+
+    [Fact] void should_not_be_successful() => _result.ShouldNotBeSuccessful();
+    [Fact] void should_have_validation_errors() => _result.ShouldHaveValidationErrors();
+}

--- a/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/when_executing_command/and_the_unique_property_value_already_exists.cs
+++ b/Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/when_executing_command/and_the_unique_property_value_already_exists.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Chronicle.for_CommandScenario_with_UniqueConstraint.when_executing_command;
+
+public class and_the_unique_property_value_already_exists : given.a_command_that_appends_an_event_with_a_unique_property
+{
+    CommandResult _result;
+
+    async Task Because() => _result = await _scenario.Execute(new ACommandWithUniquePropertyEvent
+    {
+        EventSourceId = _secondEventSourceId,
+        Name = "Alice"
+    });
+
+    [Fact] void should_not_be_successful() => _result.ShouldNotBeSuccessful();
+    [Fact] void should_have_validation_errors() => _result.ShouldHaveValidationErrors();
+}


### PR DESCRIPTION
## Preservation only — do not merge

This is **recovered orphaned work**, opened as a draft purely so it is discoverable. It is not a live proposal and it is not ready to merge.

The branch was never pushed before now and **never had a pull request at any point**. It was sitting only in a local checkout.

### Why the repository PR template is not used

The template in `.github/pull_request_template.md` states that *"Release notes are generated from this description"*. This PR must never generate a release note — it ships nothing. The template's `## Added` / `## Changed` / `## Fixed` sections are therefore deliberately omitted rather than left empty.

### Why there is no semver label

**No `major` / `minor` / `patch` label is applied, and none should be added.** A missing label is the correct and intended state: it means no release is cut, which is exactly right for a branch that exists only to preserve history. The `verify` check will fail because the label is missing. **That failure is expected and must not be "fixed".**

### How far behind main this is

**1,148 commits behind `main`.** The merge base is `f6eaad58` (2026-04-24).

**The diff GitHub renders is enormous and misleading** — almost all of it is `main` moving on, not work this branch did. The branch itself is a single commit touching five files. Do not read the diff. The file list below is the actual deliverable.

### What the work is

One commit from 2026-04-24 adding `CommandScenario` spec coverage for the `[Unique]` constraint, in both of the shapes it can be applied:

- `[Unique]` on an **event property** — the "a value already exists" rejection path.
- `[Unique]` on an **event type** — the "an event of this type already exists" rejection path.

This is pure test coverage. No production code is touched other than the spec project file.

### Files genuinely unique to this branch

Verified individually as absent from `origin/main` at `d9918345`:

- `Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/given/a_command_that_appends_an_event_of_a_unique_event_type.cs`
- `Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/given/a_command_that_appends_an_event_with_a_unique_property.cs`
- `Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/when_executing_command/and_the_unique_event_type_already_exists.cs`
- `Source/DotNET/Chronicle.Specs/for_CommandScenario_with_UniqueConstraint/when_executing_command/and_the_unique_property_value_already_exists.cs`

The fifth changed file is `Source/DotNET/Chronicle.Specs/Chronicle.Specs.csproj`, which exists on `main` and has moved on since.
