### PR TITLE
Compare useQuery arguments by value instead of by identity

### DIFF
--- a/Source/JavaScript/Arc.React/queries/for_useQuery/FakeQueryWithObjectArgument.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQuery/FakeQueryWithObjectArgument.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryFor } from '@cratis/arc/queries';
+import { ParameterDescriptor } from '@cratis/arc/reflection';
+import { Guid } from '@cratis/fundamentals';
+
+export interface FakeQueryWithObjectArgumentResult {
+    id: string;
+    name: string;
+}
+
+export interface FakeQueryWithObjectArgumentArguments {
+    engagementId: Guid;
+}
+
+/**
+ * A query whose required parameter is an object at runtime - the shape every `Guid`, `DateOnly` and
+ * generated concept has, and the one a raw-value dependency array compares by identity.
+ */
+export class FakeQueryWithObjectArgument extends QueryFor<
+    FakeQueryWithObjectArgumentResult[]
+> {
+    readonly route = '/api/fake-query-with-object-argument';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return ['engagementId'];
+    }
+
+    defaultValue: FakeQueryWithObjectArgumentResult[] = [];
+
+    constructor() {
+        super(Object, true);
+    }
+}

--- a/Source/JavaScript/Arc.React/queries/for_useQuery/when_a_required_argument_is_an_object.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQuery/when_a_required_argument_is_an_object.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { Guid } from '@cratis/fundamentals';
+import { QueryInstanceCache } from '@cratis/arc/queries';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { useQuery } from '../useQuery';
+import { FakeQueryWithObjectArgument, FakeQueryWithObjectArgumentArguments } from './FakeQueryWithObjectArgument';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+/**
+ * A required parameter whose runtime type is an object - a `Guid`, a `DateOnly`, any generated
+ * concept - is the shape a consumer re-derives in render position (`Guid.parse(useParams().id)`).
+ * Comparing those by identity re-runs the subscribe effect every render, and that loop sustains
+ * itself: each turn aborts the in-flight request and settles a freshly constructed result object,
+ * which guarantees the next render. What is pinned here is that the request count does not grow
+ * with the number of renders.
+ */
+describe('when a required argument is an object', () => {
+    let fetchStub: sinon.SinonStub;
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+
+    const guidValue = '6f9619ff-8b86-d011-b42d-00cf4fc964ff';
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com',
+    };
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        fetchStub = fetchHelper.stubFetch();
+        fetchStub.resolves({
+            json: async () => ({
+                data: [],
+                isSuccess: true,
+                isAuthorized: true,
+                isValid: true,
+                hasExceptions: false,
+                validationResults: [],
+                exceptionMessages: [],
+                exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 },
+            }),
+        } as Response);
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(
+            QueryInstanceCacheContext.Provider,
+            { value: new QueryInstanceCache() },
+            React.createElement(ArcContext.Provider, { value: config }, children),
+        );
+
+    it('should not perform the query again when the argument is re-parsed to an equal value', async () => {
+        // Parsed inside the hook callback, so every render hands the hook a brand new - but equal -
+        // Guid instance, exactly as a call site parsing a route parameter in render position does.
+        const { rerender } = renderHook(
+            () =>
+                useQuery(FakeQueryWithObjectArgument, {
+                    engagementId: Guid.parse(guidValue),
+                } as FakeQueryWithObjectArgumentArguments),
+            { wrapper },
+        );
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+
+        rerender();
+        rerender();
+        rerender();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        fetchStub.should.have.been.calledOnce;
+    });
+
+    it('should perform the query again when the argument changes to a different value', async () => {
+        const { rerender } = renderHook(
+            ({ id }: { id: string }) =>
+                useQuery(FakeQueryWithObjectArgument, {
+                    engagementId: Guid.parse(id),
+                } as FakeQueryWithObjectArgumentArguments),
+            { wrapper, initialProps: { id: guidValue } },
+        );
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+
+        fetchStub.resetHistory();
+
+        rerender({ id: '11112222-3333-4444-5555-666677778888' });
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/serializeArgsForDependency.ts
+++ b/Source/JavaScript/Arc.React/queries/serializeArgsForDependency.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Derives a stable, constant-shape dependency value from query arguments for use in a React
+ * dependency array.
+ *
+ * React compares dependencies with `Object.is`, so an argument whose runtime type is an object -
+ * a `Guid`, a `DateOnly`, any generated concept - is compared by identity. A value re-derived in
+ * render position (`Guid.parse(useParams().id)`) is a new object every render, so an effect keyed
+ * on the raw value re-runs on every render. Every query argument type Arc generates implements
+ * `toJSON()`, so serializing collapses them to their canonical string and the comparison becomes
+ * one by value.
+ *
+ * Spreading `Object.values(args)` positionally makes the dependency array's length track the
+ * argument object's key count. React's `areHookInputsEqual` only compares the overlapping prefix
+ * when a dependency array's length changes between renders, so a render where `args` goes from
+ * `undefined` to `{ key: value }` (or vice versa) can have its memo/effect report "no change" even
+ * though the arguments did change. Collapsing `args` into one sorted, serialized string keeps the
+ * dependency array a constant length regardless of `args`' shape.
+ * @param {object} [args] The query arguments to serialize.
+ * @returns {string} A stable string dependency, empty when there are no arguments.
+ */
+export function serializeArgsForDependency(args?: object): string {
+    if (!args || Object.keys(args).length === 0) {
+        return '';
+    }
+
+    const sorted = Object.keys(args)
+        .sort()
+        .reduce<Record<string, unknown>>((accumulator, key) => {
+            accumulator[key] = (args as Record<string, unknown>)[key];
+            return accumulator;
+        }, {});
+
+    return JSON.stringify(sorted);
+}

--- a/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
@@ -9,6 +9,7 @@ import { SetPage } from './SetPage';
 import { SetPageSize } from './SetPageSize';
 import { ArcContext } from '../ArcContext';
 import { QueryInstanceCacheContext } from './QueryInstanceCacheContext';
+import { serializeArgsForDependency } from './serializeArgsForDependency';
 import { useQueryScope } from './useQueryScope';
 
 /**
@@ -119,34 +120,6 @@ function deserializeResponseData<TDataType>(data: unknown, modelType: Constructo
     }
 
     return deserializeItems(modelType, data) as TDataType;
-}
-
-/**
- * Derives a stable, constant-shape dependency value from query arguments for use in a React
- * dependency array.
- *
- * Spreading `Object.values(args)` positionally makes the dependency array's length track the
- * argument object's key count. React's `areHookInputsEqual` only compares the overlapping prefix
- * when a dependency array's length changes between renders, so a render where `args` goes from
- * `undefined` to `{ key: value }` (or vice versa) can have its memo/effect report "no change" even
- * though the arguments did change. Collapsing `args` into one sorted, serialized string keeps the
- * dependency array a constant length regardless of `args`' shape.
- * @param {object} [args] The query arguments to serialize.
- * @returns {string} A stable string dependency, empty when there are no arguments.
- */
-function serializeArgsForDependency(args?: object): string {
-    if (!args || Object.keys(args).length === 0) {
-        return '';
-    }
-
-    const sorted = Object.keys(args)
-        .sort()
-        .reduce<Record<string, unknown>>((accumulator, key) => {
-            accumulator[key] = (args as Record<string, unknown>)[key];
-            return accumulator;
-        }, {});
-
-    return JSON.stringify(sorted);
 }
 
 function hasAllRequiredArguments(requiredRequestParameters: string[], args?: object): boolean {

--- a/Source/JavaScript/Arc.React/queries/useQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useQuery.ts
@@ -10,6 +10,7 @@ import { SetPageSize } from './SetPageSize';
 import { ArcContext } from '../ArcContext';
 import { useCommandScope } from '../commands/useCommandScope';
 import { QueryInstanceCacheContext } from './QueryInstanceCacheContext';
+import { serializeArgsForDependency } from './serializeArgsForDependency';
 import { useQueryScope } from './useQueryScope';
 
 /**
@@ -104,7 +105,14 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
         cachedResult ?? QueryResultWithState.initial(queryInstance.defaultValue)
     );
 
-    const argumentsDependency = queryInstance.requiredRequestParameters.map(_ => args?.[_ as keyof TArguments]);
+    // Serialized rather than spread as raw values. React compares dependencies with `Object.is`, so a
+    // required parameter whose runtime type is an object - a `Guid`, a `DateOnly`, any generated
+    // concept - would be compared by identity. A value re-derived in render position is a new object
+    // every render, which re-runs the effect, which aborts the in-flight request and settles a fresh
+    // result object, which re-renders: a loop that never converges. Serializing compares them by
+    // value, the same way the observable and suspense hooks already do.
+    const argumentsDependency = serializeArgsForDependency(
+        Object.fromEntries(queryInstance.requiredRequestParameters.map(_ => [_, args?.[_ as keyof TArguments]])));
 
     const queryExecutor = (async (args?: TArguments) => {
         if (queryInstance) {
@@ -157,7 +165,7 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
             arc.observableQueryDiagnostics?.endTracking(key);
             queryCache.release(key);
         };
-    }, [...argumentsDependency, ...[currentPaging, currentSorting, isEnabled]]);
+    }, [argumentsDependency, currentPaging, currentSorting, isEnabled]);
 
     return [
         isEnabled === false ? QueryResultWithState.empty(queryInstance.defaultValue) : result!,


### PR DESCRIPTION
# Summary

Handing a `useQuery` hook an object-typed argument that is created in render position — a `Guid`, a `DateOnly`, or any generated concept, e.g. `Guid.parse(useParams().id)` — put the page into an unbounded request loop. `useQuery` derived its subscribe-effect dependency from raw argument values, and React compares dependencies with `Object.is`, so two equal-but-distinct `Guid`s re-ran the effect on every render. Each turn aborted the in-flight request and settled a newly constructed result object, which guaranteed the next render, so the loop sustained itself at hundreds of requests per second — enough to stop the tab responding to input and to leave a page permanently stuck in its loading state.

No consumer change is needed: arguments are now compared by serialized value, so an unmemoized `Guid` can be handed to a query hook in render position safely. This is the same treatment the observable hooks received in #1962; the three sibling hooks (`useObservableQuery`, `useSuspenseQuery`, `useSuspenseObservableQuery`) already serialized their arguments, and `useQuery` was the odd one out.

## Fixed

- `useQuery` and `useQueryWithPaging` no longer re-subscribe on every render when a query argument is an object such as a `Guid`, a `DateOnly`, or a generated concept — arguments are compared by serialized value instead of by reference identity (#2584)

## Changed

- `serializeArgsForDependency` moved out of `useObservableQuery` into its own module so every query hook derives its argument dependency the same way (#2584)