### PR TITLE
Map generated endpoints in linear time

### DIFF
--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/given/a_counting_endpoint_data_source.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/given/a_counting_endpoint_data_source.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Primitives;
+
+namespace Cratis.Arc.Http.for_AspNetCoreEndpointMapper.given;
+
+/// <summary>
+/// An <see cref="EndpointDataSource"/> that records how many times its endpoints were materialized.
+/// </summary>
+/// <remarks>
+/// Reading <see cref="EndpointDataSource.Endpoints"/> on a real route builder rebuilds every endpoint rather than
+/// returning a cached list, so the number of reads - not wall-clock time - is what makes the difference between a
+/// linear and a quadratic mapping pass observable in a spec.
+/// </remarks>
+/// <param name="endpointNames">The names of the endpoints this source holds.</param>
+public class a_counting_endpoint_data_source(params string[] endpointNames) : EndpointDataSource
+{
+    readonly List<Endpoint> _endpoints = [.. endpointNames.Select(Endpoint)];
+
+    public int Reads { get; private set; }
+
+    public override IReadOnlyList<Endpoint> Endpoints
+    {
+        get
+        {
+            Reads++;
+
+            return _endpoints;
+        }
+    }
+
+    public override IChangeToken GetChangeToken() => new CancellationChangeToken(CancellationToken.None);
+
+    static Endpoint Endpoint(string name) =>
+        new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse($"/{name}"),
+            order: 0,
+            new EndpointMetadataCollection(new EndpointNameMetadata(name)),
+            name);
+}

--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_checking_whether_an_endpoint_exists/and_it_was_registered_before_the_mapper_started.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_checking_whether_an_endpoint_exists/and_it_was_registered_before_the_mapper_started.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Http.for_AspNetCoreEndpointMapper.when_checking_whether_an_endpoint_exists;
+
+public class and_it_was_registered_before_the_mapper_started : given.an_endpoint_mapper
+{
+    bool _existing;
+    bool _unrelated;
+
+    void Establish() => _routeBuilder.DataSources.Add(new given.a_counting_endpoint_data_source("MappedBySomethingElse"));
+
+    void Because()
+    {
+        _existing = _mapper.EndpointExists("MappedBySomethingElse");
+        _unrelated = _mapper.EndpointExists("NeverMapped");
+    }
+
+    [Fact] void should_find_the_endpoint_this_mapper_did_not_map() => _existing.ShouldBeTrue();
+    [Fact] void should_not_find_an_endpoint_nothing_mapped() => _unrelated.ShouldBeFalse();
+}

--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_checking_whether_an_endpoint_exists/and_many_are_checked_while_mapping.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_checking_whether_an_endpoint_exists/and_many_are_checked_while_mapping.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Http.for_AspNetCoreEndpointMapper.when_checking_whether_an_endpoint_exists;
+
+/// <summary>
+/// The guard that keeps a mapping pass from registering the same endpoint name twice used to ask the route builder
+/// every time, and every one of those asks rebuilt the entire endpoint table - so mapping N endpoints cost N table
+/// rebuilds and grew with the square of the number of commands and queries. The table must be read once.
+/// </summary>
+public class and_many_are_checked_while_mapping : given.an_endpoint_mapper
+{
+    const int Endpoints = 25;
+    given.a_counting_endpoint_data_source _dataSource;
+
+    void Establish()
+    {
+        _dataSource = new("AlreadyThere");
+        _routeBuilder.DataSources.Add(_dataSource);
+    }
+
+    void Because()
+    {
+        for (var index = 0; index < Endpoints; index++)
+        {
+            var name = $"Endpoint{index}";
+            if (!_mapper.EndpointExists(name))
+            {
+                _mapper.MapGet($"/test/{name}", _ => Task.CompletedTask, new EndpointMetadata(name, string.Empty, [], false));
+            }
+        }
+    }
+
+    [Fact] void should_materialize_the_endpoint_table_only_once() => _dataSource.Reads.ShouldEqual(1);
+    [Fact] void should_map_every_endpoint() => Enumerable.Range(0, Endpoints).Count(index => _mapper.EndpointExists($"Endpoint{index}")).ShouldEqual(Endpoints);
+}

--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_checking_whether_an_endpoint_exists/and_this_mapper_mapped_it.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_checking_whether_an_endpoint_exists/and_this_mapper_mapped_it.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Http.for_AspNetCoreEndpointMapper.when_checking_whether_an_endpoint_exists;
+
+public class and_this_mapper_mapped_it : given.an_endpoint_mapper
+{
+    const string EndpointName = "MappedByThisMapper";
+    bool _mapped;
+    bool _mappedWithoutMetadata;
+
+    void Establish()
+    {
+        _mapper.MapPost("/test/mapped", _ => Task.CompletedTask, new EndpointMetadata(EndpointName, string.Empty, [], false));
+        _mapper.MapGet("/test/anonymous", _ => Task.CompletedTask);
+    }
+
+    void Because()
+    {
+        _mapped = _mapper.EndpointExists(EndpointName);
+        _mappedWithoutMetadata = _mapper.EndpointExists(string.Empty);
+    }
+
+    [Fact] void should_find_it() => _mapped.ShouldBeTrue();
+    [Fact] void should_not_record_a_name_for_an_endpoint_mapped_without_metadata() => _mappedWithoutMetadata.ShouldBeFalse();
+}

--- a/Source/DotNET/Arc/EndpointRouteBuilderExtensions.cs
+++ b/Source/DotNET/Arc/EndpointRouteBuilderExtensions.cs
@@ -9,13 +9,41 @@ namespace Microsoft.AspNetCore.Routing;
 public static class EndpointRouteBuilderExtensions
 {
     /// <summary>
+    /// Gets the names of every endpoint currently registered that carries an endpoint name.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <returns>The set of endpoint names.</returns>
+    /// <remarks>
+    /// Reading <see cref="EndpointDataSource.Endpoints"/> while the route builder is still being populated does
+    /// not return a cached list - it materializes every endpoint, running the conventions and the request
+    /// delegate factory for each one. That makes this an expensive call, so callers registering many endpoints
+    /// should take the set once and consult it, rather than asking per registration.
+    /// </remarks>
+    public static IReadOnlySet<string> EndpointNames(this IEndpointRouteBuilder endpoints)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var endpoint in endpoints.DataSources.SelectMany(dataSource => dataSource.Endpoints))
+        {
+            if (endpoint.Metadata.GetMetadata<EndpointNameMetadata>()?.EndpointName is { } name)
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
     /// Checks if an endpoint with the specified name already exists.
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="endpointName">The name of the endpoint to check.</param>
     /// <returns>True if the endpoint exists, false otherwise.</returns>
+    /// <remarks>
+    /// Carries the cost described on <see cref="EndpointNames"/> - a single call materializes the whole endpoint
+    /// table. Use <see cref="EndpointNames"/> when checking more than one name.
+    /// </remarks>
     public static bool EndpointExists(this IEndpointRouteBuilder endpoints, string endpointName) =>
-        endpoints.DataSources
-            .SelectMany(ds => ds.Endpoints)
-            .Any(e => e.Metadata.GetMetadata<EndpointNameMetadata>()?.EndpointName == endpointName);
+        endpoints.EndpointNames().Contains(endpointName);
 }

--- a/Source/DotNET/Arc/Http/AspNetCoreEndpointMapper.cs
+++ b/Source/DotNET/Arc/Http/AspNetCoreEndpointMapper.cs
@@ -20,6 +20,21 @@ public class AspNetCoreEndpointMapper(IEndpointRouteBuilder endpoints, string? g
             ? endpoints.MapGroup(string.Empty)
             : endpoints.MapGroup(groupPrefix);
 
+    readonly HashSet<string> _mapped = new(StringComparer.Ordinal);
+    IReadOnlySet<string>? _preExisting;
+
+    /// <summary>
+    /// Gets the names of the endpoints that were already registered when this mapper started mapping.
+    /// </summary>
+    /// <remarks>
+    /// Taken once, on first use, rather than per registration. Asking the route builder is not a lookup - it
+    /// rebuilds the entire endpoint table (see <c>EndpointNames</c>) - so doing it for every endpoint made
+    /// mapping cost grow with the square of the number of commands and queries.
+    /// A mapper is created immediately before the pass that uses it and nothing else registers endpoints during
+    /// that pass, so a single snapshot plus the names this mapper has since added is the same answer.
+    /// </remarks>
+    IReadOnlySet<string> PreExisting => _preExisting ??= endpoints.EndpointNames();
+
     /// <inheritdoc/>
     public void MapGet(string pattern, Func<IHttpRequestContext, Task> handler, EndpointMetadata? metadata = null) =>
         Map("GET", pattern, handler, metadata);
@@ -33,7 +48,7 @@ public class AspNetCoreEndpointMapper(IEndpointRouteBuilder endpoints, string? g
         Map(httpMethod, pattern, handler, metadata);
 
     /// <inheritdoc/>
-    public bool EndpointExists(string name) => endpoints.EndpointExists(name);
+    public bool EndpointExists(string name) => _mapped.Contains(name) || PreExisting.Contains(name);
 
     void Map(string httpMethod, string pattern, Func<IHttpRequestContext, Task> handler, EndpointMetadata? metadata)
     {
@@ -60,6 +75,7 @@ public class AspNetCoreEndpointMapper(IEndpointRouteBuilder endpoints, string? g
         }
 
         builder.WithName(metadata.Name);
+        _mapped.Add(metadata.Name);
 
         if (!string.IsNullOrEmpty(metadata.Summary))
         {


### PR DESCRIPTION
## Fixed

- Applications with many commands and queries now start in a fraction of the time — Arc mapped its generated endpoints in O(n²), rebuilding the entire ASP.NET endpoint table before every single registration. A model-driven host registering ~480 endpoints spent 54 seconds in `UseCratisArc()` on an idle 14-core machine; it is now unmeasurable. Every Arc application pays this on startup, in proportion to how many commands and queries it has (#2591)
