### PR TITLE
Update Arc Screenplay generator to Screenplay 4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.35.3" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.0" />
-    <PackageVersion Include="Cratis.Screenplay" Version="2.1.0" />
+    <PackageVersion Include="Cratis.Screenplay" Version="4.2.1" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />

--- a/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_observing_nothing.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_observing_nothing.cs
@@ -15,7 +15,7 @@ public class a_reactor_observing_nothing : Specification
 {
     ScreenplayDiagnostics _diagnostics;
     ReactorSyntaxBuilder _builder;
-    ReactorSyntax? _result;
+    ReactionSyntax? _result;
 
     void Establish()
     {

--- a/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_without_a_source_file.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ReactorSyntaxBuilder/when_building/a_reactor_without_a_source_file.cs
@@ -17,7 +17,7 @@ public class a_reactor_without_a_source_file : Specification
 {
     ScreenplayDiagnostics _diagnostics;
     ReactorSyntaxBuilder _builder;
-    ReactorSyntax? _result;
+    ReactionSyntax? _result;
 
     void Establish()
     {
@@ -30,6 +30,6 @@ public class a_reactor_without_a_source_file : Specification
         "Library.Lending.Restocking");
 
     [Fact] void should_point_at_the_conventional_path() => _result!.Triggers.Single().File!.Path.ShouldEqual("Lending/Restocking/RestockRequester.cs");
-    [Fact] void should_observe_the_event() => _result!.Triggers.Single().Event.ShouldEqual("BookReserved");
+    [Fact] void should_observe_the_event() => ((NamedTriggerSourceSyntax)_result!.Triggers.Single().Source).Name.ShouldEqual("BookReserved");
     [Fact] void should_report_nothing() => _diagnostics.All.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/an_application_importing_an_event.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/an_application_importing_an_event.cs
@@ -47,7 +47,7 @@ public class an_application_importing_an_event : given.an_emitter
     }
 
     [Fact] void should_declare_the_import() => _emission.Source.Contains("import Partners.Contracts.InvitationToJoinAdaAccepted", StringComparison.Ordinal).ShouldBeTrue();
-    [Fact] void should_still_observe_it_from_the_reactor() => _emission.Source.Contains("on InvitationToJoinAdaAccepted", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_still_observe_it_from_the_reactor() => _emission.Source.Contains("when InvitationToJoinAdaAccepted", StringComparison.Ordinal).ShouldBeTrue();
     [Fact] void should_compile_without_errors() => _roundTrip.Errors.ShouldBeEmpty();
     [Fact] void should_leave_the_language_nothing_to_warn_about() => _roundTrip.Diagnostics.ShouldBeEmpty();
     [Fact] void should_print_the_same_text_on_a_second_pass() => _roundTrip.Reprinted.ShouldEqual(_roundTrip.Printed);

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_projects_of_a_layered_application.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_projects_of_a_layered_application.cs
@@ -48,7 +48,7 @@ public class from_the_projects_of_a_layered_application : Specification
     [Fact] void should_declare_the_event_the_contracts_project_holds() => Says("event OrderPlaced").ShouldBeTrue();
     [Fact] void should_state_what_the_command_produces() => Says("produces OrderPlaced").ShouldBeTrue();
     [Fact] void should_declare_the_slice_only_the_application_project_holds() => Says("query AllOrders").ShouldBeTrue();
-    [Fact] void should_observe_the_event_of_one_project_from_a_reactor_in_the_other() => Says("reactor Dispatcher").ShouldBeTrue();
+    [Fact] void should_observe_the_event_of_one_project_from_a_reactor_in_the_other() => Says("reaction Dispatcher").ShouldBeTrue();
     [Fact] void should_declare_a_concept_both_projects_refer_to_once() => Counted("concept CustomerName : String @pii").ShouldEqual(1);
     [Fact] void should_write_the_path_of_a_file_relative_to_the_directory_the_projects_share() => Says("Library/Shipping/Dispatching/Dispatching.cs").ShouldBeTrue();
     [Fact] void should_import_nothing() => _result.Model.Imports.ShouldBeEmpty();

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_whole_application.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_the_source_of_a_whole_application.cs
@@ -54,7 +54,7 @@ public class from_the_source_of_a_whole_application : Specification
     [Fact] void should_declare_the_constraint() => Says("constraint UniqueAuthorName").ShouldBeTrue();
     [Fact] void should_declare_the_query() => Says("query AllAuthors").ShouldBeTrue();
     [Fact] void should_declare_the_projection() => Says("projection Author").ShouldBeTrue();
-    [Fact] void should_declare_the_reactor() => Says("reactor ReservationNotifier").ShouldBeTrue();
+    [Fact] void should_declare_the_reactor() => Says("reaction ReservationNotifier").ShouldBeTrue();
     [Fact] void should_read_the_reactor_from_the_file_it_lives_in() => Says("Lending/Notifications/Notifications.cs").ShouldBeTrue();
     [Fact] void should_report_nothing_as_unmappable() => _result.Diagnostics.ShouldBeEmpty();
     [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();

--- a/Source/DotNET/Screenplay/Emission/Reactors/ReactorSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Reactors/ReactorSyntaxBuilder.cs
@@ -10,7 +10,7 @@ using Cratis.Screenplay.Syntax;
 namespace Cratis.Arc.Screenplay.Emission.Reactors;
 
 /// <summary>
-/// Builds the Screenplay <c>reactor</c> declaration for a reactor.
+/// Builds the Screenplay <c>reaction</c> declaration for a reactor.
 /// </summary>
 /// <param name="naming">The <see cref="IScreenplayNaming"/> used for name conversion.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
@@ -25,8 +25,8 @@ public class ReactorSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostic
     /// </summary>
     /// <param name="reactor">The reactor to build for.</param>
     /// <param name="namespace">The namespace of the slice the reactor lives in.</param>
-    /// <returns>The <see cref="ReactorSyntax"/>, or <see langword="null"/> when it observes no events.</returns>
-    public ReactorSyntax? Build(ReactorModel reactor, string @namespace)
+    /// <returns>The <see cref="ReactionSyntax"/>, or <see langword="null"/> when it observes no events.</returns>
+    public ReactionSyntax? Build(ReactorModel reactor, string @namespace)
     {
         var name = naming.ToDeclarationName(reactor.Name);
         var path = naming.ToFilePath(reactor.SourceFilePath) ?? SourceFilePaths.Conventional(@namespace, name);
@@ -36,7 +36,12 @@ public class ReactorSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagnostic
             .Select(naming.ToDeclarationName)
             .Where(_ => _.Length > 1)
             .Distinct(StringComparer.Ordinal)
-            .Select(_ => new ReactorTriggerSyntax(_, file, null, SourceLocation.Start))
+            .Select(_ => new ReactionTriggerSyntax(
+                new NamedTriggerSourceSyntax(_, SourceLocation.Start),
+                [],
+                file,
+                null,
+                SourceLocation.Start))
             .ToList();
 
         if (triggers.Count == 0)

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceContent.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceContent.cs
@@ -26,7 +26,7 @@ public static class SliceContent
         !slice.Queries.Any() &&
         !slice.Projections.Any() &&
         !slice.Captures.Any() &&
-        !slice.Reactors.Any() &&
+        !slice.Reactions.Any() &&
         !slice.Screens.Any() &&
         !slice.Constraints.Any() &&
         !slice.Specifications.Any() &&

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
@@ -62,7 +62,7 @@ public class SliceSyntaxBuilder(
             [
                 .. slice.Reactors
                     .Select(_ => reactors.Build(_, slice.Namespace))
-                    .OfType<ReactorSyntax>()
+                    .OfType<ReactionSyntax>()
                     .OrderBy(_ => _.Name, StringComparer.Ordinal)
             ],
             [


### PR DESCRIPTION
# Summary

Moves the Arc source generator onto the current Screenplay language and reaction model, unblocking consumers that also use current Stage/rendering packages.

## Changed

- Generate Screenplay `reaction` declarations and named trigger sources instead of the removed reactor syntax. (#2558)
- Require `Cratis.Screenplay` 4.2.1 and verify generated documents across single- and multi-project Arc applications. (#2558)