### PR TITLE
Support enum parameters in model-bound queries

### DIFF
--- a/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
@@ -55,8 +55,8 @@ public class ModelBoundQueryPerformer : IQueryPerformer
             CustomRoute = pathProperty?.GetValue(pathAttribute) as string;
         }
 
-        _dependencies = performMethod.GetParameters().Where(p => serviceProviderIsService.IsService(p.ParameterType));
-        _queryParameters = performMethod.GetParameters().Where(p => !serviceProviderIsService.IsService(p.ParameterType));
+        _dependencies = performMethod.GetParameters().Where(p => IsDependency(serviceProviderIsService, p));
+        _queryParameters = performMethod.GetParameters().Where(p => !IsDependency(serviceProviderIsService, p));
         Dependencies = _dependencies.Select(p => p.ParameterType);
         Parameters = new(_queryParameters.Select(p => new QueryParameter(p.Name ?? string.Empty, p.ParameterType, !IsNullableOrOptional(p))));
         AllowsAnonymousAccess = performMethod.IsAnonymousAllowed();
@@ -154,6 +154,22 @@ public class ModelBoundQueryPerformer : IQueryPerformer
 
     static bool CanRepresentEmptyString(Type type) =>
         type == typeof(string) || (type.IsConcept() && type.GetConceptValueType() == typeof(string));
+
+    /// <summary>
+    /// Determines whether a parameter is an injected dependency rather than an argument the caller supplies.
+    /// </summary>
+    /// <param name="serviceProviderIsService">Used to ask the container whether the type is a registered service.</param>
+    /// <param name="parameter">The <see cref="ParameterInfo"/> to classify.</param>
+    /// <returns>True when the parameter should be resolved from the container; otherwise false.</returns>
+    /// <remarks>
+    /// Asking the container alone is not sufficient. <c>AddSelfBindings</c> self-registers every discovered concrete
+    /// type, and an enum is concrete - so <c>IsService</c> answers true for it and an enum query argument was
+    /// classified as a dependency, then failed to resolve at request time with a container error naming the enum.
+    /// A value type is never something the caller injects here, so it is excluded before the container is consulted.
+    /// </remarks>
+    static bool IsDependency(IServiceProviderIsService serviceProviderIsService, ParameterInfo parameter) =>
+        !parameter.ParameterType.IsValueType &&
+        serviceProviderIsService.IsService(parameter.ParameterType);
 
     static bool IsNullableOrOptional(ParameterInfo parameter)
     {

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/ReadModels.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/ReadModels.cs
@@ -770,3 +770,89 @@ public class EnumerableParameterReadModel
         });
     }
 }
+
+/// <summary>
+/// A read model with enum query parameters, used to verify an enum survives proxy generation as a query argument.
+/// </summary>
+/// <remarks>
+/// The nullable variant is covered alongside the plain one because the two took different paths through the
+/// generator's parameter classification: a nullable enum already qualified as a query parameter, while a plain one
+/// was classified as an injected dependency and dropped from the proxy entirely.
+/// </remarks>
+[ReadModel]
+public class EnumParameterReadModel
+{
+    /// <summary>
+    /// Gets or sets the ID.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the status.
+    /// </summary>
+    public ReadModelStatus Status { get; set; }
+
+    /// <summary>
+    /// Searches by status.
+    /// </summary>
+    /// <param name="status">The status to filter by.</param>
+    /// <returns>Collection of matching read models.</returns>
+    public static IEnumerable<EnumParameterReadModel> SearchByStatus(ReadModelStatus status)
+    {
+        return
+        [
+            new EnumParameterReadModel { Id = Guid.NewGuid(), Name = $"Item {status}", Status = status }
+        ];
+    }
+
+    /// <summary>
+    /// Searches by status and name.
+    /// </summary>
+    /// <param name="status">The status to filter by.</param>
+    /// <param name="name">The name to filter by.</param>
+    /// <returns>Collection of matching read models.</returns>
+    public static IEnumerable<EnumParameterReadModel> SearchByStatusAndName(ReadModelStatus status, string name)
+    {
+        return
+        [
+            new EnumParameterReadModel { Id = Guid.NewGuid(), Name = name, Status = status }
+        ];
+    }
+
+    /// <summary>
+    /// Searches by status, alongside an injected dependency.
+    /// </summary>
+    /// <param name="status">The status to filter by.</param>
+    /// <param name="dependency">An injected dependency, resolved from the container rather than supplied by the caller.</param>
+    /// <returns>Collection of matching read models.</returns>
+    /// <remarks>
+    /// This is the shape the defect was reported against: an enum argument sitting next to real injected services.
+    /// It is covered separately because the enum and the dependency are classified by the same predicate, so a fix
+    /// that rescues the enum could just as easily start treating the dependency as a caller-supplied argument.
+    /// </remarks>
+    public static IEnumerable<EnumParameterReadModel> SearchByStatusWithDependency(ReadModelStatus status, EnumParameterQueryDependency dependency)
+    {
+        return
+        [
+            new EnumParameterReadModel { Id = Guid.NewGuid(), Name = dependency.Describe(status), Status = status }
+        ];
+    }
+}
+
+/// <summary>
+/// A dependency injected into a query that also takes an enum argument.
+/// </summary>
+public class EnumParameterQueryDependency
+{
+    /// <summary>
+    /// Describes a status.
+    /// </summary>
+    /// <param name="status">The status to describe.</param>
+    /// <returns>The description.</returns>
+    public string Describe(ReadModelStatus status) => $"Resolved {status}";
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_with_enum_parameter_and_checking_url.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_with_enum_parameter_and_checking_url.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound;
+
+/// <summary>
+/// Verifies that an enum query parameter survives proxy generation and reaches the server as a query argument.
+/// </summary>
+/// <remarks>
+/// The defect this pins was not a malformed value but a missing one: an enum parameter was classified as an
+/// injected dependency rather than a query argument, so the proxy had no way to send it at all and the server
+/// saw the enum's default. Asserting the value reaches the URL is what distinguishes those two outcomes.
+/// </remarks>
+[Collection(ScenarioCollectionDefinition.Name)]
+public class when_performing_query_with_enum_parameter_and_checking_url : given.a_scenario_web_application
+{
+    QueryExecutionResult<IEnumerable<EnumParameterReadModel>>? _executionResult;
+
+    void Establish() => LoadQueryProxy<EnumParameterReadModel>("SearchByStatus");
+
+    async Task Because()
+    {
+        var parameters = new Dictionary<string, object>
+        {
+            ["status"] = (int)ReadModelStatus.Active
+        };
+
+        _executionResult = await Bridge.PerformQueryViaProxyAsync<IEnumerable<EnumParameterReadModel>>("SearchByStatus", parameters);
+    }
+
+    [Fact] void should_return_successful_result() => _executionResult.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_include_the_enum_value_in_url() => _executionResult.RequestUrl.ShouldContain($"status={(int)ReadModelStatus.Active}");
+    [Fact] void should_pass_the_enum_value_through_to_the_query() => _executionResult.RawJson.ShouldContain($"Item {nameof(ReadModelStatus.Active)}");
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_with_enum_parameter_and_injected_dependency.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_with_enum_parameter_and_injected_dependency.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound;
+
+/// <summary>
+/// Verifies that an enum argument and an injected dependency on the same query are classified apart from each other.
+/// </summary>
+/// <remarks>
+/// One predicate decides both, so the two failures are mirror images and a fix for either can cause the other: an
+/// enum treated as a dependency is looked up in the container and fails the request, while a dependency treated as
+/// an argument is expected from the caller and never resolved. This is the shape the defect was reported against.
+/// </remarks>
+[Collection(ScenarioCollectionDefinition.Name)]
+public class when_performing_query_with_enum_parameter_and_injected_dependency : given.a_scenario_web_application
+{
+    QueryExecutionResult<IEnumerable<EnumParameterReadModel>>? _executionResult;
+
+    void Establish() => LoadQueryProxy<EnumParameterReadModel>("SearchByStatusWithDependency");
+
+    async Task Because()
+    {
+        var parameters = new Dictionary<string, object>
+        {
+            ["status"] = (int)ReadModelStatus.Archived
+        };
+
+        _executionResult = await Bridge.PerformQueryViaProxyAsync<IEnumerable<EnumParameterReadModel>>("SearchByStatusWithDependency", parameters);
+    }
+
+    [Fact] void should_return_successful_result() => _executionResult.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_include_the_enum_value_in_url() => _executionResult.RequestUrl.ShouldContain($"status={(int)ReadModelStatus.Archived}");
+    [Fact] void should_not_expect_the_dependency_from_the_caller() => _executionResult.RequestUrl.ShouldNotContain("dependency=");
+    [Fact] void should_resolve_the_dependency_and_pass_the_enum_to_it() => _executionResult.RawJson.ShouldContain($"Resolved {nameof(ReadModelStatus.Archived)}");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/ControllerBased/MethodInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ControllerBased/MethodInfoExtensions.cs
@@ -100,14 +100,18 @@ public static class MethodInfoExtensions
     {
         List<PropertyDescriptor> properties = [];
         var parameters = method.GetParameters();
-        var primitives = parameters.Where(_ =>
-            _.ParameterType.IsAPrimitiveType() ||
-            _.ParameterType.IsConcept() ||
-            _.ParameterType.IsEnumerableOfPrimitiveOrConcept());
-        var complex = parameters.Where(_ =>
-            !_.ParameterType.IsAPrimitiveType() &&
-            !_.ParameterType.IsConcept() &&
-            !_.ParameterType.IsEnumerableOfPrimitiveOrConcept());
+
+        // The two predicates are exact complements on purpose - a parameter this classifies as complex has its own
+        // properties flattened into the request, so a type missing from the simple side is not skipped, it is
+        // expanded into its members. An enum expanded that way emits its static fields as request properties.
+        static bool IsSimple(ParameterInfo parameter) =>
+            parameter.ParameterType.IsAPrimitiveType() ||
+            parameter.ParameterType.IsConcept() ||
+            parameter.ParameterType.IsEnum ||
+            parameter.ParameterType.IsEnumerableOfPrimitiveOrConcept();
+
+        var primitives = parameters.Where(IsSimple);
+        var complex = parameters.Where(_ => !IsSimple(_));
 
         properties.AddRange(primitives.ToList().ConvertAll(_ => _.ToPropertyDescriptor()));
 

--- a/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
@@ -232,9 +232,16 @@ public static class QueryExtensions
     /// </summary>
     /// <param name="parameter">The <see cref="ParameterInfo"/> to check.</param>
     /// <returns>True when the parameter is a query argument; otherwise false.</returns>
+    /// <remarks>
+    /// Enums are included explicitly. Everything this predicate rejects is assumed to be an injected dependency, so an
+    /// omission here does not merely skip a parameter - it silently reclassifies a caller-supplied argument as a
+    /// dependency, and the generated proxy has no way to pass it. A nullable enum already qualified by way of
+    /// <c>IsNullable</c>, which made <c>Status?</c> work while <c>Status</c> did not.
+    /// </remarks>
     static bool IsQueryParameter(ParameterInfo parameter) =>
         parameter.ParameterType.IsAPrimitiveType() ||
         parameter.ParameterType.IsConcept() ||
+        parameter.ParameterType.IsEnum ||
         parameter.ParameterType.IsEnumerableOfPrimitiveOrConcept();
 
     /// <summary>


### PR DESCRIPTION
## Fixed

- Model-bound queries now keep enum arguments in generated proxies and bind them from callers instead of attempting dependency resolution (#2595)