### PR TITLE
Fix observable query subscription reliability

### DIFF
--- a/.ai/agents/coordinator.md
+++ b/.ai/agents/coordinator.md
@@ -1,19 +1,19 @@
 ---
 name: Coordinator
 description: >
-  General-purpose coordinator agent for Cratis-based projects.
-  Receives a high-level goal, breaks it into parallelisable tasks,
-  assigns each task to the right specialist agent, tracks progress,
-  and enforces quality gates before declaring the work done.
-  Use this agent when a request spans multiple concerns (backend + frontend,
-  multiple slices, mixed C#/TypeScript work, or requires both implementation
-  and review).
+    General-purpose coordinator agent for Cratis-based projects.
+    Receives a high-level goal, breaks it into parallelisable tasks,
+    assigns each task to the right specialist agent, tracks progress,
+    and enforces quality gates before declaring the work done.
+    Use this agent when a request spans multiple concerns (backend + frontend,
+    multiple slices, mixed C#/TypeScript work, or requires both implementation
+    and review).
 model: claude-sonnet-4-5
 tools:
-  - githubRepo
-  - codeSearch
-  - usages
-  - terminalLastCommand
+    - githubRepo
+    - codeSearch
+    - usages
+    - terminalLastCommand
 ---
 
 # Coordinator
@@ -22,20 +22,21 @@ You are the **Coordinator** for Cratis-based projects.
 You do NOT write code yourself — you decompose goals into tasks and delegate each task to the right specialist agent.
 
 Always read and follow:
-- `.github/copilot-instructions.md`
-- `.github/instructions/vertical-slices.instructions.md`
+
+- `.ai/rules/general.md`
+- `.ai/rules/vertical-slices.md`
 
 ---
 
 ## Available specialist agents
 
-| Agent | Handles |
-|---|---|
-| `backend-developer` | C# slice files — commands, events, validators, constraints, projections, reactors |
-| `frontend-developer` | React/TypeScript components, composition pages, routing |
-| `spec-writer` | Integration specs (C#) and unit specs (TypeScript) |
-| `code-reviewer` | Architecture conformance, C# and TypeScript standards, review checklist |
-| `security-reviewer` | Security vulnerabilities, injection, auth/authz, data exposure |
+| Agent                  | Handles                                                                                |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| `backend-developer`    | C# slice files — commands, events, validators, constraints, projections, reactors      |
+| `frontend-developer`   | React/TypeScript components, composition pages, routing                                |
+| `spec-writer`          | Integration specs (C#) and unit specs (TypeScript)                                     |
+| `code-reviewer`        | Architecture conformance, C# and TypeScript standards, review checklist                |
+| `security-reviewer`    | Security vulnerabilities, injection, auth/authz, data exposure                         |
 | `performance-reviewer` | Chronicle projections, MongoDB query patterns, .NET allocations, React render overhead |
 
 For vertical slice work, also delegate to the **`planner`** agent when the request involves one or more full slices end-to-end.
@@ -72,19 +73,24 @@ When you receive a goal:
 ## Coordinator Plan: <goal summary>
 
 ### Phase 1 — <description> [can run in parallel]
+
 - [ ] [<agent>] <task description>
 - [ ] [<agent>] <task description>
 
 ### Phase 2 — <description> (depends on Phase 1)
+
 - [ ] [<agent>] <task description>
 
 ### Phase 3 — Build
+
 - [ ] Run `dotnet build` — must succeed before any Phase 4 work
 
 ### Phase 4 — <description> [can run in parallel]
+
 - [ ] [<agent>] <task description>
 
 ### Phase 5 — Quality Gates
+
 - [ ] [code-reviewer] Review all changed files
 - [ ] [security-reviewer] Security review of all changed files
 ```
@@ -133,16 +139,20 @@ Always output a plan before starting any delegation:
 ## Coordinator Plan: <goal>
 
 ### Phase 1 — Backend [parallel]
+
 - [ ] [backend-developer] <task>
 
 ### Phase 2 — Build
+
 - [ ] `dotnet build`
 
 ### Phase 3 — Frontend + Specs [parallel]
+
 - [ ] [frontend-developer] <task>
 - [ ] [spec-writer] <task>
 
 ### Phase 4 — Quality Gates
+
 - [ ] [code-reviewer] Review all changed files
 - [ ] [security-reviewer] Security review
 ```

--- a/.ai/agents/orchestrator.md
+++ b/.ai/agents/orchestrator.md
@@ -1,19 +1,19 @@
 ---
 name: Orchestrator
 description: >
-  Top-level team orchestrator for Cratis-based projects.
-  Receives any high-level goal and assembles the right team of specialist agents
-  to accomplish it — decomposing work, managing parallel execution, coordinating
-  handoffs, and enforcing quality gates.
-  Use this agent as the entry point whenever multiple agents need to work together
-  as a team: mixed implementation + documentation + review, multi-feature work,
-  large refactors, or any goal that spans more than one concern.
+    Top-level team orchestrator for Cratis-based projects.
+    Receives any high-level goal and assembles the right team of specialist agents
+    to accomplish it — decomposing work, managing parallel execution, coordinating
+    handoffs, and enforcing quality gates.
+    Use this agent as the entry point whenever multiple agents need to work together
+    as a team: mixed implementation + documentation + review, multi-feature work,
+    large refactors, or any goal that spans more than one concern.
 model: claude-sonnet-4-5
 tools:
-  - githubRepo
-  - codeSearch
-  - usages
-  - terminalLastCommand
+    - githubRepo
+    - codeSearch
+    - usages
+    - terminalLastCommand
 ---
 
 # Orchestrator
@@ -23,34 +23,35 @@ You are the **top-level team manager** — the entry point for any complex goal 
 You do NOT write code or documentation yourself — you assemble the right team, sequence their work, and ensure nothing falls through the cracks.
 
 Always read and follow:
-- `.github/copilot-instructions.md`
-- `.github/instructions/vertical-slices.instructions.md`
+
+- `.ai/rules/general.md`
+- `.ai/rules/vertical-slices.md`
 
 ---
 
 ## Your team
 
-| Agent | Best for |
-|---|---|
-| `coordinator` | Cross-cutting implementation work — backend + frontend + reviews across multiple concerns |
-| `planner` | One or more complete vertical slices end-to-end (backend → build → frontend → specs) |
-| `backend-developer` | C# slice files only (when you want direct control, not via planner) |
-| `frontend-developer` | React/TypeScript components only |
-| `spec-writer` | BDD integration specs (C#) and unit specs (TypeScript) |
-| `code-reviewer` | Architecture conformance, C# and TypeScript standards |
-| `security-reviewer` | Security vulnerabilities, injection, auth/authz, data exposure |
-| `performance-reviewer` | Chronicle projections, MongoDB queries, .NET allocations, React overhead |
+| Agent                  | Best for                                                                                  |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `coordinator`          | Cross-cutting implementation work — backend + frontend + reviews across multiple concerns |
+| `planner`              | One or more complete vertical slices end-to-end (backend → build → frontend → specs)      |
+| `backend-developer`    | C# slice files only (when you want direct control, not via planner)                       |
+| `frontend-developer`   | React/TypeScript components only                                                          |
+| `spec-writer`          | BDD integration specs (C#) and unit specs (TypeScript)                                    |
+| `code-reviewer`        | Architecture conformance, C# and TypeScript standards                                     |
+| `security-reviewer`    | Security vulnerabilities, injection, auth/authz, data exposure                            |
+| `performance-reviewer` | Chronicle projections, MongoDB queries, .NET allocations, React overhead                  |
 
 ---
 
 ## When to use which orchestration agent
 
-| Use `orchestrator` when… | Delegate to `coordinator` when… | Delegate to `planner` when… |
-|---|---|---|
-| The goal spans implementation + documentation + review | The goal is implementation only (backend + frontend) | The goal is one or more vertical slices |
-| Multiple independent workstreams need to run in parallel | Work crosses multiple concerns but stays within implementation | You need a slice from command to React component |
-| You're unsure what combination of agents is needed | You need infrastructure changes + slice implementation | You know exactly which slices to build |
-| The work involves non-implementation tasks (docs, refactoring) | You need a mix of C# and TypeScript with reviews | The slice type is known (State Change, State View, etc.) |
+| Use `orchestrator` when…                                       | Delegate to `coordinator` when…                                | Delegate to `planner` when…                              |
+| -------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------- |
+| The goal spans implementation + documentation + review         | The goal is implementation only (backend + frontend)           | The goal is one or more vertical slices                  |
+| Multiple independent workstreams need to run in parallel       | Work crosses multiple concerns but stays within implementation | You need a slice from command to React component         |
+| You're unsure what combination of agents is needed             | You need infrastructure changes + slice implementation         | You know exactly which slices to build                   |
+| The work involves non-implementation tasks (docs, refactoring) | You need a mix of C# and TypeScript with reviews               | The slice type is known (State Change, State View, etc.) |
 
 ---
 
@@ -86,21 +87,26 @@ When you receive a goal:
 ## Orchestration Plan: <goal summary>
 
 ### Phase 1 — <description> [can run in parallel]
+
 - [ ] [<agent>] <stream description>
 - [ ] [<agent>] <stream description>
 
 ### Phase 2 — Build synchronisation point
+
 - [ ] Run `dotnet build` — must succeed before Phase 3
 
 ### Phase 3 — <description> [can run in parallel]
+
 - [ ] [<agent>] <stream description>
 - [ ] [<agent>] <stream description>
 
 ### Phase 4 — Quality Gates [run in parallel]
+
 - [ ] [code-reviewer] Review all changed files
 - [ ] [security-reviewer] Security review of all changed files
 
 ### Phase 5 — Documentation (if applicable)
+
 - [ ] [write-documentation skill] Document <feature/concept>
 ```
 
@@ -151,16 +157,20 @@ Always output a plan **before** starting any delegation:
 ## Orchestration Plan: <goal>
 
 ### Phase 1 — <phase name> [parallel / sequential]
+
 - [ ] [<agent>] <task>
 
 ### Phase 2 — Build
+
 - [ ] `dotnet build`
 
 ### Phase 3 — <phase name> [parallel]
+
 - [ ] [<agent>] <task>
 - [ ] [<agent>] <task>
 
 ### Phase 4 — Quality Gates
+
 - [ ] [code-reviewer] Review all changed files
 - [ ] [security-reviewer] Security review
 ```
@@ -171,12 +181,15 @@ After each phase completes, output a progress update:
 ## Progress update
 
 ### ✅ Completed
+
 - Phase 1: <what was done>
 
 ### 🔄 In progress
+
 - Phase 2: <what is running now>
 
 ### ⏳ Remaining
+
 - Phase 3: <what is next>
 ```
 

--- a/.ai/agents/performance-reviewer.md
+++ b/.ai/agents/performance-reviewer.md
@@ -1,15 +1,15 @@
 ---
 name: Performance Reviewer
 description: >
-  Performance-focused review agent for Cratis-based projects. Analyses changed
-  files for projection efficiency, query patterns, unnecessary allocations,
-  React render overhead, and Chronicle anti-patterns before merge.
+    Performance-focused review agent for Cratis-based projects. Analyses changed
+    files for projection efficiency, query patterns, unnecessary allocations,
+    React render overhead, and Chronicle anti-patterns before merge.
 model: claude-sonnet-4-5
 tools:
-  - githubRepo
-  - codeSearch
-  - usages
-  - terminalLastCommand
+    - githubRepo
+    - codeSearch
+    - usages
+    - terminalLastCommand
 ---
 
 # Performance Reviewer
@@ -23,7 +23,7 @@ Your responsibility is to identify performance problems in changed code before t
 
 ### Chronicle / Event Sourcing
 
-- [ ] Projections use `.AutoMap()` — avoids manual field mapping cost
+- [ ] Projections rely on automatic mapping by default and avoid redundant manual field mapping
 - [ ] Projections do NOT perform joins on the read model (Chronicle re-hydrates from events; joining on the model forces a full re-read)
 - [ ] Reactors do NOT re-query the event log inside their `On()` handler — use event data directly
 - [ ] No eager loading of entire event logs or event sequences without paging/filtering
@@ -65,25 +65,27 @@ Your responsibility is to identify performance problems in changed code before t
 
 ## Risk classification
 
-| Label | Meaning |
-|-------|---------|
-| 🔴 High | Will cause measurable degradation at moderate load — must fix before merge |
-| 🟡 Medium | Could degrade under load or at scale — should fix soon |
-| 🟢 Low | Minor inefficiency or style issue — fix when convenient |
+| Label     | Meaning                                                                    |
+| --------- | -------------------------------------------------------------------------- |
+| 🔴 High   | Will cause measurable degradation at moderate load — must fix before merge |
+| 🟡 Medium | Could degrade under load or at scale — should fix soon                     |
+| 🟢 Low    | Minor inefficiency or style issue — fix when convenient                    |
 
 ---
 
 ## Output format
 
 Start with a **summary**:
+
 > **Performance Review: ✅ No issues / ⚠️ Minor findings / ❌ Blocking issues found**
 
 Group findings by category:
 
-```
+```markdown
 ### MongoDB / Read Models
 
 🟡 **Medium** — `Features/Projects/Listing/AllProjects.cs`
+
 > The query does not specify a sort order or index hint, which will result in a
 > collection scan once the `projects` collection grows.
 > Fix: Add `.SortBy(m => m.Name)` and ensure an index on `Name` exists in the
@@ -92,10 +94,10 @@ Group findings by category:
 
 End with a summary table:
 
-| Category | Status |
-|----------|--------|
-| Chronicle / Event Sourcing | ✅ / ⚠️ / ❌ |
-| MongoDB / Read Models | ✅ / ⚠️ / ❌ |
+| Category                          | Status       |
+| --------------------------------- | ------------ |
+| Chronicle / Event Sourcing        | ✅ / ⚠️ / ❌ |
+| MongoDB / Read Models             | ✅ / ⚠️ / ❌ |
 | ASP.NET Core / Commands & Queries | ✅ / ⚠️ / ❌ |
-| React / TypeScript | ✅ / ⚠️ / ❌ |
-| General .NET | ✅ / ⚠️ / ❌ |
+| React / TypeScript                | ✅ / ⚠️ / ❌ |
+| General .NET                      | ✅ / ⚠️ / ❌ |

--- a/.ai/agents/planner.md
+++ b/.ai/agents/planner.md
@@ -1,16 +1,16 @@
 ---
 name: Vertical Slice Planner
 description: >
-  Orchestrates the implementation of one or more vertical slices.
-  Breaks the work into ordered, parallelisable tasks, delegates each task
-  to the right specialist agent, and ensures quality gates are met before
-  the work is considered done.
+    Orchestrates the implementation of one or more vertical slices.
+    Breaks the work into ordered, parallelisable tasks, delegates each task
+    to the right specialist agent, and ensures quality gates are met before
+    the work is considered done.
 model: claude-sonnet-4-5
 tools:
-  - githubRepo
-  - codeSearch
-  - usages
-  - terminalLastCommand
+    - githubRepo
+    - codeSearch
+    - usages
+    - terminalLastCommand
 ---
 
 # Vertical Slice Planner
@@ -20,8 +20,9 @@ Your responsibility is to **plan, sequence, and coordinate** the implementation 
 You do NOT write code yourself — you decompose the work and delegate it.
 
 Always read and follow:
-- `.github/instructions/vertical-slices.instructions.md`
-- `.github/copilot-instructions.md`
+
+- `.ai/rules/vertical-slices.md`
+- `.ai/rules/general.md`
 
 ---
 
@@ -41,24 +42,29 @@ Extract the following from their request:
 
 For each slice, produce a numbered task list using this template:
 
-```
-## Plan for <Feature> / <Slice>  (Type: <SliceType>)
+```markdown
+## Plan for <Feature> / <Slice> (Type: <SliceType>)
 
-### Phase 1 — Backend  [delegate to: backend-developer]
-1. Create `Features/<Feature>/<Slice>/<Slice>.cs` with ALL artifacts
+### Phase 1 — Backend [delegate to: backend-developer]
 
-### Phase 2 — Specs  [delegate to: spec-writer]  (State Change slices only)
-2. Write integration specs in `Features/<Feature>/<Slice>/when_<behavior>/`
+1. Create `<AppSourceRoot>/<Module>/<Feature>/<Slice>/<Slice>.cs` with ALL artifacts (`<Module>` is optional)
 
-### Phase 3 — Build  [run: dotnet build]
+### Phase 2 — Specs [delegate to: spec-writer] (State Change slices only)
+
+2. Write specs in `<AppSourceRoot>/<Module>/<Feature>/<Slice>/when_<behavior>/`
+
+### Phase 3 — Build [run: dotnet build]
+
 3. Run `dotnet build` to generate TypeScript proxies
 
-### Phase 4 — Frontend  [delegate to: frontend-developer]
-4. Create React component(s) in `Features/<Feature>/<Slice>/`
-5. Register component in the composition page `Features/<Feature>/<Feature>.tsx`
+### Phase 4 — Frontend [delegate to: frontend-developer]
+
+4. Create React component(s) in `<AppSourceRoot>/<Module>/<Feature>/<Slice>/`
+5. Register component in the composition page `<AppSourceRoot>/<Module>/<Feature>/<Feature>.tsx`
 6. Update routing if this slice introduces a new page
 
-### Phase 5 — Quality Gates  [delegate to: code-reviewer, then security-reviewer]
+### Phase 5 — Quality Gates [delegate to: code-reviewer, then security-reviewer]
+
 7. Code review
 8. Security review
 ```
@@ -80,7 +86,7 @@ For each slice, produce a numbered task list using this template:
 When handing off to a specialist:
 
 1. State exactly which files need to be created or modified.
-2. Quote the relevant section of `vertical-slices.instructions.md` that applies.
+2. Quote the relevant section of `.ai/rules/vertical-slices.md` that applies.
 3. State the acceptance criteria (what "done" looks like for this task).
 4. Tell the specialist which agent to hand back to when finished.
 
@@ -106,6 +112,7 @@ A slice is **not done** until:
 ## Session management
 
 For large features with many slices, use these techniques to keep context manageable:
+
 - **`/compact`** after completing each phase to free context space. Add focus notes: `/compact focus on remaining slices and unresolved issues`.
 - **`/fork`** before exploring an alternative design approach, so the original plan is preserved.
 - The **Explore subagent** automatically handles codebase research on a fast model — let it work rather than doing manual searches.

--- a/.ai/prompts/code-review.md
+++ b/.ai/prompts/code-review.md
@@ -1,4 +1,0 @@
-# Code Review Prompt
-
-Review the proposed change for correctness, maintainability, and security.
-Focus on actionable findings and minimize false positives.

--- a/.ai/prompts/new-feature.md
+++ b/.ai/prompts/new-feature.md
@@ -1,4 +1,0 @@
-# New Feature Prompt
-
-Implement the requested feature as a vertical slice with minimal, focused changes.
-Add or update tests for behavior changes and validate build/test before completion.

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_body_read_fails_without_request_abort.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_body_read_fails_without_request_abort.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_body_read_fails_without_request_abort : given.an_observable_query_demultiplexer
+{
+    IHttpRequestContext _context;
+    Exception? _error;
+
+    void Establish()
+    {
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(CancellationToken.None);
+        _context.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<object?>(new IOException("The request body ended unexpectedly.")));
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _hub.HandleSSESubscribe(_context));
+
+    [Fact] void should_propagate_the_body_read_error() => _error.ShouldBeOfExactType<IOException>();
+    [Fact] void should_not_set_a_status_code() => _context.DidNotReceiveWithAnyArgs().SetStatusCode(default);
+
+    [Fact]
+    void should_not_perform_a_query() =>
+        _queryPipeline.DidNotReceiveWithAnyArgs().Perform(
+            default!,
+            default!,
+            default!,
+            default!,
+            default!);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_body_read_is_aborted.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_body_read_is_aborted.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_body_read_is_aborted : given.an_observable_query_demultiplexer
+{
+    IHttpRequestContext _context;
+    Exception? _error;
+
+    void Establish()
+    {
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(new CancellationToken(canceled: true));
+        _context.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<object?>(new IOException("The request body ended unexpectedly.")));
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _hub.HandleSSESubscribe(_context));
+
+    [Fact] void should_return_cleanly() => _error.ShouldBeNull();
+    [Fact] void should_not_set_a_status_code() => _context.DidNotReceiveWithAnyArgs().SetStatusCode(default);
+
+    [Fact]
+    void should_not_perform_a_query() =>
+        _queryPipeline.DidNotReceiveWithAnyArgs().Perform(
+            default!,
+            default!,
+            default!,
+            default!,
+            default!);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_get_context_is_disposed_while_query_is_performed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_get_context_is_disposed_while_query_is_performed.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_get_context_is_disposed_while_query_is_performed : given.a_guarded_connection
+{
+    readonly ClaimsPrincipal _postPrincipal = new(new ClaimsIdentity([new Claim(ClaimTypes.Name, "fresh-caller")], "test"));
+    readonly ConcurrentQueue<string> _messages = [];
+    readonly TaskCompletionSource<QueryResult> _performCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    readonly TaskCompletionSource _performStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    readonly CancellationTokenSource _connectionCancellation = new();
+    IHttpRequestContext _authorizationContext;
+    IHttpRequestContext _connectionContext;
+    IHttpRequestContext _subscribeContext;
+    string _connectionId;
+    bool _getContextDisposed;
+    int _getUserReads;
+    int _getUserWrites;
+    int _subscribeStatusCode;
+
+    void Establish()
+    {
+        _connectionId = string.Empty;
+
+        _queryPipeline.Perform(
+                Arg.Any<FullyQualifiedQueryName>(),
+                Arg.Any<QueryArguments>(),
+                Arg.Any<Paging>(),
+                Arg.Any<Sorting>(),
+                Arg.Any<IServiceProvider>())
+            .Returns(_ =>
+            {
+                _authorizationContext = _httpRequestContextAccessor.Current;
+                _performStarted.TrySetResult();
+                return _performCompletion.Task;
+            });
+
+        _connectionContext = Substitute.For<IHttpRequestContext>();
+        _connectionContext.RequestAborted.Returns(_connectionCancellation.Token);
+        _connectionContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _connectionContext.User.Returns(_ =>
+        {
+            _getUserReads++;
+            ObjectDisposedException.ThrowIf(_getContextDisposed, _connectionContext);
+
+            return new ClaimsPrincipal();
+        });
+        _connectionContext.When(_ => _.User = Arg.Any<ClaimsPrincipal>())
+            .Do(_ =>
+            {
+                _getUserWrites++;
+                ObjectDisposedException.ThrowIf(_getContextDisposed, _connectionContext);
+            });
+        _connectionContext.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _messages.Enqueue(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        _subscribeContext = Substitute.For<IHttpRequestContext>();
+        _subscribeContext.Headers.Returns(new Dictionary<string, string>());
+        _subscribeContext.RequestAborted.Returns(CancellationToken.None);
+        _subscribeContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _subscribeContext.User.Returns(_postPrincipal);
+        _subscribeContext.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<object?>(new ObservableQuerySSESubscribeRequest(
+                _connectionId,
+                FirstQueryId,
+                new ObservableQuerySubscriptionRequest(QueryName))));
+        _subscribeContext.When(_ => _.SetStatusCode(Arg.Any<int>()))
+            .Do(callInfo => _subscribeStatusCode = callInfo.Arg<int>());
+    }
+
+    async Task Because()
+    {
+        var connectionTask = _hub.HandleSSEConnection(_connectionContext);
+        await WaitFor(() => TryExtractConnectionId(out _connectionId));
+
+        try
+        {
+            var subscribeTask = _hub.HandleSSESubscribe(_subscribeContext);
+            await _performStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            _getContextDisposed = true;
+            var queryResult = QueryResult.Success(CorrelationId.New());
+            queryResult.Data = _subject;
+            _performCompletion.TrySetResult(queryResult);
+
+            await subscribeTask;
+            _subject.OnNext(["event-store-a"]);
+            await WaitFor(() => _guardCalls.Count == 1);
+        }
+        finally
+        {
+            await _connectionCancellation.CancelAsync();
+            await connectionTask;
+        }
+    }
+
+    [Fact] void should_complete_the_subscribe() => _subscribeStatusCode.ShouldEqual(200);
+    [Fact] void should_authorize_with_the_post_context() => _authorizationContext.ShouldEqual(_subscribeContext);
+    [Fact] void should_not_read_user_from_the_get_context() => _getUserReads.ShouldEqual(0);
+    [Fact] void should_not_write_user_to_the_get_context() => _getUserWrites.ShouldEqual(0);
+    [Fact] void should_consult_the_emission_guard() => _guardCalls.Count.ShouldEqual(1);
+    [Fact] void should_give_the_emission_guard_the_post_principal() => _guardCalls.Single().Principal.ShouldEqual(_postPrincipal);
+
+    bool TryExtractConnectionId(out string connectionId)
+    {
+        connectionId = string.Empty;
+
+        foreach (var hubMessage in _messages.Select(TryParseHubMessage).Where(_ => _ is not null).Select(_ => _!))
+        {
+            if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
+            {
+                continue;
+            }
+
+            connectionId = payload.GetString() ?? string.Empty;
+            return !string.IsNullOrEmpty(connectionId);
+        }
+
+        return false;
+    }
+
+    ObservableQueryHubMessage? TryParseHubMessage(string sseMessage)
+    {
+        if (!sseMessage.StartsWith("data: ", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var json = sseMessage["data: ".Length..].Trim();
+        return JsonSerializer.Deserialize<ObservableQueryHubMessage>(json, _arcOptions.Value.JsonSerializerOptions);
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_malformed_body_read_fails_when_request_is_aborted.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_malformed_body_read_fails_when_request_is_aborted.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_malformed_body_read_fails_when_request_is_aborted : given.an_observable_query_demultiplexer
+{
+    IHttpRequestContext _context;
+    Exception? _error;
+
+    void Establish()
+    {
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(new CancellationToken(canceled: true));
+        _context.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<object?>(new JsonException("The request body is malformed.")));
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _hub.HandleSSESubscribe(_context));
+
+    [Fact] void should_propagate_the_malformed_body_error() => _error.ShouldBeOfExactType<JsonException>();
+    [Fact] void should_not_set_a_status_code() => _context.DidNotReceiveWithAnyArgs().SetStatusCode(default);
+
+    [Fact]
+    void should_not_perform_a_query() =>
+        _queryPipeline.DidNotReceiveWithAnyArgs().Perform(
+            default!,
+            default!,
+            default!,
+            default!,
+            default!);
+}

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.WebSockets;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
+using System.Security.Claims;
 using System.Text.Json;
 using Cratis.Arc.Http;
 using Cratis.DependencyInjection;
@@ -197,8 +198,22 @@ public class ObservableQueryDemultiplexer(
     /// <inheritdoc/>
     public async Task HandleSSESubscribe(IHttpRequestContext context)
     {
-        if (await context.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), context.RequestAborted)
-            is not ObservableQuerySSESubscribeRequest body
+        ObservableQuerySSESubscribeRequest? body;
+        try
+        {
+            body = await context.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), context.RequestAborted)
+                as ObservableQuerySSESubscribeRequest;
+        }
+        catch (Exception ex) when (
+            context.RequestAborted.IsCancellationRequested &&
+            ex is OperationCanceledException or IOException)
+        {
+            // The subscribe POST ended while its body was being read. There is no response left to write and no
+            // subscription work to perform. Malformed JSON and unrelated failures deliberately continue to escape.
+            return;
+        }
+
+        if (body is null
             || string.IsNullOrEmpty(body.ConnectionId)
             || string.IsNullOrEmpty(body.QueryId)
             || body.Request is null)
@@ -214,12 +229,12 @@ public class ObservableQueryDemultiplexer(
             return;
         }
 
-        // The subscribe POST carries the latest cookies and headers, which the middleware
-        // already authenticated. Transfer the principal to the SSE connection context so the
-        // authorization pipeline sees the current identity — not the one from when the SSE
-        // GET was originally established (which may have been anonymous).
-        state.Context.User = context.User;
-        httpRequestContextAccessor.Current = state.Context;
+        // The subscribe POST carries the latest cookies and headers, which the middleware already authenticated.
+        // Keep its principal independently from the retained SSE GET context: the GET may be disposed while the query
+        // pipeline is awaiting, and writing the principal through it makes that lifetime race observable. The active
+        // POST remains the ambient context for subscription-time authorization; emissions restore the GET context.
+        var principal = context.User;
+        httpRequestContextAccessor.Current = context;
 
         logger.ClientSubscribed(body.Request.QueryName, body.QueryId);
 
@@ -234,6 +249,7 @@ public class ObservableQueryDemultiplexer(
 
         var subscription = await CreateSubscription(
             state.Context,
+            principal,
             body.QueryId,
             body.Request,
             async result =>
@@ -505,6 +521,7 @@ public class ObservableQueryDemultiplexer(
 
         var subscription = await CreateSubscription(
             context,
+            context.User,
             queryId,
             request,
             async result =>
@@ -586,6 +603,7 @@ public class ObservableQueryDemultiplexer(
 
     async Task<IDisposable?> CreateSubscription(
         IHttpRequestContext context,
+        ClaimsPrincipal principal,
         string queryId,
         ObservableQuerySubscriptionRequest request,
         Func<QueryResult, Task> onNext,
@@ -646,7 +664,7 @@ public class ObservableQueryDemultiplexer(
         var identity = new ObservableQuerySubscriptionIdentity(
             fullyQualifiedName,
             performedQueryContext?.Arguments ?? arguments,
-            context.User);
+            principal);
 
         return SubscribeToStreamingData(context, streamingData, queryId, queryResult.Paging, request.TransferMode, queryResult.CorrelationId, identity, onNext, onError, onUnauthorized, token);
     }

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeCalendarObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeCalendarObservableQuery.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ObservableQueryFor, type QueryResult, type ObservableQuerySubscription, type OnNextResult } from '@cratis/arc/queries';
+import type { ParameterDescriptor } from '@cratis/arc/reflection';
+import { DateOnly, field, TimeOnly } from '@cratis/fundamentals';
+
+export class FakeCalendarChild {
+    @field(DateOnly)
+    date!: DateOnly;
+
+    @field(TimeOnly)
+    time!: TimeOnly;
+}
+
+export class FakeCalendarItem {
+    @field(FakeCalendarChild, true)
+    children!: FakeCalendarChild[];
+}
+
+export type CalendarSubscribeCallback = OnNextResult<QueryResult<FakeCalendarItem[]>>;
+
+export class FakeCalendarObservableQuery extends ObservableQueryFor<FakeCalendarItem[], Record<string, unknown>> {
+    readonly route = '/api/fake-calendar-observable-query';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    defaultValue: FakeCalendarItem[] = [];
+
+    constructor() {
+        super(FakeCalendarItem, true);
+    }
+
+    static subscribeCallbacks: CalendarSubscribeCallback[] = [];
+    static subscriptionReturned: ObservableQuerySubscription<FakeCalendarItem[]>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    subscribe(callback: CalendarSubscribeCallback, _queryArguments?: Record<string, unknown>): ObservableQuerySubscription<FakeCalendarItem[]> {
+        FakeCalendarObservableQuery.subscribeCallbacks.push(callback);
+        // SAFETY: The test double implements the unsubscribe behavior exercised by the hook.
+        FakeCalendarObservableQuery.subscriptionReturned = {
+            unsubscribe: () => {}
+        } as unknown as ObservableQuerySubscription<FakeCalendarItem[]>;
+        return FakeCalendarObservableQuery.subscriptionReturned;
+    }
+
+    static reset() {
+        FakeCalendarObservableQuery.subscribeCallbacks = [];
+    }
+}

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_an_already_deserialized_model_has_a_calendar_collection.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_an_already_deserialized_model_has_a_calendar_collection.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { DateOnly, TimeOnly } from '@cratis/fundamentals';
+import { QueryInstanceCache, type QueryResult, type QueryResultWithState } from '@cratis/arc/queries';
+import { useObservableQuery } from '../useObservableQuery';
+import { FakeCalendarChild, FakeCalendarItem, FakeCalendarObservableQuery } from './FakeCalendarObservableQuery';
+import { type ArcConfiguration, ArcContext } from '../../ArcContext';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+describe('when an already deserialized model has a calendar collection', () => {
+    let calendarDate: DateOnly;
+    let calendarTime: TimeOnly;
+    let capturedResult: QueryResultWithState<FakeCalendarItem[]> | undefined;
+    let cachedResult: QueryResultWithState<FakeCalendarItem[]> | undefined;
+
+    beforeEach(async () => {
+        FakeCalendarObservableQuery.reset();
+        calendarDate = DateOnly.from(2026, 2, 3);
+        calendarTime = TimeOnly.from(14, 15, 16);
+        capturedResult = undefined;
+        cachedResult = undefined;
+
+        const queryCache = new QueryInstanceCache();
+        const configuration: ArcConfiguration = {
+            microservice: 'test-microservice',
+            apiBasePath: '/api',
+            origin: 'https://example.com',
+        };
+
+        const TestComponent = () => {
+            const [result] = useObservableQuery<FakeCalendarItem[], FakeCalendarObservableQuery>(FakeCalendarObservableQuery);
+            capturedResult = result;
+            return React.createElement('div', null, 'Test');
+        };
+
+        render(
+            React.createElement(
+                QueryInstanceCacheContext.Provider,
+                { value: queryCache },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: configuration },
+                    React.createElement(TestComponent)
+                )
+            )
+        );
+
+        const child = new FakeCalendarChild();
+        child.date = calendarDate;
+        child.time = calendarTime;
+        const item = new FakeCalendarItem();
+        item.children = [child];
+        const callback = FakeCalendarObservableQuery.subscribeCallbacks[0];
+
+        await act(async () => {
+            // SAFETY: The test payload implements the query-result contract while preserving live model instances.
+            callback({
+                data: [item],
+                isSuccess: true,
+                isAuthorized: true,
+                isValid: true,
+                hasExceptions: false,
+                validationResults: [],
+                exceptionMessages: [],
+                exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 1, totalPages: 1 }
+            } as unknown as QueryResult<FakeCalendarItem[]>);
+        });
+
+        const cacheKey = queryCache.buildKey(FakeCalendarObservableQuery.name);
+        cachedResult = queryCache.getLastResult<FakeCalendarItem[]>(cacheKey);
+    });
+
+    it('should emit the live child date', () => capturedResult!.data[0].children[0].date.should.equal(calendarDate));
+    it('should emit the live child time', () => capturedResult!.data[0].children[0].time.should.equal(calendarTime));
+    it('should cache the live child date', () => cachedResult!.data[0].children[0].date.should.equal(calendarDate));
+    it('should cache the live child time', () => cachedResult!.data[0].children[0].time.should.equal(calendarTime));
+});

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_items_are_removed_as_delta/and_item_is_identified_by_a_guid.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_items_are_removed_as_delta/and_item_is_identified_by_a_guid.ts
@@ -49,7 +49,7 @@ describe('when items are removed as delta and item is identified by a guid', () 
         const callback = FakeGuidObservableQuery.subscribeCallbacks[0];
 
         await act(async () => {
-            callback({
+            callback(new QueryResult({
                 data: [
                     { id: firstId.toString(), name: 'First' },
                     { id: secondId.toString(), name: 'Second' },
@@ -62,14 +62,15 @@ describe('when items are removed as delta and item is identified by a guid', () 
                 exceptionMessages: [],
                 exceptionStackTrace: '',
                 paging: { page: 0, size: 0, totalItems: 2, totalPages: 1 }
-            } as unknown as QueryResult<FakeGuidItem[]>);
+            }, FakeGuidItem, true));
         });
 
         capturedResult!.data.length.should.equal(2);
-        capturedResult!.data[0].id.equals(firstId).should.be.true;
-        capturedResult!.data[1].id.equals(secondId).should.be.true;
+        capturedResult!.data[0].id.equals(firstId).should.equal(true);
+        capturedResult!.data[1].id.equals(secondId).should.equal(true);
 
         await act(async () => {
+            // SAFETY: Delta entries remain in their wire shape because ObservableQueryFor only deserializes response data.
             callback({
                 data: [],
                 isSuccess: true,
@@ -89,6 +90,6 @@ describe('when items are removed as delta and item is identified by a guid', () 
         });
 
         capturedResult!.data.length.should.equal(1);
-        capturedResult!.data[0].id.equals(secondId).should.be.true;
+        capturedResult!.data[0].id.equals(secondId).should.equal(true);
     });
 });

--- a/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { QueryResultWithState, IObservableQueryFor, Sorting, Paging, ChangeSet, isPrimitiveModelType } from '@cratis/arc/queries';
-import { Constructor, JsonSerializer } from '@cratis/fundamentals';
+import { QueryResultWithState, type IObservableQueryFor, Sorting, Paging, type ChangeSet, isPrimitiveModelType } from '@cratis/arc/queries';
+import { type Constructor, JsonSerializer } from '@cratis/fundamentals';
 import { useState, useEffect, useContext, useRef, useMemo } from 'react';
-import { SetSorting } from './SetSorting';
-import { SetPage } from './SetPage';
-import { SetPageSize } from './SetPageSize';
+import type { SetSorting } from './SetSorting';
+import type { SetPage } from './SetPage';
+import type { SetPageSize } from './SetPageSize';
 import { ArcContext } from '../ArcContext';
 import { QueryInstanceCacheContext } from './QueryInstanceCacheContext';
 import { serializeArgsForDependency } from './serializeArgsForDependency';
@@ -19,9 +19,11 @@ import { useQueryScope } from './useQueryScope';
  * server-side {@code ChangeSetComputor}). Without an identity property, JSON-string equality
  * is used as a fallback (additions and removals only — no replacements).
  */
+type ItemIdentity = string | number | boolean | bigint | symbol | object | null | undefined;
+
 function applyChangeSet<T>(previous: T[], changeSet: ChangeSet<unknown>): T[] {
-    const getId = (item: unknown): unknown => (item as Record<string, unknown>)?.id;
-    const toIdentityValue = (id: unknown): unknown => {
+    const getId = (item: unknown): ItemIdentity => (item as Record<string, ItemIdentity>)?.id;
+    const toIdentityValue = (id: ItemIdentity): ItemIdentity => {
         if (id === null || id === undefined) {
             return id;
         }
@@ -37,7 +39,7 @@ function applyChangeSet<T>(previous: T[], changeSet: ChangeSet<unknown>): T[] {
         return id;
     };
 
-    const idsEqual = (left: unknown, right: unknown): boolean => {
+    const idsEqual = (left: ItemIdentity, right: ItemIdentity): boolean => {
         if (left === right) {
             return true;
         }
@@ -71,7 +73,7 @@ function applyChangeSet<T>(previous: T[], changeSet: ChangeSet<unknown>): T[] {
 
         result = result.map(item => {
             const replacement = changeSet.replaced.find(candidate => idsEqual(getId(candidate), getId(item)));
-            return replacement !== undefined ? replacement : item;
+            return replacement === undefined ? item : replacement;
         });
     } else {
         const removedJsons = new Set(changeSet.removed.map(item => JSON.stringify(item)));
@@ -113,23 +115,13 @@ function deserializeChangeSet(changeSet: ChangeSet<unknown>, modelType: Construc
     };
 }
 
-function deserializeResponseData<TDataType>(data: unknown, modelType: Constructor | null): TDataType {
-    // Non-array payloads (null, undefined, a single value) are passed through untouched.
-    if (!Array.isArray(data)) {
-        return data as TDataType;
-    }
-
-    return deserializeItems(modelType, data) as TDataType;
-}
-
-function hasAllRequiredArguments(requiredRequestParameters: string[], args?: object): boolean {
+function hasAllRequiredArguments(requiredRequestParameters: string[], args?: Record<string, unknown>): boolean {
     if (requiredRequestParameters.length === 0) {
         return true;
     }
 
-    const argumentValues = args as Record<string, unknown> | undefined;
     return requiredRequestParameters.every(requiredRequestParameter => {
-        const value = argumentValues?.[requiredRequestParameter];
+        const value = args?.[requiredRequestParameter];
         return value !== undefined && value !== null && value !== '';
     });
 }
@@ -186,7 +178,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
         listenerRef.current = (r: QueryResultWithState<TDataType>) => setResult(r);
     }
 
-    const hasAllRequiredArgumentsSet = hasAllRequiredArguments(queryInstance.requiredRequestParameters, args as object | undefined);
+    const hasAllRequiredArgumentsSet = hasAllRequiredArguments(queryInstance.requiredRequestParameters, args as Record<string, unknown> | undefined);
 
     // Use all arg values (not just required ones) because the cache key includes every arg.
     // Also include arc context values so the effect re-runs and cleans up the old subscription
@@ -224,13 +216,18 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
 
             const subscription = queryInstance.subscribe(response => {
                 let withState: QueryResultWithState<TDataType>;
-                const modelType = (queryInstance as unknown as { modelType?: Constructor }).modelType ?? null;
+                // SAFETY: Observable query implementations expose this runtime metadata even though the interface omits it.
+                const queryMetadata = queryInstance as unknown as { modelType?: Constructor; enumerable: boolean; queryName?: string };
+                const modelType = queryMetadata.modelType ?? null;
 
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const isDataArray = Array.isArray(response.data);
-                const isEnumerable = (queryInstance as unknown as { enumerable: boolean }).enumerable;
-                if (isEnumerable && !isDataArray && response.data !== null && response.data !== undefined && (response.data as unknown as object) !== null) {
-                    console.error(`[useObservableQuery] NON-ARRAY data received for key="${key}" queryName="${(queryInstance as unknown as {queryName?: string}).queryName}" data type=${typeof response.data} constructor=${(response.data as unknown as {constructor?: {name?: string}})?.constructor?.name}`, response.data);
+                const responseData: unknown = response.data;
+                const isDataArray = Array.isArray(responseData);
+                const isEnumerable = queryMetadata.enumerable;
+                if (isEnumerable && !isDataArray && responseData !== null && responseData !== undefined) {
+                    const responseDataConstructor = typeof responseData === 'object'
+                        ? (responseData as { constructor?: { name?: string } }).constructor?.name
+                        : undefined;
+                    console.error(`[useObservableQuery] NON-ARRAY data received for key="${key}" queryName="${queryMetadata.queryName}" data type=${typeof responseData} constructor=${responseDataConstructor}`, responseData);
                 }
 
                 if (response.changeSet && Array.isArray(response.data) && response.data.length === 0) {
@@ -254,10 +251,9 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
                             deserializedChangeSet
                         );
                     } else {
-                        // Fallback if there's no previous result
-                        const deserializedData = deserializeResponseData<TDataType>(response.data, modelType);
+                        // Fallback if there's no previous result. ObservableQueryFor has already deserialized response.data.
                         withState = new QueryResultWithState<TDataType>(
-                            deserializedData,
+                            response.data,
                             response.paging,
                             response.isSuccess,
                             response.isAuthorized,
@@ -270,10 +266,9 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
                             response.changeSet);
                     }
                 } else {
-                    // Initial response or full-data responses (non-delta mode)
-                    const deserializedData = deserializeResponseData<TDataType>(response.data, modelType);
+                    // ObservableQueryFor deserializes initial and full response data before invoking this callback.
                     withState = new QueryResultWithState<TDataType>(
-                        deserializedData,
+                        response.data,
                         response.paging,
                         response.isSuccess,
                         response.isAuthorized,

--- a/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { IObservableQueryFor, OnNextResult } from './IObservableQueryFor';
+import type { IObservableQueryFor, OnNextResult } from './IObservableQueryFor';
 import { ObservableQuerySubscription } from './ObservableQuerySubscription';
 import { ValidateRequestArguments } from './ValidateRequestArguments';
-import { QueryValidator } from './QueryValidator';
-import { IObservableQueryConnection } from './IObservableQueryConnection';
+import type { QueryValidator } from './QueryValidator';
+import type { IObservableQueryConnection } from './IObservableQueryConnection';
 import { NullObservableQueryConnection } from './NullObservableQueryConnection';
 import { createObservableQueryConnection } from './ObservableQueryConnectionFactory';
-import { Constructor } from '@cratis/fundamentals';
+import type { Constructor } from '@cratis/fundamentals';
 import { deserializeQueryModel, deserializeQueryModels } from './deserializeQueryModel';
 import { QueryResult } from './QueryResult';
 import { Sorting } from './Sorting';
@@ -16,10 +16,10 @@ import { Paging } from './Paging';
 import { SortDirection } from './SortDirection';
 import { Globals } from '../Globals';
 import { UrlHelpers } from '../UrlHelpers';
-import { GetHttpHeaders } from '../GetHttpHeaders';
-import { ParameterDescriptor } from '../reflection/ParameterDescriptor';
+import type { GetHttpHeaders } from '../GetHttpHeaders';
+import type { ParameterDescriptor } from '../reflection/ParameterDescriptor';
 import { ParametersHelper } from '../reflection/ParametersHelper';
-import { QueryHttpMethod } from './QueryHttpMethod';
+import type { QueryHttpMethod } from './QueryHttpMethod';
 import { executeQueryHttpRequest } from './QueryHttpRequest';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -106,9 +106,7 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
             this._connection = new NullObservableQueryConnection(
                 this.defaultValue,
                 QueryResult.validationFailed(clientValidationErrors, this));
-        } else if (!this.validateArguments(args)) {
-            this._connection = new NullObservableQueryConnection(this.defaultValue);
-        } else {
+        } else if (this.validateArguments(args)) {
             this._connection = createObservableQueryConnection({
                 route: this.route,
                 queryName: this.queryName ?? this.constructor.name,
@@ -117,6 +115,8 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
                 microservice: this._microservice,
                 args: args as object,
             });
+        } else {
+            this._connection = new NullObservableQueryConnection(this.defaultValue);
         }
 
         // Descriptor-backed instance properties provide defaults; fresh args passed to subscribe()

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/given/TestQueries.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/given/TestQueries.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ObservableQueryFor } from '../../ObservableQueryFor';
-import { Constructor } from '@cratis/fundamentals';
+import { Constructor, DateOnly, field, TimeOnly } from '@cratis/fundamentals';
 import { ParameterDescriptor } from '../../../reflection/ParameterDescriptor';
 
 export class TestObservableQuery extends ObservableQueryFor<string, { id: string }> {
@@ -34,6 +34,35 @@ export class TestEnumerableQuery extends ObservableQueryFor<string[], { category
 
     constructor() {
         super(String as Constructor, true);
+    }
+}
+
+export class TestCalendarChild {
+    @field(DateOnly)
+    date!: DateOnly;
+
+    @field(TimeOnly)
+    time!: TimeOnly;
+}
+
+export class TestCalendarItem {
+    @field(TestCalendarChild, true)
+    children!: TestCalendarChild[];
+}
+
+export class TestCalendarEnumerableQuery extends ObservableQueryFor<TestCalendarItem[], { category: string }> {
+    readonly route = '/api/calendar-items/{category}';
+    readonly defaultValue: TestCalendarItem[] = [];
+    readonly parameterDescriptors: ParameterDescriptor[] = [
+        new ParameterDescriptor('category', String as Constructor)
+    ];
+
+    get requiredRequestParameters(): string[] {
+        return ['category'];
+    }
+
+    constructor() {
+        super(TestCalendarItem, true);
     }
 }
 

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/given/an_observable_query_for.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/given/an_observable_query_for.ts
@@ -4,6 +4,7 @@
 import {
     TestObservableQuery,
     TestEnumerableQuery,
+    TestCalendarEnumerableQuery,
     TestObservableQueryWithParameterDescriptorValues,
     TestObservableQueryWithRouteAndQueryArgs,
     TestObservableQueryWithMultipleRequiredParameters
@@ -12,6 +13,7 @@ import {
 export class an_observable_query_for {
     query: TestObservableQuery;
     enumerableQuery: TestEnumerableQuery;
+    calendarEnumerableQuery: TestCalendarEnumerableQuery;
     queryWithParameterDescriptorValues: TestObservableQueryWithParameterDescriptorValues;
     queryWithRouteAndQueryArgs: TestObservableQueryWithRouteAndQueryArgs;
     queryWithMultipleRequiredParameters: TestObservableQueryWithMultipleRequiredParameters;
@@ -19,6 +21,7 @@ export class an_observable_query_for {
     constructor() {
         this.query = new TestObservableQuery();
         this.enumerableQuery = new TestEnumerableQuery();
+        this.calendarEnumerableQuery = new TestCalendarEnumerableQuery();
         this.queryWithParameterDescriptorValues = new TestObservableQueryWithParameterDescriptorValues();
         this.queryWithRouteAndQueryArgs = new TestObservableQueryWithRouteAndQueryArgs();
         this.queryWithMultipleRequiredParameters = new TestObservableQueryWithMultipleRequiredParameters();

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_receiving_a_result/and_the_model_has_a_calendar_collection.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_receiving_a_result/and_the_model_has_a_calendar_collection.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as sinon from 'sinon';
+import { DateOnly, TimeOnly } from '@cratis/fundamentals';
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import type { TestCalendarItem } from '../given/TestQueries';
+import { given } from '../../../given';
+import { Globals } from '../../../Globals';
+import type { EventSourceFactory } from '../../../EventSourceFactory';
+import type { QueryResult } from '../../QueryResult';
+import { QueryTransportMethod } from '../../QueryTransportMethod';
+import type { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+
+interface FakeEventSource {
+    onmessage: ((event: MessageEvent) => void) | null;
+    onerror: (() => void) | null;
+    close: sinon.SinonStub;
+}
+
+describe('and the model has a calendar collection', given(an_observable_query_for, context => {
+    let subscription: ObservableQuerySubscription<TestCalendarItem[]>;
+    let fakeEventSource: FakeEventSource;
+    let received: QueryResult<TestCalendarItem[]>[];
+    let originalQueryDirectMode: boolean;
+    let originalTransportMethod: QueryTransportMethod;
+    let originalFactory: EventSourceFactory | undefined;
+
+    beforeEach(() => {
+        originalQueryDirectMode = Globals.queryDirectMode;
+        originalTransportMethod = Globals.queryTransportMethod;
+        originalFactory = Globals.eventSourceFactory;
+
+        Globals.queryDirectMode = true;
+        Globals.queryTransportMethod = QueryTransportMethod.ServerSentEvents;
+
+        fakeEventSource = { onmessage: null, onerror: null, close: sinon.stub() };
+        // SAFETY: The test double implements the EventSource members exercised by the query connection.
+        Globals.eventSourceFactory = (() => fakeEventSource) as unknown as EventSourceFactory;
+
+        context.calendarEnumerableQuery.setOrigin('https://example.com');
+
+        received = [];
+        subscription = context.calendarEnumerableQuery.subscribe(
+            result => received.push(result),
+            { category: 'test-category' });
+
+        fakeEventSource.onmessage!({
+            data: JSON.stringify({
+                data: [{ children: [{ date: '2026-02-03', time: '14:15:16' }] }],
+                isSuccess: true,
+                isAuthorized: true,
+                isValid: true,
+                hasExceptions: false,
+                validationResults: [],
+                exceptionMessages: [],
+                exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 1, totalPages: 1 }
+            })
+        } as MessageEvent);
+    });
+
+    afterEach(() => {
+        subscription?.unsubscribe();
+        Globals.queryDirectMode = originalQueryDirectMode;
+        Globals.queryTransportMethod = originalTransportMethod;
+        Globals.eventSourceFactory = originalFactory;
+        sinon.restore();
+    });
+
+    it('should deliver the result to the subscriber', () => received.length.should.equal(1));
+    it('should deserialize the child date', () => received[0].data[0].children[0].date.should.be.instanceOf(DateOnly));
+    it('should preserve the child date', () => received[0].data[0].children[0].date.equals(DateOnly.from(2026, 2, 3)).should.be.true);
+    it('should deserialize the child time', () => received[0].data[0].children[0].time.should.be.instanceOf(TimeOnly));
+    it('should preserve the child time', () => received[0].data[0].children[0].time.equals(TimeOnly.from(14, 15, 16)).should.be.true);
+}));


### PR DESCRIPTION
# Summary

Improve observable-query reliability across server subscription lifetimes and client model handling, while restoring the repository AI corpus quality gate.

## Fixed

- Prevented SSE subscriptions from reading disposed request contexts when clients disconnect mid-subscribe. (#2568)
- Prevented React observable-query hooks from deserializing already converted models a second time. (#2567)
- Restored AI corpus validation by removing obsolete prompt stubs and refreshing canonical rule guidance.
