### PR TITLE
Add neutral Arc specification facts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,10 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.35.3" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.0" />
-    <PackageVersion Include="Cratis.Screenplay" Version="4.2.1" />
+    <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.10.1" />
+    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.10.1" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.10.1" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
@@ -67,21 +70,21 @@
          Cratis.Arc.Core.Generators) are shipped as Roslyn components, so a consumer whose .NET SDK ships
          an older compiler than this cannot load them and gets CS9057 — silently losing proxy generation
          and all ARC*/ARCCHR* analyzer coverage.
-         5.6.0 requires .NET SDK 10.0.301+ (SDK 10.0.2xx ships Roslyn 5.3.0, 10.0.1xx ships 5.0.0).
+         5.9.0 requires .NET SDK 10.0.400+ (older SDK feature bands ship older Roslyn hosts).
          Raising this floor is a MINOR change and must be stated in the release notes — never slip it in
          on a patch. See the SDK requirement in README.md. -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <!-- Reading a real project into a compilation, for the end to end check on Screenplay generation.
          Microsoft.Build.Framework is declared above and is referenced with ExcludeAssets="runtime", so that MSBuild
          itself always comes from the SDK that MSBuildLocator registers rather than from an output folder. -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.8.2" />
     <!-- Override vulnerable/incompatible transitive dependencies from analyzer testing packages -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.9.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Composition" Version="1.0.31" />
     <!-- Analysis -->

--- a/Documentation/generating-a-screenplay.md
+++ b/Documentation/generating-a-screenplay.md
@@ -182,7 +182,7 @@ slice StateChange Registration
 
 Both shapes Arc documents are read: the in-process one driving the pipeline through a scenario (`Scenario.Given…`, `Scenario.Execute`) and the one driving a running host (`EventLog.Append`, `Client.ExecuteCommand`). Which calls are which is decided by the type each one sits on, so neither testing package has to be referenced for either to be read.
 
-A rejection the source asserts without naming a reason is written as `then error ""`. The grammar requires a string there, the source gives none, and inventing one would put a sentence in the document the application never states. [Cratis/Screenplay#46](https://github.com/Cratis/Screenplay/issues/46) proposes a bare `then error` for exactly this.
+A rejection the source asserts without naming a reason is written as bare `then error`. The source gives no code or presentation message, and inventing either would put meaning in the document the application never states.
 
 Expect the document to grow. On a real application this roughly doubled it, at about seven lines per scenario.
 
@@ -196,7 +196,15 @@ A step need not construct what it states where it is written. A specification ro
 
 One hop, and only from one place. A member given a value twice, or given it under a condition, held different values in different runs and the source does not say which one the step saw — so it stays unread and the scenario is left out with `SP0039`, the same as any other conditional step. Following a chain would mean reasoning about what a value was at the moment the step ran, which is a different discipline from reading what was written.
 
-Values are the exception, because a value stands on its own the way a mapping does. They follow [the discipline every other value follows](#a-value-is-only-ever-what-the-source-states): the identity two steps agree on is routinely a fresh identifier held in a field rather than something written down, and such a value is reported on its own while the rest of the scenario stands.
+Values are the exception for the compatibility document generator, because a value stands on its own the way a mapping does. They follow [the discipline every other value follows](#a-value-is-only-ever-what-the-source-states): the identity two steps agree on is routinely a fresh identifier held in a field rather than something written down, and such a value is reported on its own while the rest of the legacy scenario stands.
+
+### Neutral specification facts are stricter
+
+`ArcSpecificationFactAdapter` is the independently consumable source-evidence surface. It contributes Generation scenario, ordered-step, and typed-value facts only when every explicitly authored step and value is exact. One computed or unreadable required value, conditional/repeated step, unretained read-model assertion, or event predicate value blocks the whole neutral scenario with `ARCSP0001`; it never contributes a smaller example than the source wrote.
+
+The adapter retains scenario-, step-, value-, and rejection-level source ranges separately from the existing Arc model. This does not change legacy model equality or the current `.play` generator's compatibility output. Generation resolves the neutral facts by stable source identity, attaches the scenario through the exact target artifact placement, and lowers it only after complete atomic admission.
+
+This distinction is deliberate: the compatibility generator keeps existing consumers stable, while the neutral adapter provides the fail-closed evidence required for render→recover semantic fidelity.
 
 ## Screens
 

--- a/Source/DotNET/Screenplay.Specs/Screenplay.Specs.csproj
+++ b/Source/DotNET/Screenplay.Specs/Screenplay.Specs.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
         <!-- The shared spec global usings pull in Cratis.Types, which the package under specification does not need. -->
         <PackageReference Include="Cratis.Fundamentals" />
+        <PackageReference Include="Cratis.Screenplay.Generation" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     </ItemGroup>
 

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_expecting_a_rejection.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_expecting_a_rejection.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
 using Cratis.Arc.Screenplay.Model;
 
 namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
@@ -89,5 +90,7 @@ public class a_specification_expecting_a_rejection : Specification
     [Fact] void should_expect_no_event_alongside_a_rejection() => _named.Then.ShouldBeEmpty();
     [Fact] void should_state_a_rejection_the_source_names_no_reason_for() => _unnamed.Errors.ShouldContainOnly([string.Empty]);
     [Fact] void should_state_two_ways_of_saying_the_same_rejection_once() => _unnamed.Errors.Count().ShouldEqual(1);
+    [Fact] void should_retain_rejection_step_evidence() => SpecificationEvidence.For(_named).Errors.Single().IsInSource.ShouldBeTrue();
+    [Fact] void should_retain_unnamed_rejection_step_evidence() => SpecificationEvidence.For(_unnamed).Errors.Single().IsInSource.ShouldBeTrue();
     [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_read_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_read_model.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
 using Cratis.Arc.Screenplay.Model;
 
 namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
@@ -89,6 +90,8 @@ public class a_specification_of_a_read_model : Specification
     [Fact] void should_issue_no_command() => _specification.When.ShouldBeNull();
     [Fact] void should_say_the_read_model_followed() => _specification.Then.Single().Name.ShouldEqual("Author");
     [Fact] void should_state_it_as_a_read_model() => _specification.Then.Single().Kind.ShouldEqual(SpecificationStateKind.ReadModel);
+    [Fact] void should_retain_the_exact_read_model_symbol() => SpecificationEvidence.For(_specification).States[_specification.Then.Single()].Artifact.Name.ShouldEqual("Author");
+    [Fact] void should_retain_read_model_step_evidence() => SpecificationEvidence.For(_specification).States[_specification.Then.Single()].Source.IsInSource.ShouldBeTrue();
     [Fact] void should_report_no_scenario_left_out() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.UnreadableSpecification).ShouldBeFalse();
     [Fact] void should_report_no_scenario_without_a_counterpart() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.ScenarioWithoutCounterpart).ShouldBeFalse();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_slice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_slice.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
 using Cratis.Arc.Screenplay.Model;
 
 namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
@@ -87,5 +88,12 @@ public class a_specification_of_a_slice : Specification
     [Fact] void should_state_the_values_the_command_was_issued_with() => _specification.When.Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Mary Shelley")), new PropertyMappingModel("Age", new LiteralSource(42))]);
     [Fact] void should_expect_the_event_the_assertion_names() => _specification.Then.Single().Name.ShouldEqual("AuthorRegistered");
     [Fact] void should_expect_no_rejection() => _specification.Errors.ShouldBeEmpty();
+    [Fact] void should_retain_the_exact_scenario_type() => Evidence().SourceType.Name.ShouldEqual("and_the_author_is_new");
+    [Fact] void should_retain_the_exact_command_symbol() => Evidence().States[_specification.When].Artifact.Name.ShouldEqual("RegisterAuthor");
+    [Fact] void should_retain_step_level_source_evidence() => Evidence().States.Values.All(step => step.Source.IsInSource).ShouldBeTrue();
+    [Fact] void should_retain_value_level_source_evidence() => Evidence().Values.Values.All(source => source.IsInSource).ShouldBeTrue();
+    [Fact] void should_have_no_neutral_fact_blockers() => Evidence().Blockers.ShouldBeEmpty();
     [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+
+    SpecificationScenarioEvidence Evidence() => SpecificationEvidence.For(_specification)!;
 }

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
@@ -47,6 +47,7 @@ public class when_analyzing_an_exact_rejection_scenario : Specification
 
     AdapterContribution _contribution = null!;
     ResolvedApplicationGraph _graph = null!;
+    ScreenplayLoweringResult _lowering = null!;
     bool _canAnalyze;
 
     void Because()
@@ -70,6 +71,7 @@ public class when_analyzing_an_exact_rejection_scenario : Specification
             context,
             new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
         _graph = new GenerationResolver().Resolve([_contribution]);
+        _lowering = new ScreenplayLowerer().Lower(_graph, "Projects");
     }
 
     [Fact] void should_recognize_the_scenario() => _canAnalyze.ShouldBeTrue();
@@ -83,4 +85,10 @@ public class when_analyzing_an_exact_rejection_scenario : Specification
     [Fact] void should_preserve_the_empty_name_value() => _graph.Specifications.Single().Steps.SelectMany(step => step.Values).Single().Definition.Scalar.ShouldEqual(string.Empty);
     [Fact] void should_preserve_the_rejected_outcome() => _graph.Specifications.Single().Steps.Single(step => step.Definition.Kind == SpecificationStepKind.Error).Definition.ErrorMessage.ShouldBeNull();
     [Fact] void should_preserve_step_level_source_evidence() => _graph.Specifications.Single().Steps.All(step => step.Evidence.Single().Source is not null).ShouldBeTrue();
+    [Fact] void should_lower_without_diagnostics() => _lowering.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_lower_the_exact_command_value() => ((Cratis.Screenplay.Syntax.LiteralExpressionSyntax)Lowered().When!.Values.Single().Source).Value.ShouldEqual(string.Empty);
+    [Fact] void should_lower_the_bare_rejection_without_inventing_a_message() => Lowered().ThenErrors.Single().Name.ShouldBeNull();
+
+    Cratis.Screenplay.Syntax.Specifications.SpecificationSyntax Lowered() =>
+        _lowering.Application.Modules.Single().Features.Single().Slices.Single().Specifications.Single();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_analyzing_an_exact_rejection_scenario : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [Command]
+        public record RegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_rejecting_an_empty_project_name;
+
+        public class when_rejecting_an_empty_project_name
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterProject(""));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+    ResolvedApplicationGraph _graph = null!;
+    bool _canAnalyze;
+
+    void Because()
+    {
+        var compilation = Analyzed.Compile(
+        [
+            ("Projects/Registration/RegisterProject/RegisterProject.cs", Slice),
+            ("Projects/Registration/RegisterProject/when_rejecting_an_empty_project_name.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        ]);
+        var project = new DotNetProjectCompilation
+        {
+            Name = "Projects",
+            Compilation = compilation,
+            AuthoredSyntaxTrees = compilation.SyntaxTrees.ToHashSet()
+        };
+        var context = new DotNetAnalysisContext([project]);
+        var adapter = new ArcSpecificationFactAdapter();
+        _canAnalyze = adapter.CanAnalyze(context);
+        _contribution = adapter.Analyze(
+            context,
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+        _graph = new GenerationResolver().Resolve([_contribution]);
+    }
+
+    [Fact] void should_recognize_the_scenario() => _canAnalyze.ShouldBeTrue();
+    [Fact] void should_have_no_adapter_diagnostics() => _contribution.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_contribute_one_scenario_fact() => _contribution.Facts.OfType<SpecificationScenarioFact>().Count().ShouldEqual(1);
+    [Fact] void should_contribute_the_when_and_error_steps() => _contribution.Facts.OfType<SpecificationStepFact>().Count().ShouldEqual(2);
+    [Fact] void should_contribute_the_exact_empty_value() => _contribution.Facts.OfType<SpecificationValueFact>().Single().Definition.Scalar.ShouldEqual(string.Empty);
+    [Fact] void should_contribute_one_atomic_scenario() => _graph.Specifications.Count.ShouldEqual(1);
+    [Fact] void should_attach_the_scenario_to_the_exact_slice() => _graph.Specifications.Single().Placement.Slice.ShouldEqual("RegisterProject");
+    [Fact] void should_preserve_the_when_command() => _graph.Specifications.Single().Steps.Single(step => step.Definition.Phase == SpecificationStepPhase.When).Definition.Kind.ShouldEqual(SpecificationStepKind.Command);
+    [Fact] void should_preserve_the_empty_name_value() => _graph.Specifications.Single().Steps.SelectMany(step => step.Values).Single().Definition.Scalar.ShouldEqual(string.Empty);
+    [Fact] void should_preserve_the_rejected_outcome() => _graph.Specifications.Single().Steps.Single(step => step.Definition.Kind == SpecificationStepKind.Error).Definition.ErrorMessage.ShouldBeNull();
+    [Fact] void should_preserve_step_level_source_evidence() => _graph.Specifications.Single().Steps.All(step => step.Evidence.Single().Source is not null).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_event_predicate_values.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_event_predicate_values.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_analyzing_event_predicate_values : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [Command]
+        public record RegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Testing.Commands;
+        using Cratis.Arc.Testing.Commands;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_registering;
+
+        public class when_registering
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+
+            async Task Because() => await _scenario.Execute(new RegisterProject("Screenplay"));
+
+            [Fact] Task should_append() => _scenario.ShouldHaveAppendedEvent<RegisterProject, ProjectRegistered>(
+                "project",
+                @event => @event.Name == "Screenplay");
+        }
+        """;
+
+    const string Assertions = """
+        using System;
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Events;
+
+        namespace Cratis.Arc.Chronicle.Testing.Commands;
+
+        public static class Assertions
+        {
+            public static Task ShouldHaveAppendedEvent<TCommand, TEvent>(
+                this CommandScenario<TCommand> scenario,
+                EventSourceId eventSourceId,
+                Func<TEvent, bool> predicate) => Task.CompletedTask;
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because()
+    {
+        var compilation = Analyzed.Compile(
+        [
+            ("Projects/Registration/RegisterProject/RegisterProject.cs", Slice),
+            ("Projects/Registration/RegisterProject/when_registering.cs", Scenario),
+            ("Integration/Assertions.cs", Assertions),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        ]);
+        var project = new DotNetProjectCompilation
+        {
+            Name = "Projects",
+            Compilation = compilation,
+            AuthoredSyntaxTrees = compilation.SyntaxTrees.ToHashSet()
+        };
+        _contribution = new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    [Fact] void should_contribute_no_partial_scenario() => _contribution.Facts.OfType<SpecificationScenarioFact>().ShouldBeEmpty();
+    [Fact] void should_report_the_unrepresented_predicate_values() => _contribution.Diagnostics.Single().Code.ShouldEqual("ARCSP0001");
+    [Fact] void should_retain_the_scenario_source() => _contribution.Diagnostics.Single().Source!.Path.ShouldEqual("Projects/Registration/RegisterProject/when_registering.cs");
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationDraft.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationDraft.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
 
 namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 
@@ -16,6 +17,10 @@ namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 /// </remarks>
 public class SpecificationDraft
 {
+    readonly List<Location> _errorEvidence = [];
+    readonly Dictionary<SpecificationStateModel, SpecificationStateEvidence> _stateEvidence = new(ReferenceEqualityComparer.Instance);
+    readonly Dictionary<PropertyMappingModel, Location> _valueEvidence = new(ReferenceEqualityComparer.Instance);
+
     /// <summary>
     /// Gets what had already happened when the command was issued.
     /// </summary>
@@ -42,8 +47,80 @@ public class SpecificationDraft
     public string? Unreadable { get; private set; }
 
     /// <summary>
-    /// Records why the scenario cannot be read.
+    /// Records why a scenario cannot be read.
     /// </summary>
     /// <param name="reason">What made it unreadable.</param>
     public void CannotRead(string reason) => Unreadable ??= reason;
+
+    /// <summary>
+    /// Gets exact rejection assertion locations.
+    /// </summary>
+    /// <returns>The ordered rejection evidence.</returns>
+    internal IReadOnlyList<Location> GetErrorEvidence() => _errorEvidence;
+
+    /// <summary>
+    /// Gets exact state-step evidence by legacy model reference.
+    /// </summary>
+    /// <returns>The state evidence map.</returns>
+    internal IReadOnlyDictionary<SpecificationStateModel, SpecificationStateEvidence> GetStateEvidence() => _stateEvidence;
+
+    /// <summary>
+    /// Gets exact value evidence by legacy model reference.
+    /// </summary>
+    /// <returns>The value evidence map.</returns>
+    internal IReadOnlyDictionary<PropertyMappingModel, Location> GetValueEvidence() => _valueEvidence;
+
+    /// <summary>
+    /// Adds one Given state and its exact evidence.
+    /// </summary>
+    /// <param name="state">The recovered legacy state.</param>
+    /// <param name="artifact">The exact referenced artifact.</param>
+    /// <param name="source">The exact authored step location.</param>
+    internal void AddGiven(SpecificationStateModel state, ITypeSymbol artifact, Location source)
+    {
+        Given.Add(state);
+        _stateEvidence.Add(state, new(artifact, source));
+    }
+
+    /// <summary>
+    /// Adds one Then state and its exact evidence.
+    /// </summary>
+    /// <param name="state">The recovered legacy state.</param>
+    /// <param name="artifact">The exact referenced artifact.</param>
+    /// <param name="source">The exact authored step location.</param>
+    internal void AddThen(SpecificationStateModel state, ITypeSymbol artifact, Location source)
+    {
+        Then.Add(state);
+        _stateEvidence.Add(state, new(artifact, source));
+    }
+
+    /// <summary>
+    /// Sets the When command and its exact evidence.
+    /// </summary>
+    /// <param name="state">The recovered legacy state.</param>
+    /// <param name="artifact">The exact referenced command.</param>
+    /// <param name="source">The exact authored invocation location.</param>
+    internal void SetWhen(SpecificationStateModel state, ITypeSymbol artifact, Location source)
+    {
+        When = state;
+        _stateEvidence.Add(state, new(artifact, source));
+    }
+
+    /// <summary>
+    /// Adds exact evidence for one stated value.
+    /// </summary>
+    /// <param name="value">The recovered legacy value.</param>
+    /// <param name="source">The exact authored value expression.</param>
+    internal void AddValue(PropertyMappingModel value, Location source) => _valueEvidence.Add(value, source);
+
+    /// <summary>
+    /// Adds one rejection and its exact assertion location.
+    /// </summary>
+    /// <param name="error">The rejection reason, or an empty string when unnamed.</param>
+    /// <param name="source">The exact authored assertion location.</param>
+    internal void AddError(string error, Location source)
+    {
+        Errors.Add(error);
+        _errorEvidence.Add(source);
+    }
 }

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationEvidence.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationEvidence.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Holds neutral-fact source evidence without changing legacy model equality or public API shape.
+/// </summary>
+internal static class SpecificationEvidence
+{
+    static readonly ConditionalWeakTable<SpecificationModel, SpecificationScenarioEvidence> _evidence = new();
+
+    /// <summary>
+    /// Registers source evidence for one recovered specification model.
+    /// </summary>
+    /// <param name="specification">The recovered specification.</param>
+    /// <param name="evidence">The exact source evidence.</param>
+    public static void Register(SpecificationModel specification, SpecificationScenarioEvidence evidence) =>
+        _evidence.Add(specification, evidence);
+
+    /// <summary>
+    /// Gets source evidence for one recovered specification when it was produced by source analysis.
+    /// </summary>
+    /// <param name="specification">The recovered specification.</param>
+    /// <returns>The evidence, or <see langword="null"/> when no source analysis registered it.</returns>
+    public static SpecificationScenarioEvidence? For(SpecificationModel specification) =>
+        _evidence.TryGetValue(specification, out var evidence) ? evidence : null;
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
@@ -90,6 +90,16 @@ public static class SpecificationMembers
     public static bool HoldsAScenario(INamedTypeSymbol type) => Holds(type, WellKnownTypeNames.CommandScenario) is not null;
 
     /// <summary>
+    /// Gets the command a type is written as a scenario of.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>The command, or <see langword="null"/> when the type holds no command scenario.</returns>
+    public static ITypeSymbol? CommandOf(INamedTypeSymbol type) =>
+        Holds(type, WellKnownTypeNames.CommandScenario) is INamedTypeSymbol { TypeArguments.Length: 1 } scenario
+            ? scenario.TypeArguments[0]
+            : null;
+
+    /// <summary>
     /// Gets the read model a type is written as a scenario of.
     /// </summary>
     /// <param name="type">The type to check.</param>

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
@@ -50,8 +50,9 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
     /// Adds an event a specification says followed, or records that it cannot be read.
     /// </summary>
     /// <param name="appended">The type the assertion names.</param>
+    /// <param name="source">The exact authored assertion location.</param>
     /// <param name="draft">The scenario collected so far.</param>
-    static void AddEvent(ITypeSymbol appended, SpecificationDraft draft)
+    static void AddEvent(ITypeSymbol appended, Location source, SpecificationDraft draft)
     {
         if (!EventReader.IsEvent(appended))
         {
@@ -61,7 +62,8 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
 
         if (!draft.Then.Any(_ => string.Equals(_.Name, appended.Name, StringComparison.Ordinal)))
         {
-            draft.Then.Add(new(appended.Name, SpecificationStateKind.Event, []));
+            var state = new SpecificationStateModel(appended.Name, SpecificationStateKind.Event, []);
+            draft.AddThen(state, appended, source);
         }
     }
 
@@ -97,7 +99,7 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
 
             if (appended is not null)
             {
-                AddEvent(appended, draft);
+                AddEvent(appended, invocation.GetLocation(), draft);
                 continue;
             }
 
@@ -128,7 +130,7 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
 
         if (!draft.Errors.Contains(reason, StringComparer.Ordinal))
         {
-            draft.Errors.Add(reason);
+            draft.AddError(reason, invocation.GetLocation());
         }
     }
 

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
@@ -114,7 +114,17 @@ public class SpecificationReader(SemanticModels models, ScreenplayDiagnostics di
 
         diagnostics.AddRange(stated.All);
 
-        return new(name, [.. draft.Given], draft.When, [.. draft.Then], [.. draft.Errors]);
+        var specification = new SpecificationModel(name, [.. draft.Given], draft.When, [.. draft.Then], [.. draft.Errors]);
+        SpecificationEvidence.Register(
+            specification,
+            new(
+                type,
+                type.Locations.First(location => location.IsInSource),
+                draft.GetStateEvidence(),
+                draft.GetValueEvidence(),
+                draft.GetErrorEvidence(),
+                [.. stated.All]));
+        return specification;
     }
 
     /// <summary>
@@ -150,7 +160,11 @@ public class SpecificationReader(SemanticModels models, ScreenplayDiagnostics di
             return;
         }
 
-        draft.Then.Add(new(readModel.Name, SpecificationStateKind.ReadModel, []));
+        var state = new SpecificationStateModel(readModel.Name, SpecificationStateKind.ReadModel, []);
+        draft.AddThen(
+            state,
+            readModel,
+            readModel.Locations.First(location => location.IsInSource));
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationScenarioEvidence.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationScenarioEvidence.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Represents exact scenario, step, value, rejection, and atomic-admission evidence.
+/// </summary>
+/// <param name="SourceType">The exact authored scenario type.</param>
+/// <param name="Source">The exact authored scenario declaration.</param>
+/// <param name="States">State steps keyed by their legacy model instances using reference identity.</param>
+/// <param name="Values">Values keyed by their legacy model instances using reference identity.</param>
+/// <param name="Errors">Rejection assertion locations in legacy model order.</param>
+/// <param name="Blockers">Diagnostics proving neutral fact contribution must fail atomically.</param>
+internal sealed record SpecificationScenarioEvidence(
+    INamedTypeSymbol SourceType,
+    Location Source,
+    IReadOnlyDictionary<SpecificationStateModel, SpecificationStateEvidence> States,
+    IReadOnlyDictionary<PropertyMappingModel, Location> Values,
+    IReadOnlyList<Location> Errors,
+    IReadOnlyList<ScreenplayDiagnostic> Blockers);

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStateEvidence.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStateEvidence.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Represents the exact source artifact and location establishing one specification state step.
+/// </summary>
+/// <param name="Artifact">The exact event, read model, or command symbol.</param>
+/// <param name="Source">The exact authored step location.</param>
+internal sealed record SpecificationStateEvidence(ITypeSymbol Artifact, Location Source);

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
@@ -60,7 +60,7 @@ public class SpecificationStepReader(SemanticModels models, SpecificationValues 
 
             foreach (var stated in CallArguments.For(invocation, method, SpecificationCalls.PayloadParameterOf(method) ?? string.Empty))
             {
-                Add(draft.Given, stated, kind, semanticModel, draft, name, location);
+                Add(stated, kind, semanticModel, draft, name, location);
             }
         }
     }
@@ -108,10 +108,11 @@ public class SpecificationStepReader(SemanticModels models, SpecificationValues 
                 return;
             }
 
-            draft.When = new(
+            var state = new SpecificationStateModel(
                 command.Name,
                 SpecificationStateKind.Command,
-                values.Read(construction.Creation, construction.SemanticModel, command, name, location));
+                values.Read(construction.Creation, construction.SemanticModel, command, name, location, draft));
+            draft.SetWhen(state, command, invocation.GetLocation());
         }
     }
 
@@ -144,7 +145,6 @@ public class SpecificationStepReader(SemanticModels models, SpecificationValues 
     /// <summary>
     /// Adds one state a specification starts from, or records that it cannot be read.
     /// </summary>
-    /// <param name="states">The states collected so far.</param>
     /// <param name="stated">The expression stating it.</param>
     /// <param name="kind">What the state is.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
@@ -152,7 +152,6 @@ public class SpecificationStepReader(SemanticModels models, SpecificationValues 
     /// <param name="name">The name of the specification.</param>
     /// <param name="location">Where the specification lives.</param>
     void Add(
-        IList<SpecificationStateModel> states,
         ExpressionSyntax stated,
         SpecificationStateKind kind,
         SemanticModel semanticModel,
@@ -173,6 +172,10 @@ public class SpecificationStepReader(SemanticModels models, SpecificationValues 
             return;
         }
 
-        states.Add(new(type.Name, kind, values.Read(construction.Creation, construction.SemanticModel, type, name, location)));
+        var state = new SpecificationStateModel(
+            type.Name,
+            kind,
+            values.Read(construction.Creation, construction.SemanticModel, type, name, location, draft));
+        draft.AddGiven(state, type, stated.GetLocation());
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationValues.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationValues.cs
@@ -30,20 +30,22 @@ public class SpecificationValues(ScreenplayDiagnostics diagnostics, GeneratedIde
     /// <param name="type">The type being constructed.</param>
     /// <param name="specification">The name of the specification, for use in diagnostics.</param>
     /// <param name="location">Where the specification lives, for use in diagnostics.</param>
+    /// <param name="draft">The scenario collecting exact value evidence.</param>
     /// <returns>The values, in the order the source declares them.</returns>
     public IEnumerable<PropertyMappingModel> Read(
         BaseObjectCreationExpressionSyntax creation,
         SemanticModel semanticModel,
         ITypeSymbol type,
         string specification,
-        string location)
+        string location,
+        SpecificationDraft draft)
     {
         var values = new List<PropertyMappingModel>();
         var constructor = semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol;
 
         foreach (var (name, expression) in Stated(creation, constructor))
         {
-            Add(values, PropertyOf(type, name), expression, semanticModel, type, specification, location);
+            Add(values, PropertyOf(type, name), expression, semanticModel, type, specification, location, draft);
         }
 
         return values;
@@ -113,6 +115,7 @@ public class SpecificationValues(ScreenplayDiagnostics diagnostics, GeneratedIde
     /// <param name="type">The type being constructed.</param>
     /// <param name="specification">The name of the specification.</param>
     /// <param name="location">Where the specification lives.</param>
+    /// <param name="draft">The scenario collecting exact value evidence.</param>
     /// <remarks>
     /// An identity made on the spot is left out without a word, because there is no value for the document to have
     /// missed - see <see cref="GeneratedIdentities"/>. Every other value that cannot be read is one the source states
@@ -125,11 +128,14 @@ public class SpecificationValues(ScreenplayDiagnostics diagnostics, GeneratedIde
         SemanticModel semanticModel,
         ITypeSymbol type,
         string specification,
-        string location)
+        string location,
+        SpecificationDraft draft)
     {
         if (_sources.Read(expression, semanticModel, type, location) is LiteralSource literal)
         {
-            values.Add(new(property, literal));
+            var value = new PropertyMappingModel(property, literal);
+            values.Add(value);
+            draft.AddValue(value, expression.GetLocation());
             return;
         }
 

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+using static Cratis.Arc.Screenplay.Generation.ArcSpecificationFacts;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Contributes the exact artifacts and target placement required by an Arc specification scenario.
+/// </summary>
+/// <param name="context">The analyzed application projects.</param>
+/// <param name="scenarioProject">The project declaring the scenario.</param>
+/// <param name="adapter">The adapter identity.</param>
+/// <param name="options">The host placement options.</param>
+/// <param name="facts">The facts to append.</param>
+internal sealed class ArcSpecificationArtifactFacts(
+    DotNetAnalysisContext context,
+    DotNetProjectCompilation scenarioProject,
+    AdapterIdentity adapter,
+    DotNetAdapterOptions options,
+    List<GenerationFact> facts)
+{
+    /// <summary>
+    /// Adds or resolves one exact source artifact.
+    /// </summary>
+    /// <param name="type">The exact source type.</param>
+    /// <param name="kind">The neutral artifact kind.</param>
+    /// <param name="source">The referencing step source.</param>
+    /// <returns>The artifact key, or <see langword="null"/> when source identity is ambiguous.</returns>
+    public ArtifactKey? Artifact(INamedTypeSymbol type, ArtifactKind kind, Location source)
+    {
+        var subject = context.SubjectForType(type);
+        if (subject is null)
+        {
+            return null;
+        }
+
+        var key = new ArtifactKey { Subject = subject, Kind = kind };
+        if (!facts.OfType<ArtifactFact>().Any(fact => fact.Definition.Key == key))
+        {
+            var evidence = Evidence(source, "The exact specification step references this source artifact");
+            facts.Add(new ArtifactFact
+            {
+                Id = FactId("artifact", subject, kind.ToString()),
+                Subject = subject,
+                Evidence = evidence,
+                Definition = new ArtifactDefinition
+                {
+                    Key = key,
+                    Name = type.Name,
+                    File = evidence.Source?.Path,
+                    Properties = [.. type.GetMembers().OfType<IPropertySymbol>()
+                        .Where(property => !property.IsStatic)
+                        .OrderBy(property => property.Name, StringComparer.Ordinal)
+                        .Select(property => new PropertyDefinition
+                        {
+                            Name = property.Name,
+                            Type = TypeReference(property.Type, context)
+                        })]
+                }
+            });
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Adds the current compatibility placement for the exact scenario target.
+    /// </summary>
+    /// <param name="target">The exact target artifact.</param>
+    /// <param name="type">The exact source type.</param>
+    /// <param name="source">The source evidence.</param>
+    public void AddPlacement(ArtifactKey target, INamedTypeSymbol type, Location source)
+    {
+        var segments = type.ContainingNamespace.ToDisplayString().Split('.', StringSplitOptions.RemoveEmptyEntries)
+            .Skip(options.NamespaceSegmentsToSkip)
+            .ToArray();
+        if (segments.Length == 0)
+        {
+            return;
+        }
+
+        var module = options.Module ?? segments[0];
+        var remaining = segments.Skip(string.Equals(segments[0], module, StringComparison.Ordinal) ? 1 : 0).ToArray();
+        var slice = remaining.Length == 0 ? type.Name : remaining[^1];
+        var features = remaining.Length <= 1 ? [] : remaining[..^1];
+        facts.Add(new ArtifactPlacementFact
+        {
+            Id = FactId("placement", target.Subject, target.Kind.ToString()),
+            Subject = target.Subject,
+            Evidence = Evidence(source, "The target namespace places the specification under its exact owning slice"),
+            Artifact = target,
+            Placement = new ArtifactPlacement
+            {
+                Module = module,
+                Features = features,
+                Slice = slice,
+                SliceKind = GenerationSliceKind.StateChange
+            }
+        });
+    }
+
+    Evidence Evidence(Location location, string? explanation = null)
+    {
+        var project = location.SourceTree is null ? scenarioProject : context.ProjectFor(location.SourceTree);
+        return new()
+        {
+            Adapter = adapter,
+            Strength = EvidenceStrength.Exact,
+            Source = DotNetSource.RangeForProject(location, project),
+            Explanation = explanation
+        };
+    }
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationEvidence.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationEvidence.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Specifications;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Creates exact source evidence and fail-closed adapter diagnostics.
+/// </summary>
+/// <param name="context">The analyzed application projects.</param>
+/// <param name="scenarioProject">The scenario project.</param>
+/// <param name="adapter">The adapter identity.</param>
+/// <param name="diagnostics">The diagnostics to append.</param>
+internal sealed class ArcSpecificationEvidence(
+    DotNetAnalysisContext context,
+    DotNetProjectCompilation scenarioProject,
+    AdapterIdentity adapter,
+    List<GenerationDiagnostic> diagnostics)
+{
+    /// <summary>
+    /// Creates exact neutral evidence from an authored location.
+    /// </summary>
+    /// <param name="location">The exact authored location.</param>
+    /// <param name="explanation">The evidence explanation.</param>
+    /// <returns>The neutral evidence.</returns>
+    public Evidence For(Location location, string? explanation = null)
+    {
+        var project = location.SourceTree is null ? scenarioProject : context.ProjectFor(location.SourceTree);
+        return new()
+        {
+            Adapter = adapter,
+            Strength = EvidenceStrength.Exact,
+            Source = DotNetSource.RangeForProject(location, project),
+            Explanation = explanation
+        };
+    }
+
+    /// <summary>
+    /// Reports one scenario that contributes no partial neutral facts.
+    /// </summary>
+    /// <param name="specification">The recovered legacy specification.</param>
+    /// <param name="evidence">The exact scenario evidence.</param>
+    /// <param name="reason">The blocking reason.</param>
+    public void Block(SpecificationModel specification, SpecificationScenarioEvidence evidence, string reason) =>
+        diagnostics.Add(new GenerationDiagnostic
+        {
+            Code = "ARCSP0001",
+            Severity = GenerationDiagnosticSeverity.Warning,
+            Outcome = GenerationDiagnosticOutcome.Unsupported,
+            Message = $"Specification '{specification.Name}' contributed no neutral scenario because {reason}",
+            Source = For(evidence.Source).Source,
+            Subject = scenarioProject.SubjectForType(evidence.SourceType)
+        });
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Contributes exact Arc specification source evidence as neutral Generation facts.
+/// </summary>
+public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
+{
+    const string AdapterId = "cratis.arc.specifications";
+    const string AdapterVersion = "1.0.0";
+
+    /// <inheritdoc/>
+    public AdapterIdentity Identity { get; } = new() { Id = AdapterId, Version = AdapterVersion };
+
+    /// <inheritdoc/>
+    public bool CanAnalyze(DotNetAnalysisContext context) =>
+        context.Projects.SelectMany(project => ArtifactCatalog.From(project.Compilation).Types)
+            .Any(type => SpecificationMembers.CommandOf(type) is not null || SpecificationMembers.ReadModelOf(type) is not null);
+
+    /// <inheritdoc/>
+    public AdapterContribution Analyze(DotNetAnalysisContext context, DotNetAdapterOptions options)
+    {
+        var facts = new List<GenerationFact>();
+        var diagnostics = new List<GenerationDiagnostic>();
+        var models = new SemanticModels([.. context.Projects.Select(project => project.Compilation)]);
+        var readerDiagnostics = new ScreenplayDiagnostics();
+        var reader = new SpecificationReader(models, readerDiagnostics);
+
+        foreach (var project in context.Projects)
+        {
+            foreach (var type in ArtifactCatalog.From(project.Compilation).Types.Where(reader.IsSpecification))
+            {
+                var target = SpecificationMembers.CommandOf(type) ?? SpecificationMembers.ReadModelOf(type);
+                if (target is not INamedTypeSymbol namedTarget)
+                {
+                    continue;
+                }
+
+                var slice = namedTarget.ContainingNamespace.ToDisplayString();
+                var name = SpecificationPlacement.NameOf(type, slice);
+                var diagnosticCount = readerDiagnostics.All.Count;
+                if (reader.Read(type, name) is not { } specification)
+                {
+                    var reason = string.Join("; ", readerDiagnostics.All.Skip(diagnosticCount).Select(item => item.Message));
+                    diagnostics.Add(Unreadable(project, type, reason));
+                    continue;
+                }
+
+                if (SpecificationEvidence.For(specification) is not { } evidence)
+                {
+                    diagnostics.Add(Unreadable(project, type, "source evidence was not retained"));
+                    continue;
+                }
+
+                new ArcSpecificationFactBuilder(context, project, Identity, options, facts, diagnostics)
+                    .Add(specification, evidence, namedTarget);
+            }
+        }
+
+        return new()
+        {
+            Adapter = Identity,
+            Facts = facts,
+            Diagnostics = diagnostics
+        };
+    }
+
+    GenerationDiagnostic Unreadable(DotNetProjectCompilation project, INamedTypeSymbol type, string reason) => new()
+    {
+        Code = "ARCSP0001",
+        Severity = GenerationDiagnosticSeverity.Warning,
+        Outcome = GenerationDiagnosticOutcome.Unsupported,
+        Message = $"Specification '{type.Name}' contributed no neutral scenario because {reason}",
+        Source = DotNetSource.EvidenceFor(type, Identity, project, EvidenceStrength.Exact).Source,
+        Subject = project.SubjectForType(type)
+    };
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+using static Cratis.Arc.Screenplay.Generation.ArcSpecificationFacts;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Converts one exact legacy Arc specification model into an atomic neutral fact contribution.
+/// </summary>
+/// <param name="context">The analyzed application projects.</param>
+/// <param name="scenarioProject">The project declaring the scenario.</param>
+/// <param name="adapter">The adapter identity.</param>
+/// <param name="options">The host placement options.</param>
+/// <param name="facts">The facts to contribute atomically.</param>
+/// <param name="diagnostics">The diagnostics to append.</param>
+internal sealed class ArcSpecificationFactBuilder(
+    DotNetAnalysisContext context,
+    DotNetProjectCompilation scenarioProject,
+    AdapterIdentity adapter,
+    DotNetAdapterOptions options,
+    List<GenerationFact> facts,
+    List<GenerationDiagnostic> diagnostics)
+{
+    readonly ArcSpecificationArtifactFacts _artifactFacts = new(context, scenarioProject, adapter, options, facts);
+    readonly ArcSpecificationEvidence _sourceEvidence = new(context, scenarioProject, adapter, diagnostics);
+
+    /// <summary>
+    /// Adds one scenario only when every required step, value, artifact, and source location is exact.
+    /// </summary>
+    /// <param name="specification">The recovered legacy specification.</param>
+    /// <param name="evidence">The exact source evidence.</param>
+    /// <param name="target">The exact command or read-model target.</param>
+    public void Add(
+        SpecificationModel specification,
+        SpecificationScenarioEvidence evidence,
+        INamedTypeSymbol target)
+    {
+        if (evidence.Blockers.Count > 0 || SpecificationMembers.ReadModelOf(evidence.SourceType) is not null ||
+            HasUnrepresentedEventPredicate(specification, evidence))
+        {
+            _sourceEvidence.Block(specification, evidence, "the existing Arc analyzer cannot prove every authored step and value exactly");
+            return;
+        }
+
+        var scenarioSubject = scenarioProject.SubjectForType(evidence.SourceType);
+        var targetKey = _artifactFacts.Artifact(target, ArtifactKind.Command, evidence.Source);
+        if (targetKey is null)
+        {
+            _sourceEvidence.Block(specification, evidence, "the target artifact has no unique analyzed source identity");
+            return;
+        }
+
+        var stepFacts = new List<SpecificationStepFact>();
+        var valueFacts = new List<SpecificationValueFact>();
+        var stepIndex = 0;
+        foreach (var state in specification.Given)
+        {
+            if (!TryAddState(specification, evidence, scenarioSubject, state, SpecificationStepPhase.Given, stepIndex++, stepFacts, valueFacts))
+            {
+                return;
+            }
+        }
+
+        if (specification.When is null ||
+            !TryAddState(specification, evidence, scenarioSubject, specification.When, SpecificationStepPhase.When, stepIndex++, stepFacts, valueFacts))
+        {
+            return;
+        }
+
+        foreach (var state in specification.Then)
+        {
+            if (!TryAddState(specification, evidence, scenarioSubject, state, SpecificationStepPhase.Then, stepIndex++, stepFacts, valueFacts))
+            {
+                return;
+            }
+        }
+
+        foreach (var (error, index) in specification.Errors.Select((error, index) => (error, index)))
+        {
+            var key = StepKey(scenarioSubject, stepIndex++);
+            stepFacts.Add(new()
+            {
+                Id = FactId("step", scenarioSubject, key.Index.ToString(CultureInfo.InvariantCulture)),
+                Subject = StepSubject(scenarioSubject, key.Index),
+                Evidence = _sourceEvidence.For(evidence.Errors[index], "The assertion states an exact rejected outcome"),
+                Definition = new SpecificationStepDefinition
+                {
+                    Key = key,
+                    Phase = SpecificationStepPhase.Then,
+                    Kind = SpecificationStepKind.Error,
+                    ErrorMessage = string.IsNullOrEmpty(error) ? null : error
+                }
+            });
+        }
+
+        var scenario = new SpecificationScenarioFact
+        {
+            Id = FactId("scenario", scenarioSubject),
+            Subject = scenarioSubject,
+            Evidence = _sourceEvidence.For(evidence.Source, "The authored type is an exact Arc specification scenario"),
+            Definition = new SpecificationScenarioDefinition
+            {
+                Key = new() { Scenario = scenarioSubject },
+                Name = specification.Name,
+                TargetArtifact = targetKey,
+                Steps = [.. stepFacts.Select(step => step.Definition.Key)]
+            }
+        };
+        facts.Add(scenario);
+        facts.AddRange(stepFacts);
+        facts.AddRange(valueFacts);
+        _artifactFacts.AddPlacement(targetKey, target, evidence.Source);
+    }
+
+    bool TryAddState(
+        SpecificationModel specification,
+        SpecificationScenarioEvidence evidence,
+        SubjectId scenario,
+        SpecificationStateModel state,
+        SpecificationStepPhase phase,
+        int index,
+        List<SpecificationStepFact> steps,
+        List<SpecificationValueFact> values)
+    {
+        if (!evidence.States.TryGetValue(state, out var stateEvidence) || stateEvidence.Artifact is not INamedTypeSymbol artifact)
+        {
+            _sourceEvidence.Block(specification, evidence, $"step {index} has no exact source artifact evidence");
+            return false;
+        }
+
+        var kind = Kind(state.Kind);
+        var artifactKey = _artifactFacts.Artifact(artifact, ArtifactKindFor(kind), stateEvidence.Source);
+        if (kind == SpecificationStepKind.Unknown || artifactKey is null)
+        {
+            _sourceEvidence.Block(specification, evidence, $"step {index} has an unsupported or ambiguous artifact");
+            return false;
+        }
+
+        if (!HasEveryRequiredConstructionValue(artifact, state.Values.Count()))
+        {
+            _sourceEvidence.Block(specification, evidence, $"step {index} omits a required computed or unreadable construction value");
+            return false;
+        }
+
+        var key = StepKey(scenario, index);
+        var valueKeys = new List<SpecificationValueKey>();
+        foreach (var value in state.Values)
+        {
+            if (!ArcSpecificationValueFacts.TryAdd(
+                    context,
+                    _sourceEvidence.For,
+                    evidence.Values,
+                    key,
+                    artifact,
+                    value,
+                    values,
+                    out var valueKey,
+                    out var reason))
+            {
+                _sourceEvidence.Block(specification, evidence, reason!);
+                return false;
+            }
+
+            valueKeys.Add(valueKey!);
+        }
+
+        steps.Add(new()
+        {
+            Id = FactId("step", scenario, index.ToString(CultureInfo.InvariantCulture)),
+            Subject = StepSubject(scenario, index),
+            Evidence = _sourceEvidence.For(stateEvidence.Source, "The exact allowlisted scenario API establishes this step"),
+            Definition = new SpecificationStepDefinition
+            {
+                Key = key,
+                Phase = phase,
+                Kind = kind,
+                Artifact = artifactKey,
+                Values = valueKeys
+            }
+        });
+        return true;
+    }
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFacts.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Creates deterministic neutral specification identities, types, values, and source-shape checks.
+/// </summary>
+internal static class ArcSpecificationFacts
+{
+    /// <summary>
+    /// Creates an ordered step key.
+    /// </summary>
+    /// <param name="scenario">The scenario subject.</param>
+    /// <param name="index">The authored step index.</param>
+    /// <returns>The step key.</returns>
+    public static SpecificationStepKey StepKey(SubjectId scenario, int index) => new()
+    {
+        Scenario = new() { Scenario = scenario },
+        Index = index
+    };
+
+    /// <summary>
+    /// Creates the source subject identity of an ordered step.
+    /// </summary>
+    /// <param name="scenario">The scenario subject.</param>
+    /// <param name="index">The authored step index.</param>
+    /// <returns>The step subject.</returns>
+    public static SubjectId StepSubject(SubjectId scenario, int index) => new()
+    {
+        Value = $"{scenario.Value}/step/{index.ToString(CultureInfo.InvariantCulture)}"
+    };
+
+    /// <summary>
+    /// Maps a legacy Arc specification state kind to its neutral counterpart.
+    /// </summary>
+    /// <param name="kind">The legacy kind.</param>
+    /// <returns>The neutral kind.</returns>
+    public static SpecificationStepKind Kind(SpecificationStateKind kind) => kind switch
+    {
+        SpecificationStateKind.Event => SpecificationStepKind.Event,
+        SpecificationStateKind.ReadModel => SpecificationStepKind.ReadModel,
+        SpecificationStateKind.Command => SpecificationStepKind.Command,
+        _ => SpecificationStepKind.Unknown
+    };
+
+    /// <summary>
+    /// Maps a neutral specification step to the referenced artifact kind.
+    /// </summary>
+    /// <param name="kind">The neutral step kind.</param>
+    /// <returns>The artifact kind.</returns>
+    public static ArtifactKind ArtifactKindFor(SpecificationStepKind kind) => kind switch
+    {
+        SpecificationStepKind.Event => ArtifactKind.Event,
+        SpecificationStepKind.ReadModel => ArtifactKind.ReadModel,
+        SpecificationStepKind.Command => ArtifactKind.Command,
+        _ => ArtifactKind.Unknown
+    };
+
+    /// <summary>
+    /// Converts one exact Arc literal to its neutral shape and canonical scalar.
+    /// </summary>
+    /// <param name="value">The literal value.</param>
+    /// <param name="kind">The neutral value kind.</param>
+    /// <param name="scalar">The canonical scalar.</param>
+    /// <returns><see langword="true"/> when the literal is supported.</returns>
+    public static bool TryValue(object? value, out SpecificationValueKind kind, out string? scalar)
+    {
+        (kind, scalar) = value switch
+        {
+            null => (SpecificationValueKind.Null, null),
+            bool boolean => (SpecificationValueKind.Boolean, boolean ? "true" : "false"),
+            string text => (SpecificationValueKind.Text, text),
+            EnumValue enumeration => (SpecificationValueKind.Text, enumeration.Member),
+            byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal =>
+                (SpecificationValueKind.Number, Convert.ToString(value, CultureInfo.InvariantCulture)),
+            _ => (SpecificationValueKind.Unknown, null)
+        };
+        return kind != SpecificationValueKind.Unknown;
+    }
+
+    /// <summary>
+    /// Creates a neutral type reference from an exact Roslyn type.
+    /// </summary>
+    /// <param name="type">The exact Roslyn type.</param>
+    /// <param name="context">The analyzed application context.</param>
+    /// <returns>The neutral type reference.</returns>
+    public static TypeReferenceDefinition TypeReference(ITypeSymbol type, DotNetAnalysisContext context) => new()
+    {
+        Name = type.SpecialType switch
+        {
+            SpecialType.System_String => "String",
+            SpecialType.System_Boolean => "Bool",
+            SpecialType.System_Byte or SpecialType.System_SByte or SpecialType.System_Int16 or SpecialType.System_UInt16 or
+            SpecialType.System_Int32 or SpecialType.System_UInt32 or SpecialType.System_Int64 or SpecialType.System_UInt64 => "Int",
+            SpecialType.System_Decimal or SpecialType.System_Double or SpecialType.System_Single => "Decimal",
+            _ => type.Name
+        },
+        Subject = type is INamedTypeSymbol named ? context.SubjectForType(named) : null
+    };
+
+    /// <summary>
+    /// Creates a stable adapter-qualified fact identity.
+    /// </summary>
+    /// <param name="kind">The fact kind.</param>
+    /// <param name="subject">The fact subject.</param>
+    /// <param name="suffix">The optional identity suffix.</param>
+    /// <returns>The fact identity.</returns>
+    public static FactId FactId(string kind, SubjectId subject, string? suffix = null) => new()
+    {
+        Value = suffix is null
+            ? $"{AdapterId(kind)}:{subject.Value}"
+            : $"{AdapterId(kind)}:{subject.Value}:{suffix}"
+    };
+
+    /// <summary>
+    /// Determines whether every required construction value survived legacy analysis.
+    /// </summary>
+    /// <param name="artifact">The exact constructed artifact.</param>
+    /// <param name="valueCount">The number of exact values retained.</param>
+    /// <returns><see langword="true"/> when no required constructor value was omitted.</returns>
+    public static bool HasEveryRequiredConstructionValue(INamedTypeSymbol artifact, int valueCount)
+    {
+        var required = artifact.InstanceConstructors
+            .Where(constructor => !constructor.IsStatic)
+            .Select(constructor => constructor.Parameters.Count(parameter => !parameter.HasExplicitDefaultValue))
+            .DefaultIfEmpty()
+            .Max();
+        return valueCount >= required;
+    }
+
+    /// <summary>
+    /// Determines whether an expected event assertion contains predicate values the legacy analyzer did not retain.
+    /// </summary>
+    /// <param name="specification">The recovered specification.</param>
+    /// <param name="evidence">The exact scenario evidence.</param>
+    /// <returns><see langword="true"/> when predicate values would be lost.</returns>
+    public static bool HasUnrepresentedEventPredicate(
+        SpecificationModel specification,
+        SpecificationScenarioEvidence evidence) =>
+        specification.Then
+            .Where(state => state.Kind == SpecificationStateKind.Event)
+            .Select(state => evidence.States[state].Source)
+            .Any(location => location.SourceTree!.GetRoot().FindNode(location.SourceSpan)
+                .DescendantNodesAndSelf()
+                .OfType<LambdaExpressionSyntax>()
+                .Any());
+
+    static string AdapterId(string kind) => $"cratis.arc.specifications:{kind}";
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationValueFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationValueFacts.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+using static Cratis.Arc.Screenplay.Generation.ArcSpecificationFacts;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Converts exact authored Arc specification literals into neutral value facts.
+/// </summary>
+internal static class ArcSpecificationValueFacts
+{
+    /// <summary>
+    /// Adds one value fact when its literal, type, identity, and source evidence are exact.
+    /// </summary>
+    /// <param name="context">The analyzed application projects.</param>
+    /// <param name="evidenceFor">The exact evidence factory.</param>
+    /// <param name="valueEvidence">Value-expression evidence by legacy model reference.</param>
+    /// <param name="step">The owning neutral step.</param>
+    /// <param name="artifact">The exact source artifact.</param>
+    /// <param name="value">The recovered legacy value.</param>
+    /// <param name="values">The atomic value fact buffer.</param>
+    /// <param name="key">The value key when successful.</param>
+    /// <param name="reason">The blocking reason when unsuccessful.</param>
+    /// <returns><see langword="true"/> when the value fact was added.</returns>
+    public static bool TryAdd(
+        DotNetAnalysisContext context,
+        Func<Location, string?, Evidence> evidenceFor,
+        IReadOnlyDictionary<PropertyMappingModel, Location> valueEvidence,
+        SpecificationStepKey step,
+        INamedTypeSymbol artifact,
+        PropertyMappingModel value,
+        List<SpecificationValueFact> values,
+        out SpecificationValueKey? key,
+        out string? reason)
+    {
+        key = null;
+        reason = null;
+        if (value.Source is not LiteralSource literal || !valueEvidence.TryGetValue(value, out var source))
+        {
+            reason = $"value '{value.Property}' is not an exact authored literal";
+            return false;
+        }
+
+        var property = artifact.GetMembers(value.Property).OfType<IPropertySymbol>().SingleOrDefault();
+        if (property is null || !TryValue(literal.Value, out var kind, out var scalar))
+        {
+            reason = $"value '{artifact.Name}.{value.Property}' has an unsupported type or shape";
+            return false;
+        }
+
+        key = new() { Step = step, Path = [value.Property] };
+        values.Add(new()
+        {
+            Id = FactId("value", step.Scenario.Scenario, $"{step.Index.ToString(CultureInfo.InvariantCulture)}:{value.Property}"),
+            Subject = new SubjectId { Value = $"{step.Scenario.Scenario.Value}/step/{step.Index.ToString(CultureInfo.InvariantCulture)}/value/{value.Property}" },
+            Evidence = evidenceFor(source, "The authored construction states this exact literal value"),
+            Definition = new SpecificationValueDefinition
+            {
+                Key = key,
+                Kind = kind,
+                Type = TypeReference(property.Type, context),
+                Scalar = scalar
+            }
+        });
+        return true;
+    }
+}

--- a/Source/DotNET/Screenplay/Screenplay.csproj
+++ b/Source/DotNET/Screenplay/Screenplay.csproj
@@ -13,6 +13,8 @@
 
     <ItemGroup>
         <PackageReference Include="Cratis.Screenplay" />
+        <PackageReference Include="Cratis.Screenplay.Generation.Contracts" />
+        <PackageReference Include="Cratis.Screenplay.Generation.DotNet" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

Adopt Generation's neutral specification facts behind an independent Arc source adapter while preserving the existing Arc Screenplay generator and output.

## Added

- Add an independent Arc specification-fact adapter with exact scenario, step, value, artifact, placement, and source evidence. (Cratis/Screenplay.Generation#25)
- Add fail-closed atomic contribution for unsupported computed values, read-model assertions, and event predicates. (Cratis/Screenplay.Generation#25)

## Changed

- Take Screenplay 4.6.0 and Screenplay.Generation 0.10.x, raising the Roslyn host floor to 5.9/.NET SDK 10.0.400. (Cratis/Screenplay.Generation#25)
