### PR TITLE
Present Arc's documented application framework surface

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,8 +251,14 @@ jobs:
             exit 1
           fi
 
-          no_release=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-            --jq '[.[].labels[].name] | any(. == "no-release")')
+          pulls=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls")
+          merged_count=$(printf '%s' "$pulls" | jq --arg sha "$GITHUB_SHA" '[.[] | select(.merge_commit_sha == $sha)] | length')
+          if [ "$merged_count" -ne 1 ]; then
+            echo "::error::Expected exactly one pull request whose merge commit is $GITHUB_SHA; found $merged_count."
+            exit 1
+          fi
+          no_release=$(printf '%s' "$pulls" | jq -r --arg sha "$GITHUB_SHA" \
+            '[.[] | select(.merge_commit_sha == $sha) | .labels[].name] | any(. == "no-release")')
 
           if [ "$no_release" = "true" ]; then
             echo "The merged pull request explicitly selected no-release; publishing nothing is the intended result."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ permissions:
   contents: write
   deployments: write
   id-token: write
+  pull-requests: read
 
 jobs:
   release:
@@ -198,7 +199,11 @@ jobs:
       - name: Publish NPM packages
         run: |
           echo "npm $(npm --version) | node $(node --version)"
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL is $([ -n \"$ACTIONS_ID_TOKEN_REQUEST_URL\" ] && echo 'set' || echo 'NOT set')"
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "ACTIONS_ID_TOKEN_REQUEST_URL is set"
+          else
+            echo "ACTIONS_ID_TOKEN_REQUEST_URL is NOT set"
+          fi
           echo "NODE_AUTH_TOKEN is '${NODE_AUTH_TOKEN:-(unset)}'"
           echo "--- .npmrc ---"
           cat "$NPM_CONFIG_USERCONFIG" 2>/dev/null || echo "(no .npmrc)"
@@ -236,7 +241,23 @@ jobs:
     needs: [release]
 
     steps:
-      - name: Report that nothing was published
+      - name: Verify an intentional no-release merge
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "::error::Nothing was published and no release was cut (reason: ${{ needs.release.outputs.reason }}). For 'no-label', add exactly one of major, minor or patch to the merged pull request and re-run this workflow - see verify-semver-label, which is meant to catch this before the merge."
+          reason='${{ needs.release.outputs.reason }}'
+          if [ "$reason" = "error" ]; then
+            echo "::error::The release action failed; no-release cannot suppress a release error."
+            exit 1
+          fi
+
+          no_release=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '[.[].labels[].name] | any(. == "no-release")')
+
+          if [ "$no_release" = "true" ]; then
+            echo "The merged pull request explicitly selected no-release; publishing nothing is the intended result."
+            exit 0
+          fi
+
+          echo "::error::Nothing was published and no release was cut (reason: ${{ needs.release.outputs.reason }}). Add exactly one release-intent label before merge; use no-release when publishing nothing is intentional."
           exit 1

--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -12,7 +12,7 @@ concurrency:
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
     # Scoped to the same base branch Publish releases from. A pull request stacked onto another one's
     # branch cannot cut a release, so demanding a version label of it would be asking which version a
     # merge that publishes nothing should carry.

--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -1,9 +1,8 @@
 name: Verify Semver Label
 
-# A merged pull request with no major/minor/patch label produces a Publish run that reports success while
-# skipping every publish step, because the release action resolves should-publish to false. That reads as a
-# release having happened when nothing was published. Requiring the label here turns a silent non-release into
-# a visible failure before the merge, where it costs nothing to fix.
+# Every pull request declares one release intent. major/minor/patch authorizes a package release when the
+# publish workflow's path filters also match; no-release explicitly records that the change should publish
+# nothing. Requiring exactly one intent prevents both accidental releases and ambiguous silent skips.
 #
 # Triggered on labeled/unlabeled as well as the usual events, so adding the label re-runs the check rather than
 # leaving a red cross behind that only a push would clear.
@@ -28,21 +27,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Require exactly one semantic version label
+      - name: Require exactly one release-intent label
         env:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          count=$(printf '%s' "$LABELS" | jq '[.[] | select(. == "major" or . == "minor" or . == "patch")] | length')
+          count=$(printf '%s' "$LABELS" | jq '[.[] | select(. == "major" or . == "minor" or . == "patch" or . == "no-release")] | length')
 
           if [ "$count" -eq 1 ]; then
-            echo "Found one semantic version label."
+            echo "Found one release-intent label."
             exit 0
           fi
 
           if [ "$count" -eq 0 ]; then
-            echo "::error::This pull request has no semantic version label. Add exactly one of major, minor or patch. Without one, merging produces a Publish run that succeeds while skipping every publish step, so no release is cut and nothing is published."
+            echo "::error::This pull request has no release-intent label. Add exactly one of major, minor, patch or no-release."
           else
-            echo "::error::This pull request carries $count semantic version labels. Exactly one of major, minor or patch is required, since the release version cannot be derived from more than one."
+            echo "::error::This pull request carries $count release-intent labels. Add exactly one of major, minor, patch or no-release."
           fi
 
           exit 1

--- a/Documentation/backend/core/getting-started.md
+++ b/Documentation/backend/core/getting-started.md
@@ -4,7 +4,7 @@ This guide walks you through building your first Arc.Core application from scrat
 
 ## Prerequisites
 
-- .NET 9 SDK or later
+- .NET SDK 10.0.301 or later
 - Basic understanding of C# and .NET concepts
 
 ## Installation

--- a/Documentation/index.mdx
+++ b/Documentation/index.mdx
@@ -3,7 +3,7 @@ title: Arc
 description: Commands, queries, validation, authorization, and TypeScript proxy generation for ASP.NET Core.
 ---
 
-import { CardGrid, Steps } from '@astrojs/starlight/components';
+import { CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
 import SimpleCard from '@components/SimpleCard.astro';
 import TopicHero from '@components/TopicHero.astro';
 
@@ -19,27 +19,30 @@ import TopicHero from '@components/TopicHero.astro';
 
 ## Start here
 
-When commands, queries, validation, authorization, and frontend contracts drift
-into separate conventions, begin with Arc's CQRS boundary. You can use Arc with
-current-state persistence or application services; add the optional Chronicle
-integration only when the behavior needs an event-sourced path.
+When commands, queries, validation, authorization, frontend contracts, and
+persistence each grow their own conventions, Arc gives them one application
+boundary. Start with current-state persistence or application services. Add
+Chronicle only where event sourcing fits, and add Components only where its
+React compositions fit.
 
 <CardGrid>
   <SimpleCard title="Start an Arc host" icon="rocket" link="#start-an-arc-host">
     Add the Arc package and configure an ASP.NET Core host.
   </SimpleCard>
-  <SimpleCard title="What Arc owns" icon="seti:c-sharp" link="#what-arc-owns">
-    See the current command, query, validation, authorization, and proxy boundary.
+  <SimpleCard title="Commands and queries" icon="seti:c-sharp" link="#commands-and-queries">
+    Execute changes, expose reads, and generate the client contracts for both.
   </SimpleCard>
-  <SimpleCard title="Components relationship" icon="laptop" link="#relationship-to-components">
-    Keep Arc contracts separate from the React compositions that consume them.
+  <SimpleCard title="Frontend contracts" icon="laptop" link="#frontend-contracts">
+    Use the generated TypeScript runtime directly or compose it with React.
+  </SimpleCard>
+  <SimpleCard title="Persistence choices" icon="seti:db" link="#persistence-choices">
+    Keep current state in application services, MongoDB, or EF Core, or add Chronicle.
   </SimpleCard>
 </CardGrid>
 
 ## Start an Arc host
 
-The current Arc analyzers and source generators require .NET SDK 10.0.301 or
-newer.
+Use the .NET SDK declared by Arc's current `global.json`.
 
 <Steps>
 1. Install the umbrella host package.
@@ -68,30 +71,101 @@ Starting the host verifies the setup path only. Commands, queries, generated
 proxies, persistence integrations, and frontend packages each have additional
 configuration and version requirements.
 
-## What Arc owns
+## Commands and queries
 
-| Boundary | Current Arc role |
-| --- | --- |
-| Commands | Explicit application intentions, validation, authorization, execution, and generated HTTP endpoints |
-| Queries | Purpose-shaped reads exposed through Arc query surfaces |
-| Generated contracts | TypeScript proxy generation for recognized application artifacts |
-| ASP.NET Core integration | Hosting, dependency injection, identity, tenancy, OpenAPI, and application conventions |
-| Frontend packages | TypeScript runtime support for generated proxies plus React and React/MVVM integration packages |
-| Persistence integration | Separate current-state integrations and an optional Chronicle integration |
+Arc supports model-bound records and methods as well as controller-based
+endpoints. The command and query pipelines handle dependency injection,
+validation, authorization, filters, execution scopes, result conversion, and
+HTTP exposure.
 
-Arc.Core does not depend on Chronicle. The Chronicle integration is optional and
-supplies event-sourced behavior when configured.
+Queries can return one result or use Arc's observable-query APIs. The TypeScript
+generator creates clients for recognized commands, queries, referenced types,
+validation rules, and identity details. See the detailed product documentation for the exact transport, subscription,
+and lifecycle behavior.
 
-## Relationship to Components
+<CardGrid>
+  <LinkCard
+    title="Command pipeline"
+    description="Model intentions, validate and authorize them, provide dependencies, execute handlers, and convert typed results into HTTP responses."
+    href="/arc/backend/commands/"
+  />
+  <LinkCard
+    title="Query pipeline"
+    description="Expose purpose-shaped reads with paging, sorting, filtering, result rendering, and diagnostics."
+    href="/arc/backend/queries/"
+  />
+  <LinkCard
+    title="Observable-query APIs"
+    description="Work with documented query subscriptions, collection changes, subscription guards, and query health information."
+    href="/arc/backend/queries/observable-query-demultiplexer/"
+  />
+</CardGrid>
 
-Components is a React component library aligned with Arc application patterns.
-Applications may use Arc without Components. Components' exact package and
-application behavior is documented on the [Components page](/components/).
+## Frontend contracts
 
-:::caution[Keep the profile exact]
-Arc and package availability do not imply support for every frontend, runtime,
-persistence provider, browser, or product-version combination. Use the exact
-package manifests and owning release evidence for the profile you evaluate.
+`@cratis/arc` supplies the TypeScript command, query, validation, identity, and
+messaging runtime used by generated proxies. `@cratis/arc.react` adds hooks,
+command forms, dialogs, identity composition, and query components. The optional
+React/MVVM package adds view models, dependency injection, route parameters, and
+browser abstractions.
+
+[Explore Arc's frontend packages](/arc/frontend/) to choose the TypeScript,
+React, or React/MVVM path. Components is separate: applications may use Arc
+without Components, and may use the generated TypeScript clients without Arc's
+React packages.
+
+## Identity and tenancy
+
+Arc includes [pluggable identity and access behavior](/arc/understanding-identity-and-access/),
+identity-detail providers, server-side authorization and role checks, and
+frontend identity context. [Tenant resolution](/arc/backend/tenancy/) can use a
+header, query parameter, claim, subdomain, fixed value, or development setting
+before provider-specific database or namespace mapping.
+
+Frontend visibility helpers do not replace server-side authorization. Tenant
+resolution also does not by itself establish isolation for an application or
+storage topology.
+
+## Persistence choices
+
+Arc.Core does not depend on Chronicle. Commands and queries can use application
+services or current-state persistence without an event log.
+
+<CardGrid>
+  <LinkCard
+    title="MongoDB"
+    description="Use Arc's serialization conventions, tenant-aware database resolution, resilient collection access, and observable change streams."
+    href="/arc/backend/mongodb/"
+  />
+  <LinkCard
+    title="Entity Framework Core"
+    description="Discover read models, configure value conversions and mappings, run migrations, and observe supported SQL Server, PostgreSQL, or SQLite changes."
+    href="/arc/backend/entity-framework/"
+  />
+  <LinkCard
+    title="Chronicle"
+    description="Add event-sourced commands, projections, reducers, aggregates, reactors, concurrency behavior, tenant namespaces, and Chronicle-specific testing."
+    href="/arc/backend/chronicle/"
+  />
+</CardGrid>
+
+## Inspection, contracts, and testing
+
+Arc can describe registered commands, queries, identity schemas, and OpenAPI
+operations at runtime. Repository packages also include analyzers, source
+generators, command-scenario testing, proxy-generation checks, Vite helpers, and
+Arc-specific ESLint rules.
+
+- [Inspect registered application contracts](/arc/backend/introspection/)
+- [Generate OpenAPI descriptions](/arc/backend/open-api/)
+- [Test command behavior](/arc/backend/testing/)
+- [Review analyzer rules](/arc/backend/code-analysis/)
+
+:::caution[Check the combination you use]
+These are separate packages and integration surfaces. Their existence does not
+establish compatibility with every frontend, runtime, persistence provider,
+browser, or product version. Check the package manifests and the evidence for the
+combination you evaluate.
 :::
 
 ## Continue
@@ -103,7 +177,10 @@ package manifests and owning release evidence for the profile you evaluate.
   <SimpleCard title="Arc packages" icon="open-book" link="https://www.nuget.org/packages/Cratis.Arc">
     Published .NET package metadata and versions.
   </SimpleCard>
+  <SimpleCard title="Chronicle" icon="seti:db" link="/chronicle/">
+    The optional event-sourced runtime integration for Arc application behavior.
+  </SimpleCard>
   <SimpleCard title="Components" icon="laptop" link="/components/">
-    React components aligned with Arc application patterns.
+    Optional React components aligned with Arc application patterns.
   </SimpleCard>
 </CardGrid>

--- a/Documentation/index.mdx
+++ b/Documentation/index.mdx
@@ -3,65 +3,102 @@ title: Arc
 description: Commands, queries, validation, authorization, and TypeScript proxy generation for ASP.NET Core.
 ---
 
-Arc is an opinionated CQRS application framework for ASP.NET Core with commands,
-queries, validation, authorization, and TypeScript proxy generation.
+import { CardGrid, Steps } from '@astrojs/starlight/components';
+import SimpleCard from '@components/SimpleCard.astro';
+import TopicHero from '@components/TopicHero.astro';
 
-## What Arc owns
+<TopicHero
+  icon="puzzle"
+  eyebrow="Arc"
+  title="CQRS application framework for ASP.NET Core"
+>
+  Arc is an opinionated CQRS application framework for ASP.NET Core with
+  commands, queries, validation, authorization, and TypeScript proxy generation.
+  Event sourcing is not required.
+</TopicHero>
 
-- command and query application boundaries;
-- validation and authorization around those boundaries;
-- ASP.NET Core hosting and generated HTTP surfaces; and
-- TypeScript proxy generation for recognized application artifacts.
+## Start here
 
-Event sourcing is not required to use Arc. The Chronicle integration is optional
-and supplies event-sourced behavior when configured.
+<CardGrid>
+  <SimpleCard title="Start an Arc host" icon="rocket" link="#start-an-arc-host">
+    Add the Arc package and configure an ASP.NET Core host.
+  </SimpleCard>
+  <SimpleCard title="What Arc owns" icon="seti:c-sharp" link="#what-arc-owns">
+    See the current command, query, validation, authorization, and proxy boundary.
+  </SimpleCard>
+  <SimpleCard title="Components relationship" icon="laptop" link="#relationship-to-components">
+    Keep Arc contracts separate from the React compositions that consume them.
+  </SimpleCard>
+</CardGrid>
 
 ## Start an Arc host
 
 The current Arc analyzers and source generators require .NET SDK 10.0.301 or
 newer.
 
-```bash
-dotnet add package Cratis.Arc
-```
+<Steps>
+1. Install the umbrella host package.
 
-```csharp
-using Cratis.Arc;
+   ```bash
+   dotnet add package Cratis.Arc
+   ```
 
-var builder = ArcApplication.CreateBuilder(args);
-builder.AddCratisArc();
+2. Configure and run the host.
 
-var app = builder.Build();
-app.UseCratisArc();
-await app.RunAsync();
-```
+   ```csharp
+   using Cratis.Arc;
 
-Starting this host proves the Arc application setup can build and run on the
-selected SDK and package profile. Commands, queries, generated proxies,
-persistence integrations, and frontend packages each have additional exact
+   var builder = ArcApplication.CreateBuilder(args);
+   builder.AddCratisArc();
+
+   var app = builder.Build();
+   app.UseCratisArc();
+   await app.RunAsync();
+   ```
+
+3. Confirm the application starts on the selected SDK/package profile.
+</Steps>
+
+Starting the host verifies the setup path only. Commands, queries, generated
+proxies, persistence integrations, and frontend packages each have additional
 configuration and version requirements.
+
+## What Arc owns
+
+| Boundary | Current Arc role |
+| --- | --- |
+| Commands | Explicit application intentions, validation, authorization, execution, and generated HTTP endpoints |
+| Queries | Purpose-shaped reads exposed through Arc query surfaces |
+| Generated contracts | TypeScript proxy generation for recognized application artifacts |
+| ASP.NET Core integration | Hosting, dependency injection, identity, tenancy, OpenAPI, and application conventions |
+| Frontend packages | TypeScript runtime support for generated proxies plus React and React/MVVM integration packages |
+| Persistence integration | Separate current-state integrations and an optional Chronicle integration |
+
+Arc.Core does not depend on Chronicle. The Chronicle integration is optional and
+supplies event-sourced behavior when configured.
 
 ## Relationship to Components
 
 Components is a React component library aligned with Arc application patterns.
-Its package and application-level accessibility, browser, styling, and version
-behavior must be verified for the exact profile an application ships.
+Applications may use Arc without Components. Components' exact package and
+application behavior is documented on the [Components page](/components/).
 
-## Current boundaries
-
-- Arc does not require Chronicle or event sourcing.
-- Arc does not imply support for every frontend, runtime, persistence provider,
-  or product-version combination.
-- Package availability, examples, and a successful build do not establish
-  maturity, support, security, performance, or production suitability.
-- Use package manifests and owning-repository release evidence for the exact
-  profile you evaluate.
+:::caution[Keep the profile exact]
+Arc and package availability do not imply support for every frontend, runtime,
+persistence provider, browser, or product-version combination. Use the exact
+package manifests and owning release evidence for the profile you evaluate.
+:::
 
 ## Continue
 
-- [Arc source and README](https://github.com/Cratis/Arc) — repository structure,
-  package roles, contribution guidance, and current product paths.
-- [Arc packages](https://www.nuget.org/packages/Cratis.Arc) — published .NET
-  package metadata and versions.
-- [Components](/components/) — React components aligned with Arc application
-  patterns.
+<CardGrid>
+  <SimpleCard title="Arc source and README" icon="seti:folder" link="https://github.com/Cratis/Arc">
+    Repository structure, package roles, contribution guidance, and current limits.
+  </SimpleCard>
+  <SimpleCard title="Arc packages" icon="open-book" link="https://www.nuget.org/packages/Cratis.Arc">
+    Published .NET package metadata and versions.
+  </SimpleCard>
+  <SimpleCard title="Components" icon="laptop" link="/components/">
+    React components aligned with Arc application patterns.
+  </SimpleCard>
+</CardGrid>

--- a/Documentation/index.mdx
+++ b/Documentation/index.mdx
@@ -19,6 +19,11 @@ import TopicHero from '@components/TopicHero.astro';
 
 ## Start here
 
+When commands, queries, validation, authorization, and frontend contracts drift
+into separate conventions, begin with Arc's CQRS boundary. You can use Arc with
+current-state persistence or application services; add the optional Chronicle
+integration only when the behavior needs an event-sourced path.
+
 <CardGrid>
   <SimpleCard title="Start an Arc host" icon="rocket" link="#start-an-arc-host">
     Add the Arc package and configure an ASP.NET Core host.

--- a/Documentation/index.mdx
+++ b/Documentation/index.mdx
@@ -1,57 +1,67 @@
 ---
 title: Arc
-description: The full-stack application framework for Cratis — CQRS commands and queries with end-to-end type safety, from C# to React.
+description: Commands, queries, validation, authorization, and TypeScript proxy generation for ASP.NET Core.
 ---
 
-import { CardGrid } from '@astrojs/starlight/components';
-import SimpleCard from '@components/SimpleCard.astro';
-import TopicHero from '@components/TopicHero.astro';
+Arc is an opinionated CQRS application framework for ASP.NET Core with commands,
+queries, validation, authorization, and TypeScript proxy generation.
 
-<TopicHero icon="puzzle" eyebrow="Arc" title="Full-stack CQRS, typed to the browser">
-Turn **commands** and **queries** into a full-stack CQRS application with **generated TypeScript proxies** that keep React in lockstep with your C#: no hand-written API client, no DTO duplication. Arc pairs naturally with Chronicle's event sourcing, and runs just as well over MongoDB or EF Core — no event log required. [Build your first slice →](/arc/backend/getting-started/your-first-command/) · [Why Arc? →](/arc/why-arc/)
-</TopicHero>
+## What Arc owns
 
-## Start here
+- command and query application boundaries;
+- validation and authorization around those boundaries;
+- ASP.NET Core hosting and generated HTTP surfaces; and
+- TypeScript proxy generation for recognized application artifacts.
 
-<CardGrid>
-  <SimpleCard title="Your first command & query" icon="rocket" link="/arc/backend/getting-started/your-first-command/">
-    Build a backend slice end to end: a command with `Handle()`, the read model it writes, and the live query that serves it.
-  </SimpleCard>
-  <SimpleCard title="Wire up the React frontend" icon="seti:react" link="/arc/frontend/getting-started/">
-    Consume the generated proxies from React — a typed query and a command, with the client model generated from C#.
-  </SimpleCard>
-  <SimpleCard title="MediatR, MVC, and Arc" icon="right-arrow" link="/arc/coming-from-mediatr-and-mvc/">
-    Maps controllers, handlers, and DTOs onto Arc's command/query model so the shift is short.
-  </SimpleCard>
-</CardGrid>
+Event sourcing is not required to use Arc. The Chronicle integration is optional
+and supplies event-sourced behavior when configured.
 
-## Explore Arc
+## Start an Arc host
 
-<CardGrid>
-  <SimpleCard title="Why Arc" icon="approve-check" link="/arc/why-arc/">
-    The plumbing Arc removes, and why CQRS plus proxy generation keeps a full-stack app honest.
-  </SimpleCard>
-  <SimpleCard title="Vertical slices" icon="seti:folder" link="/arc/vertical-slices/">
-    How everything for one feature — backend and frontend — can live in a single folder.
-  </SimpleCard>
-  <SimpleCard title="CQRS without event sourcing" icon="right-arrow" link="/arc/arc-without-event-sourcing/">
-    Use Arc on its own over MongoDB or EF Core when you want the CQRS boundary without an event log.
-  </SimpleCard>
-  <SimpleCard title="Integrate with Chronicle" icon="seti:db" link="/arc/backend/chronicle/">
-    Add Chronicle when a slice needs events, projections, reducers, reactors, history, or aggregate roots.
-  </SimpleCard>
-  <SimpleCard title="Backend" icon="seti:c-sharp" link="/arc/backend/">
-    Commands, queries, validation, identity, tenancy, persistence, and proxy generation.
-  </SimpleCard>
-  <SimpleCard title="Frontend" icon="laptop" link="/arc/frontend/">
-    React integration, command forms, observable queries, and the optional MVVM approach.
-  </SimpleCard>
-  <SimpleCard title="Build a full-stack feature" icon="open-book" link="/build-a-full-app/">
-    One slice from command to React screen, with full-stack type safety throughout.
-  </SimpleCard>
-  <SimpleCard title="Troubleshooting" icon="list-format" link="/arc/troubleshooting/">
-    Answers to the questions that come up most when wiring Arc together.
-  </SimpleCard>
-</CardGrid>
+The current Arc analyzers and source generators require .NET SDK 10.0.301 or
+newer.
 
-Arc feeds [Components](/components/) and gives the application its CQRS boundary. In the full Cratis loop it sits on top of [Chronicle](/chronicle/) through the [Chronicle integration](/arc/backend/chronicle/); for bounded current-state slices it can also run over MongoDB or EF Core. See [Why developers choose Cratis](/why-cratis/) for how the pieces fit.
+```bash
+dotnet add package Cratis.Arc
+```
+
+```csharp
+using Cratis.Arc;
+
+var builder = ArcApplication.CreateBuilder(args);
+builder.AddCratisArc();
+
+var app = builder.Build();
+app.UseCratisArc();
+await app.RunAsync();
+```
+
+Starting this host proves the Arc application setup can build and run on the
+selected SDK and package profile. Commands, queries, generated proxies,
+persistence integrations, and frontend packages each have additional exact
+configuration and version requirements.
+
+## Relationship to Components
+
+Components is a React component library aligned with Arc application patterns.
+Its package and application-level accessibility, browser, styling, and version
+behavior must be verified for the exact profile an application ships.
+
+## Current boundaries
+
+- Arc does not require Chronicle or event sourcing.
+- Arc does not imply support for every frontend, runtime, persistence provider,
+  or product-version combination.
+- Package availability, examples, and a successful build do not establish
+  maturity, support, security, performance, or production suitability.
+- Use package manifests and owning-repository release evidence for the exact
+  profile you evaluate.
+
+## Continue
+
+- [Arc source and README](https://github.com/Cratis/Arc) — repository structure,
+  package roles, contribution guidance, and current product paths.
+- [Arc packages](https://www.nuget.org/packages/Cratis.Arc) — published .NET
+  package metadata and versions.
+- [Components](/components/) — React components aligned with Arc application
+  patterns.

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -1,5 +1,5 @@
 - name: Overview
-  href: index.md
+  href: index.mdx
 - name: Tutorial
   href: tutorial/toc.yml
 - name: Why Arc

--- a/README.md
+++ b/README.md
@@ -1,78 +1,112 @@
 # Cratis Arc
 
-## Packages / Deployables
+Arc is an opinionated CQRS application framework for ASP.NET Core with commands, queries, validation, authorization, and TypeScript proxy generation.
 
-[![Nuget](https://img.shields.io/nuget/v/Cratis.Arc?logo=nuget)](http://nuget.org/packages/Cratis.Arc)
+Arc exposes recognized command and query contracts through ASP.NET Core and can generate TypeScript client code for those artifacts.
+
+[![NuGet](https://img.shields.io/nuget/v/Cratis.Arc?logo=nuget)](https://www.nuget.org/packages/Cratis.Arc)
 [![NPM](https://img.shields.io/npm/v/@cratis/arc?label=@cratis/arc&logo=npm)](https://www.npmjs.com/package/@cratis/arc)
+[![.NET Build](https://github.com/Cratis/Arc/actions/workflows/dotnet-build.yml/badge.svg)](https://github.com/Cratis/Arc/actions/workflows/dotnet-build.yml)
+[![JavaScript Build](https://github.com/Cratis/Arc/actions/workflows/javascript-build.yml/badge.svg)](https://github.com/Cratis/Arc/actions/workflows/javascript-build.yml)
 
-## Builds
+## Start here
 
-[![.NET Build](https://github.com/cratis/arc/actions/workflows/dotnet-build.yml/badge.svg)](https://github.com/cratis/arc/actions/workflows/dotnet-build.yml)
-[![JavaScript Build](https://github.com/cratis/arc/actions/workflows/javascript-build.yml/badge.svg)](https://github.com/cratis/arc/actions/workflows/javascript-build.yml)
-[![Documentation site](https://github.com/Cratis/Documentation/actions/workflows/pages.yml/badge.svg)](https://github.com/Cratis/Documentation/actions/workflows/pages.yml)
+- [Understand why Arc exists](https://cratis.io/arc/why-arc/)
+- [Build a feature in the Arc tutorial](https://cratis.io/arc/tutorial/)
+- [Use CQRS without event sourcing](https://cratis.io/arc/arc-without-event-sourcing/)
+- [Browse the Arc documentation](https://cratis.io/arc/)
 
-## Description
+## What Arc owns
 
-Cratis Arc represents an opinionated approach to building consistent applications based on the concepts behind CQRS.
-It offers extensions for different frameworks and is built on top of ASP.NET Core. One of the traits of Arc has is the
-bridging between the backend and the frontend. Arc provides a tool, called **ProxyGenerator** that generates TypeScript
-code for recognized artifacts matching the criteria of what is considered a **commmand** or a **query**.
+| Boundary | Arc provides |
+| --- | --- |
+| Commands | Explicit application intentions, validation, authorization, execution, and generated HTTP endpoints |
+| Queries | Purpose-shaped reads exposed through model-bound or controller-based query surfaces |
+| Generated contracts | TypeScript proxies for recognized command and query artifacts |
+| ASP.NET Core integration | Hosting, dependency injection, identity, tenancy, OpenAPI, and application conventions |
+| Frontend packages | TypeScript runtime support for generated proxies plus React and React/MVVM integration packages |
+| Persistence integration | Separate integrations for current-state persistence and optional Chronicle-backed behavior |
 
-## Support
+Detailed API, configuration, provider, and frontend documentation lives in the canonical documentation. This README is the shortest path into that documentation rather than a second manual.
 
-Cratis is an open community, and we are glad to help users, teams evaluating the stack, and contributors.
+## Arc does not require event sourcing
 
-| Channel | Details |
-|---|---|
-| Discord | Join the community on [Discord](https://discord.gg/kt4AMpV8WV) for questions and discussions |
-| GitHub Issues | [Report bugs or request features](https://github.com/Cratis/Arc/issues) |
-| Documentation | Read the docs at [cratis.io](https://cratis.io) |
+Arc.Core does not depend on Chronicle. Commands and queries can use current-state persistence or application services without an event log. The [CQRS without event sourcing](https://cratis.io/arc/arc-without-event-sourcing/) guide shows that boundary explicitly.
+
+The Chronicle integration is optional and supplies event-sourced behavior when configured. Arc retains its command, query, validation, authorization, and generated-contract boundary.
+
+## Relationship to Components
+
+Components is a React component library aligned with Arc application patterns. Its exact component and integration surface is documented by the [Components product documentation](https://cratis.io/components/).
+
+Applications may use Arc without Components and remain responsible for their own frontend, accessibility, browser, and design-system verification.
+
+## Start an Arc host
+
+Arc's .NET packages embed this product-family README. The example below uses the umbrella `Cratis.Arc` package to start an Arc host; when viewing this README from a specialized package page, use that package's manifest and reference documentation for its own installation scope.
+
+The current Arc analyzers and source generators require .NET SDK 10.0.301 or newer. Install the host package:
+
+```bash
+dotnet add package Cratis.Arc
+```
+
+Create and run an Arc host:
+
+```csharp
+using Cratis.Arc;
+
+var builder = ArcApplication.CreateBuilder(args);
+builder.AddCratisArc();
+
+var app = builder.Build();
+app.UseCratisArc();
+await app.RunAsync();
+```
+
+Starting this host proves the Arc application setup can build and run on the selected SDK/profile. Continue with [Getting started](https://cratis.io/arc/backend/core/getting-started/) to define a command and query, then use the [tutorial](https://cratis.io/arc/tutorial/) for the documented backend-to-frontend path. Use [Troubleshooting](https://cratis.io/arc/troubleshooting/) if the host, generated endpoints, or proxies do not match the guide.
+
+## Packages and repository layout
+
+| Surface | Role |
+| --- | --- |
+| `Cratis.Arc` / `Cratis.Arc.Core` | .NET command, query, hosting, validation, authorization, and generation surfaces |
+| `Cratis.Arc.ProxyGenerator.Build` | Build-time TypeScript proxy generation for recognized application artifacts |
+| `@cratis/arc` | TypeScript runtime support consumed by application-specific generated command and query proxies |
+| `@cratis/arc.react` | React hooks and compositions for Arc contracts |
+| `@cratis/arc.react.mvvm` | React/MVVM integration for Arc contracts |
+| [`Source/DotNET`](https://github.com/Cratis/Arc/tree/main/Source/DotNET) | .NET framework source |
+| [`Source/JavaScript`](https://github.com/Cratis/Arc/tree/main/Source/JavaScript) | TypeScript and React package source |
+| [`Documentation`](https://github.com/Cratis/Arc/tree/main/Documentation) | Product-owned documentation rendered on cratis.io |
+| [`TestApps`](https://github.com/Cratis/Arc/tree/main/TestApps) | Sample and integration applications used by repository checks |
+
+Package existence does not imply compatibility with every frontend, runtime, persistence provider, or product version. Use the exact package manifests, current documentation, and exercised profile for the combination you adopt.
+
+## Documentation map
+
+- [Commands](https://cratis.io/arc/backend/commands/)
+- [Queries](https://cratis.io/arc/backend/queries/)
+- [Command validation](https://cratis.io/arc/backend/commands/validation/)
+- [Authorization](https://cratis.io/arc/backend/core/authorization/)
+- [Proxy generation](https://cratis.io/arc/backend/proxy-generation/)
+- [Frontend](https://cratis.io/arc/frontend/)
+- [Troubleshooting](https://cratis.io/arc/troubleshooting/)
 
 ## Contributing
 
-If you want to jump into building this repository and possibly contributing, please refer to [contributing](./Documentation/contributing/index.md).
+Arc is a framework-library repository. Public APIs, analyzers, generated output, package shapes, and backward compatibility are product contracts.
 
-### Prerequisites
+Repository development currently requires the SDK and toolchain versions declared by [`global.json`](https://github.com/Cratis/Arc/blob/main/global.json) and [`package.json`](https://github.com/Cratis/Arc/blob/main/package.json). Follow the [Cratis contribution guide](https://github.com/Cratis/.github/blob/main/contributing.md) and the [framework instructions](https://github.com/Cratis/Arc/blob/main/.ai/rules/framework.md) before changing public surfaces.
 
-The following are prerequisites to work with this repository.
+Before submitting documentation-only work, verify its links, anchors, and examples explicitly; current automated documentation checks are path-scoped. Source changes must pass the owning repository's applicable build, specification, TypeScript, and documentation gates.
 
-* [.NET SDK 10.0.301+](https://dotnet.microsoft.com/en-us/). Arc's analyzers and source generators are built
-  against Roslyn 5.6.0, which ships with .NET SDK 10.0.301 and newer. On an older SDK band the compiler
-  refuses to load them (CS9057), silently disabling proxy generation and the ARC*/ARCCHR* analyzers.
-  Consuming the `Cratis.Arc` packages carries the same floor. Raising this floor is a minor version bump.
-* [Node 16+](https://nodejs.org/en)
-* [Yarn](https://yarnpkg.com)
+## Community and repository
 
-### Central Package Management
-
-This repository leverages [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management), which
-means that all package versions are managed from a file at the root level called [Directory.Packages.props](./Directory.Packages.props).
-
-In addition there are also [Directory.Build.props](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022#directorybuildprops-and-directorybuildtargets) files for
-setting up common settings that are applied cross cuttingly.
-
-### Root package.json
-
-The `package.json` found at the root level defines all the workspaces. It is assumed
-
-All developer dependencies are defined in the top level `package.json`. The reason for this is to be able to provide global scripts
-for every package to use for easier maintenance.
-
-The `package.json` found at the top level contains scripts that can then be used in a child project for this to work properly.
-
-In a package, all you need to do is to define the scripts to use the global scripts in the `package.json´ of that project:
-
-```json
-{
-    "scripts": {
-        "prepublish": "yarn g:build",
-        "clean": "yarn g:clean",
-        "build": "yarn g:build",
-        "lint": "yarn g:lint",
-        "lint:ci": "yarn g:lint:ci",
-        "test": "yarn g:test",
-        "ci": "yarn g:ci",
-        "up": "yarn g:up"
-    }
-}
-```
+| Path | Destination |
+| --- | --- |
+| Questions and discussion | [Cratis Discord](https://discord.gg/kt4AMpV8WV) |
+| Bugs and feature requests | [GitHub Issues](https://github.com/Cratis/Arc/issues) |
+| Releases | [GitHub Releases](https://github.com/Cratis/Arc/releases) |
+| Documentation | [cratis.io/arc](https://cratis.io/arc/) |
+| Security reports | [Private security reporting](mailto:oss@cratis.io?subject=Security%3A) |
+| License | [`LICENSE`](https://github.com/Cratis/Arc/blob/main/LICENSE) |

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Arc exposes recognized command and query contracts through ASP.NET Core and can 
 
 ## Start here
 
-- [Understand why Arc exists](https://cratis.io/arc/why-arc/)
-- [Build a feature in the Arc tutorial](https://cratis.io/arc/tutorial/)
-- [Use CQRS without event sourcing](https://cratis.io/arc/arc-without-event-sourcing/)
-- [Browse the Arc documentation](https://cratis.io/arc/)
+- [Browse the canonical Arc documentation](https://cratis.io/arc/)
+- [Understand Arc's independent boundary](#arc-does-not-require-event-sourcing)
+- [Start an Arc host](#start-an-arc-host)
+- [Inspect packages and repository layout](#packages-and-repository-layout)
 
 ## What Arc owns
 
@@ -31,7 +31,7 @@ Detailed API, configuration, provider, and frontend documentation lives in the c
 
 ## Arc does not require event sourcing
 
-Arc.Core does not depend on Chronicle. Commands and queries can use current-state persistence or application services without an event log. The [CQRS without event sourcing](https://cratis.io/arc/arc-without-event-sourcing/) guide shows that boundary explicitly.
+Arc.Core does not depend on Chronicle. Commands and queries can use current-state persistence or application services without an event log. The owning repository and canonical Arc page preserve that boundary explicitly.
 
 The Chronicle integration is optional and supplies event-sourced behavior when configured. Arc retains its command, query, validation, authorization, and generated-contract boundary.
 
@@ -64,7 +64,7 @@ app.UseCratisArc();
 await app.RunAsync();
 ```
 
-Starting this host proves the Arc application setup can build and run on the selected SDK/profile. Continue with [Getting started](https://cratis.io/arc/backend/core/getting-started/) to define a command and query, then use the [tutorial](https://cratis.io/arc/tutorial/) for the documented backend-to-frontend path. Use [Troubleshooting](https://cratis.io/arc/troubleshooting/) if the host, generated endpoints, or proxies do not match the guide.
+Starting this host proves the Arc application setup can build and run on the selected SDK/profile. Continue from the [canonical Arc page](https://cratis.io/arc/) for the currently admitted documentation profile, and use [GitHub Issues](https://github.com/Cratis/Arc/issues) when observed behavior does not match it.
 
 ## Packages and repository layout
 
@@ -84,13 +84,10 @@ Package existence does not imply compatibility with every frontend, runtime, per
 
 ## Documentation map
 
-- [Commands](https://cratis.io/arc/backend/commands/)
-- [Queries](https://cratis.io/arc/backend/queries/)
-- [Command validation](https://cratis.io/arc/backend/commands/validation/)
-- [Authorization](https://cratis.io/arc/backend/core/authorization/)
-- [Proxy generation](https://cratis.io/arc/backend/proxy-generation/)
-- [Frontend](https://cratis.io/arc/frontend/)
-- [Troubleshooting](https://cratis.io/arc/troubleshooting/)
+- [Canonical Arc documentation](https://cratis.io/arc/)
+- [Product-owned documentation source](https://github.com/Cratis/Arc/tree/main/Documentation)
+- [Arc releases](https://github.com/Cratis/Arc/releases)
+- [Arc issues](https://github.com/Cratis/Arc/issues)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Arc is an opinionated CQRS application framework for ASP.NET Core with commands, queries, validation, authorization, and TypeScript proxy generation.
 
-Arc exposes recognized command and query contracts through ASP.NET Core and can generate TypeScript client code for those artifacts.
+Arc hosts application behavior, executes command and query pipelines, exposes recognized contracts over HTTP, and generates TypeScript clients for them. Its packages also cover observable queries, validation, identity and tenancy, React integration, current-state persistence, OpenAPI, analyzers, and testing. Chronicle event sourcing and Cratis Components are optional integrations.
 
 [![NuGet](https://img.shields.io/nuget/v/Cratis.Arc?logo=nuget)](https://www.nuget.org/packages/Cratis.Arc)
 [![NPM](https://img.shields.io/npm/v/@cratis/arc?label=@cratis/arc&logo=npm)](https://www.npmjs.com/package/@cratis/arc)
@@ -11,7 +11,8 @@ Arc exposes recognized command and query contracts through ASP.NET Core and can 
 
 ## Start here
 
-- [Browse the canonical Arc documentation](https://cratis.io/arc/)
+- [Browse the Arc documentation](https://www.cratis.io/arc/)
+- [Choose a documented application path](#choose-a-path)
 - [Understand Arc's independent boundary](#arc-does-not-require-event-sourcing)
 - [Start an Arc host](#start-an-arc-host)
 - [Inspect packages and repository layout](#packages-and-repository-layout)
@@ -20,24 +21,42 @@ Arc exposes recognized command and query contracts through ASP.NET Core and can 
 
 | Boundary | Arc provides |
 | --- | --- |
-| Commands | Explicit application intentions, validation, authorization, execution, and generated HTTP endpoints |
-| Queries | Purpose-shaped reads exposed through model-bound or controller-based query surfaces |
-| Generated contracts | TypeScript proxies for recognized command and query artifacts |
-| ASP.NET Core integration | Hosting, dependency injection, identity, tenancy, OpenAPI, and application conventions |
-| Frontend packages | TypeScript runtime support for generated proxies plus React and React/MVVM integration packages |
-| Persistence integration | Separate integrations for current-state persistence and optional Chronicle-backed behavior |
+| Hosting | ASP.NET Core hosting plus an Arc.Core HTTP host for workers, consoles, and custom services |
+| Commands | Model-bound and controller-based execution, validation, authorization, filters, scopes, typed results, and generated endpoints |
+| Queries | Model-bound and controller-based reads, paging and sorting, observable updates, WebSocket or Server-Sent Events transport, and query diagnostics |
+| Validation | Data annotations, FluentValidation, concept/command/query validators, generated client rules, and optional server preflight from React forms |
+| Identity and tenancy | Pluggable authentication, identity details, role-based authorization, and header, query, claim, subdomain, fixed, or development tenant resolution |
+| Generated contracts | TypeScript proxies, referenced types, validation metadata, identity details, incremental output cleanup, and package/type mapping |
+| Frontend packages | TypeScript command/query runtimes, React hooks and forms, dialogs, observable-query composition, and optional React/MVVM integration |
+| Persistence integration | MongoDB and Entity Framework Core current-state adapters plus optional Chronicle-backed event-sourced behavior |
+| Evaluation and tooling | OpenAPI, runtime introspection, analyzers, source generators, command scenarios, proxy-generation checks, Vite helpers, and ESLint rules |
 
-Detailed API, configuration, provider, and frontend documentation lives in the canonical documentation. This README is the shortest path into that documentation rather than a second manual.
+Each row is a documented capability area, not a promise of compatibility with every package, host, provider, browser, or product version.
+
+## Choose a path
+
+Arc documentation is organized around the job you need to complete:
+
+- [Execute commands](https://github.com/Cratis/Arc/blob/main/Documentation/backend/commands/index.md) — model-bound or controller-based changes, pipelines, validation, authorization, filters, and response handling.
+- [Expose queries and observable results](https://github.com/Cratis/Arc/blob/main/Documentation/backend/queries/index.md) — request/response reads, paging, sorting, streaming updates, diagnostics, and generated clients.
+- [Build the frontend](https://github.com/Cratis/Arc/blob/main/Documentation/frontend/index.mdx) — TypeScript runtimes, React hooks and forms, dialogs, identity, messaging, and optional MVVM packages.
+- [Configure identity and access](https://github.com/Cratis/Arc/blob/main/Documentation/understanding-identity-and-access.mdx) — authentication, identity details, authorization, roles, and frontend visibility boundaries.
+- [Resolve tenants](https://github.com/Cratis/Arc/blob/main/Documentation/backend/tenancy/index.md) — request resolvers, scoped tenant context, and provider-specific database or namespace mapping.
+- [Use current-state persistence](https://github.com/Cratis/Arc/blob/main/Documentation/arc-without-event-sourcing.md) — application services, MongoDB, or Entity Framework Core without requiring an event log.
+- [Add Chronicle event sourcing](https://github.com/Cratis/Arc/blob/main/Documentation/backend/chronicle/index.md) — events, projections, reducers, aggregates, reactors, concurrency, and Chronicle-specific testing.
+- [Inspect and verify the application boundary](https://github.com/Cratis/Arc/blob/main/Documentation/backend/introspection/index.md) — introspection, OpenAPI, analyzers, generated metadata, and command scenarios.
+
+The canonical Arc page remains the front door; product-owned documentation and source carry the detail.
 
 ## Arc does not require event sourcing
 
-Arc.Core does not depend on Chronicle. Commands and queries can use current-state persistence or application services without an event log. The owning repository and canonical Arc page preserve that boundary explicitly.
+Arc.Core does not depend on Chronicle. Commands and queries can use current-state persistence or application services without an event log. Choose the persistence and integrations that fit each application boundary.
 
 The Chronicle integration is optional and supplies event-sourced behavior when configured. Arc retains its command, query, validation, authorization, and generated-contract boundary.
 
 ## Relationship to Components
 
-Components is a React component library aligned with Arc application patterns. Its exact component and integration surface is documented by the [Components product documentation](https://cratis.io/components/).
+Components is a React component library aligned with Arc application patterns. See the [Components documentation](https://www.cratis.io/components/) for its packages and setup.
 
 Applications may use Arc without Components and remain responsible for their own frontend, accessibility, browser, and design-system verification.
 
@@ -45,7 +64,7 @@ Applications may use Arc without Components and remain responsible for their own
 
 Arc's .NET packages embed this product-family README. The example below uses the umbrella `Cratis.Arc` package to start an Arc host; when viewing this README from a specialized package page, use that package's manifest and reference documentation for its own installation scope.
 
-The current Arc analyzers and source generators require .NET SDK 10.0.301 or newer. Install the host package:
+Use the .NET SDK declared by Arc's current [`global.json`](https://github.com/Cratis/Arc/blob/main/global.json). Install the host package:
 
 ```bash
 dotnet add package Cratis.Arc
@@ -64,27 +83,32 @@ app.UseCratisArc();
 await app.RunAsync();
 ```
 
-Starting this host proves the Arc application setup can build and run on the selected SDK/profile. Continue from the [canonical Arc page](https://cratis.io/arc/) for the currently admitted documentation profile, and use [GitHub Issues](https://github.com/Cratis/Arc/issues) when observed behavior does not match it.
+Starting the host confirms the basic Arc setup. Continue with the [Arc documentation](https://www.cratis.io/arc/), and use [GitHub Issues](https://github.com/Cratis/Arc/issues) when the observed behavior does not match the documentation.
 
 ## Packages and repository layout
 
 | Surface | Role |
 | --- | --- |
-| `Cratis.Arc` / `Cratis.Arc.Core` | .NET command, query, hosting, validation, authorization, and generation surfaces |
+| `Cratis.Arc` / `Cratis.Arc.Core` | .NET hosting, command/query pipelines, validation, identity, tenancy, HTTP, introspection, and application conventions |
 | `Cratis.Arc.ProxyGenerator.Build` | Build-time TypeScript proxy generation for recognized application artifacts |
-| `@cratis/arc` | TypeScript runtime support consumed by application-specific generated command and query proxies |
-| `@cratis/arc.react` | React hooks and compositions for Arc contracts |
-| `@cratis/arc.react.mvvm` | React/MVVM integration for Arc contracts |
+| `Cratis.Arc.MongoDB` / `Cratis.Arc.EntityFrameworkCore*` | Optional current-state persistence and observation adapters |
+| `Cratis.Arc.Chronicle` | Optional event-sourced command, projection, reducer, aggregate, reactor, tenancy, and compliance integration |
+| `Cratis.Arc.OpenApi` / `Cratis.Arc.Swagger` | Optional OpenAPI document transformation for Arc concepts and endpoints |
+| `Cratis.Arc.Testing` / `Cratis.Arc.Chronicle.Testing` | Command-scenario and optional Chronicle event/read-model testing helpers |
+| `@cratis/arc` | TypeScript command, query, validation, identity, and messaging runtime used by generated proxies |
+| `@cratis/arc.react` | React hooks, forms, dialogs, identity, messaging, and query composition for Arc contracts |
+| `@cratis/arc.react.mvvm` | Optional React/MVVM and dependency-injection integration |
+| `@cratis/arc.vite` / `@cratis/eslint-plugin-arc` | Vite metadata/query helpers and Arc-specific frontend lint rules |
 | [`Source/DotNET`](https://github.com/Cratis/Arc/tree/main/Source/DotNET) | .NET framework source |
 | [`Source/JavaScript`](https://github.com/Cratis/Arc/tree/main/Source/JavaScript) | TypeScript and React package source |
 | [`Documentation`](https://github.com/Cratis/Arc/tree/main/Documentation) | Product-owned documentation rendered on cratis.io |
 | [`TestApps`](https://github.com/Cratis/Arc/tree/main/TestApps) | Sample and integration applications used by repository checks |
 
-Package existence does not imply compatibility with every frontend, runtime, persistence provider, or product version. Use the exact package manifests, current documentation, and exercised profile for the combination you adopt.
+Package existence does not imply compatibility with every frontend, runtime, persistence provider, or product version. Check the package manifests and documentation for the versions you use.
 
 ## Documentation map
 
-- [Canonical Arc documentation](https://cratis.io/arc/)
+- [Arc documentation](https://www.cratis.io/arc/)
 - [Product-owned documentation source](https://github.com/Cratis/Arc/tree/main/Documentation)
 - [Arc releases](https://github.com/Cratis/Arc/releases)
 - [Arc issues](https://github.com/Cratis/Arc/issues)
@@ -104,6 +128,6 @@ Before submitting documentation-only work, verify its links, anchors, and exampl
 | Questions and discussion | [Cratis Discord](https://discord.gg/kt4AMpV8WV) |
 | Bugs and feature requests | [GitHub Issues](https://github.com/Cratis/Arc/issues) |
 | Releases | [GitHub Releases](https://github.com/Cratis/Arc/releases) |
-| Documentation | [cratis.io/arc](https://cratis.io/arc/) |
+| Documentation | [www.cratis.io/arc](https://www.cratis.io/arc/) |
 | Security reports | [Private security reporting](mailto:oss@cratis.io?subject=Security%3A) |
 | License | [`LICENSE`](https://github.com/Cratis/Arc/blob/main/LICENSE) |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Package existence does not imply compatibility with every frontend, runtime, per
 
 ## Contributing
 
-Arc is a framework-library repository. Public APIs, analyzers, generated output, package shapes, and backward compatibility are product contracts.
+Arc is a framework-library repository. Changes to public APIs, analyzers, generated output, and package shapes can affect consumers and require the owning repository's compatibility and release review.
 
 Repository development currently requires the SDK and toolchain versions declared by [`global.json`](https://github.com/Cratis/Arc/blob/main/global.json) and [`package.json`](https://github.com/Cratis/Arc/blob/main/package.json). Follow the [Cratis contribution guide](https://github.com/Cratis/.github/blob/main/contributing.md) and the [framework instructions](https://github.com/Cratis/Arc/blob/main/.ai/rules/framework.md) before changing public surfaces.
 


### PR DESCRIPTION
# Summary

Make Arc's public entry points reflect the application framework documented in the repository—not only its first command/query path. Preserve Arc as a standalone CQRS framework while showing the optional persistence, frontend, Chronicle, OpenAPI, analyzer, and testing surfaces it actually owns.

**Declared effects:** merging updates the GitHub README immediately and dispatches the Arc documentation change to `Cratis/Documentation`. It publishes no Arc NuGet/npm package or GitHub release. The family README enters Arc packages only on a later separately authorized qualifying release.

## Changed

- Keep the exact approved Arc identity: CQRS for ASP.NET Core with commands, queries, validation, authorization, and TypeScript proxy generation.
- Add reader-job paths for hosting, command/query pipelines, observable-query APIs, validation, identity, tenancy, generated contracts, TypeScript/React/MVVM, MongoDB, Entity Framework Core, optional Chronicle, OpenAPI, analyzers, source generators, and testing.
- Explain the package families and which surfaces are standalone Arc versus optional integrations.
- Preserve Arc.Core's no-Chronicle dependency and make Components optional.
- Replace a hardcoded SDK floor with the repository-owned `global.json` contract.
- Link the README to detailed product-owned documentation rather than duplicating the manuals.
- Keep release intent fail-closed with exactly one `major`, `minor`, `patch`, or `no-release` classification.

## Boundaries

- Capability and package existence does not establish compatibility with every frontend, runtime, provider, browser, or product version.
- Observable-query API wording does not promise latency, delivery, ordering, scale, or support.
- Frontend role helpers do not replace server authorization.
- Tenant resolution does not by itself establish storage or application isolation.
- Chronicle and Components remain separately owned optional integrations.

## Verification

Current head: `798965ac5e3c720297c0094f2573808dc588c145`.

- Repository Markdown gate: 264 files, 0 issues.
- Product documentation links: 321 checked, 0 broken.
- Root README markdownlint: 0 issues.
- Root README links: 31 checked, 0 broken after using the working `www.cratis.io` Pages host.
- Hosted checks: 11 passed, 0 pending, 0 failing.
- Full aggregated Astro/Starlight rendering and link validation is being exercised by the separate non-destructive Documentation foundation candidate; this PR does not depend on the eight-route removal candidate.