### PR TITLE
Adopt shared Screenplay source placement

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,9 +23,9 @@
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.0" />
     <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.10.1" />
-    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.10.1" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.10.1" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.12.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.12.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.12.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />

--- a/Documentation/generating-a-screenplay.md
+++ b/Documentation/generating-a-screenplay.md
@@ -52,7 +52,7 @@ Diagnostics come in three severities. **Information** means something is worth k
 
 ## What the generator expects of its host
 
-The generator takes a Roslyn `Compilation` and nothing else. It never opens a project file or loads a workspace, which is what lets it be driven from a CLI, from a specification, or from an editor. The other side of that bargain is that **assembling the compilation the way a real build would is the caller's job** — the generator reads what it is handed and cannot tell a missing type from a type that was never written.
+The compatibility generator accepts either a Roslyn `Compilation` or a Generation `DotNetProjectCompilation`. It never opens a project file or loads a workspace, which is what lets it be driven from a CLI, from a specification, or from an editor. `DotNetProjectCompilation` adds the host-owned project role, authored syntax trees, and stable source-path context needed by neutral source adapters; the established compilation-only overloads remain available and produce the same `.play` bytes. The other side of that bargain is that **assembling the compilation the way a real build would is the caller's job** — the generator reads what it is handed and cannot tell a missing type from a type that was never written.
 
 The part hosts get wrong is source generators. `MSBuildWorkspace.GetCompilationAsync()` does not run them, and neither does any loading mode that stops at the compile items the project file lists. An Arc application leans on generation heavily — `[LoggerMessage]` partial classes, strongly-typed resource designer classes, the proxy and metrics generators — so a compilation loaded that way is missing every type those emit, and every reference to one becomes an unresolved-symbol error. This is the common case rather than an edge case.
 
@@ -101,6 +101,15 @@ So `Generate` takes a list of compilations as well as a single one, and a host g
 ```csharp
 var result = generator.Generate([contracts, application, host], options);
 ```
+
+A host that also runs neutral adapters should retain the project metadata instead of reducing each project to its compilation:
+
+```csharp
+IReadOnlyList<DotNetProjectCompilation> projects = LoadProjects();
+var result = generator.Generate(projects, options);
+```
+
+This project-aware compatibility overload intentionally delegates to the same established generator. The source context is carried for the neutral adapter path, not used to reinterpret legacy placement.
 
 What comes back is one document rather than one per project, because the boundaries between projects are a build concern rather than something the model has:
 
@@ -202,7 +211,7 @@ Values are the exception for the compatibility document generator, because a val
 
 `ArcSpecificationFactAdapter` is the independently consumable source-evidence surface. It contributes Generation scenario, ordered-step, and typed-value facts only when every explicitly authored step and value is exact. One computed or unreadable required value, conditional/repeated step, unretained read-model assertion, or event predicate value blocks the whole neutral scenario with `ARCSP0001`; it never contributes a smaller example than the source wrote.
 
-The adapter retains scenario-, step-, value-, and rejection-level source ranges separately from the existing Arc model. This does not change legacy model equality or the current `.play` generator's compatibility output. Generation resolves the neutral facts by stable source identity, attaches the scenario through the exact target artifact placement, and lowers it only after complete atomic admission.
+The adapter retains scenario-, step-, value-, and rejection-level source ranges separately from the existing Arc model. This does not change legacy model equality or the current `.play` generator's compatibility output. It creates one fixed `DotNetSourceStructures` snapshot and asks `DotNetSourcePlacementDerivation` to place all exact targets together. Application and specification projects therefore use the application target's source placement, read-model and query targets retain `StateView` placement, and folder/namespace disagreement or invalid source policy produces a typed `DOTNETSP####` diagnostic instead of a guessed placement. Generation attaches a scenario only through that exact target placement and lowers it only after complete atomic admission.
 
 This distinction is deliberate: the compatibility generator keeps existing consumers stable, while the neutral adapter provides the fail-closed evidence required for render→recover semantic fidelity.
 

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/PlacementScenarioSources.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/PlacementScenarioSources.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+static class PlacementScenarioSources
+{
+    public const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [Command]
+        public record RegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    public const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_rejecting;
+
+        public class when_rejecting
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterProject(""));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/SourceProjects.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/SourceProjects.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+/// <summary>
+/// Creates project-aware source contexts for neutral Arc adapter specifications.
+/// </summary>
+public static class SourceProjects
+{
+    /// <summary>
+    /// Creates one project with every authored syntax tree mapped to stable source identity.
+    /// </summary>
+    /// <param name="name">The logical project name.</param>
+    /// <param name="role">The role of the project.</param>
+    /// <param name="compilation">The project compilation.</param>
+    /// <param name="projectIdentity">The optional stable project identity.</param>
+    /// <param name="relativePathFor">The optional project-relative path mapping.</param>
+    /// <returns>The mapped project compilation.</returns>
+    public static DotNetProjectCompilation Create(
+        string name,
+        DotNetProjectRole role,
+        Compilation compilation,
+        string? projectIdentity = null,
+        Func<SyntaxTree, string>? relativePathFor = null)
+    {
+        var authoredTrees = compilation.SyntaxTrees.ToHashSet();
+        var documents = authoredTrees.Select(tree =>
+        {
+            var relativePath = relativePathFor?.Invoke(tree) ?? tree.FilePath;
+            return new DotNetSourceDocument
+            {
+                SyntaxTree = tree,
+                ProjectRelativePath = relativePath,
+                WorkspaceRelativePath = $"{name}/{relativePath}"
+            };
+        }).ToArray();
+        var sourceContext = DotNetSourcePaths.Create(
+            projectIdentity ?? name,
+            new DotNetSourcePathPolicy
+            {
+                DisplayRoot = DotNetSourceDisplayRoot.Project,
+                CasePolicy = DotNetSourcePathCasePolicy.Ordinal
+            },
+            documents);
+
+        return new()
+        {
+            Name = name,
+            Role = role,
+            Compilation = compilation,
+            SourceContext = sourceContext,
+            AuthoredSyntaxTrees = authoredTrees
+        };
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
@@ -58,12 +58,7 @@ public class when_analyzing_an_exact_rejection_scenario : Specification
             ("Projects/Registration/RegisterProject/when_rejecting_an_empty_project_name.cs", Scenario),
             (IntegrationTesting.Path, IntegrationTesting.Source)
         ]);
-        var project = new DotNetProjectCompilation
-        {
-            Name = "Projects",
-            Compilation = compilation,
-            AuthoredSyntaxTrees = compilation.SyntaxTrees.ToHashSet()
-        };
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
         var context = new DotNetAnalysisContext([project]);
         var adapter = new ArcSpecificationFactAdapter();
         _canAnalyze = adapter.CanAnalyze(context);

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_event_predicate_values.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_event_predicate_values.cs
@@ -74,12 +74,7 @@ public class when_analyzing_event_predicate_values : Specification
             ("Integration/Assertions.cs", Assertions),
             (IntegrationTesting.Path, IntegrationTesting.Source)
         ]);
-        var project = new DotNetProjectCompilation
-        {
-            Name = "Projects",
-            Compilation = compilation,
-            AuthoredSyntaxTrees = compilation.SyntaxTrees.ToHashSet()
-        };
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
         _contribution = new ArcSpecificationFactAdapter().Analyze(
             new DotNetAnalysisContext([project]),
             new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_deriving_shared_source_placement.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_deriving_shared_source_placement.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Cratis.Screenplay.Printing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_deriving_shared_source_placement : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [Command]
+        public record RegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_rejecting_an_empty_project_name;
+
+        public class when_rejecting_an_empty_project_name
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterProject(""));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    AdapterContribution _singleProject = null!;
+    AdapterContribution _specificationProject = null!;
+    AdapterContribution _reversed = null!;
+    string _specificationProjectSource = null!;
+    string _reversedSource = null!;
+
+    void Because()
+    {
+        _singleProject = AnalyzeSingleProject();
+        _specificationProject = AnalyzeSeparateProjects(false, false);
+        _reversed = AnalyzeSeparateProjects(true, true);
+        _specificationProjectSource = Source(_specificationProject);
+        _reversedSource = Source(_reversed);
+    }
+
+    [Fact] void should_derive_the_existing_module() => Placement(_singleProject).Module.ShouldEqual("Projects");
+    [Fact] void should_derive_the_existing_feature() => Placement(_singleProject).Features.ShouldContainOnly(["Registration"]);
+    [Fact] void should_derive_the_existing_slice() => Placement(_singleProject).Slice.ShouldEqual("RegisterProject");
+    [Fact] void should_preserve_application_and_specification_project_placement_parity() => PlacementText(_specificationProject).ShouldEqual(PlacementText(_singleProject));
+    [Fact] void should_use_the_application_target_source() => _specificationProject.Facts.OfType<ArtifactPlacementFact>().Single().Evidence.Source!.Path.ShouldEqual("Source/Projects/Registration/RegisterProject/RegisterProject.cs");
+    [Fact] void should_be_independent_of_project_and_syntax_tree_order() => _reversedSource.ShouldEqual(_specificationProjectSource);
+    [Fact] void should_report_no_diagnostics_for_any_positive_arrangement() => new[] { _singleProject, _specificationProject, _reversed }.SelectMany(_ => _.Diagnostics).ShouldBeEmpty();
+
+    static AdapterContribution AnalyzeSingleProject()
+    {
+        var compilation = Analyzed.Project(
+            "Projects",
+            [],
+            ("Source/Projects/Registration/RegisterProject/RegisterProject.cs", Slice),
+            ("Source/Projects/Registration/RegisterProject/when_rejecting_an_empty_project_name.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source));
+        return Analyze([SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation)]);
+    }
+
+    static AdapterContribution AnalyzeSeparateProjects(bool reverseProjects, bool reverseSyntaxTrees)
+    {
+        var applicationSources = new[]
+        {
+            ("Source/Projects/Registration/RegisterProject/RegisterProject.cs", Slice)
+        };
+        var application = Analyzed.Project("Projects", [], applicationSources);
+        var specificationSources = new[]
+        {
+            ("Source/Projects/Registration/RegisterProject/when_rejecting_an_empty_project_name.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        };
+        if (reverseSyntaxTrees)
+        {
+            specificationSources = [.. specificationSources.AsEnumerable().Reverse()];
+        }
+
+        var specifications = Analyzed.Project(
+            "Projects.Specifications",
+            [application.ToMetadataReference()],
+            specificationSources);
+        DotNetProjectCompilation[] projects =
+        [
+            SourceProjects.Create("Projects", DotNetProjectRole.Application, application),
+            SourceProjects.Create("Projects.Specifications", DotNetProjectRole.Specifications, specifications)
+        ];
+        if (reverseProjects)
+        {
+            projects = [.. projects.AsEnumerable().Reverse()];
+        }
+
+        return Analyze(projects);
+    }
+
+    static AdapterContribution Analyze(IReadOnlyList<DotNetProjectCompilation> projects) =>
+        new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext(projects),
+            new DotNetAdapterOptions
+            {
+                FeatureRoot = "Source",
+                Module = "Projects",
+                NamespaceSegmentsToSkip = 1
+            });
+
+    static ArtifactPlacement Placement(AdapterContribution contribution) =>
+        contribution.Facts.OfType<ArtifactPlacementFact>().Single().Placement;
+
+    static string PlacementText(AdapterContribution contribution)
+    {
+        var placement = Placement(contribution);
+        return $"{placement.Module}:{string.Join('/', placement.Features)}:{placement.Slice}:{placement.SliceKind}";
+    }
+
+    static string Source(AdapterContribution contribution)
+    {
+        var graph = new GenerationResolver().Resolve([contribution]);
+        var lowering = new ScreenplayLowerer().Lower(graph, "Projects");
+        return new ScreenplayPrinter().Print(lowering.Application);
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_one_scenario_has_invalid_placement.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_one_scenario_has_invalid_placement.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_one_scenario_has_invalid_placement : Specification
+{
+    const string ValidSlice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [Command]
+        public record RegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string InvalidSlice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RenameProject;
+
+        [EventType]
+        public record ProjectRenamed(string Name);
+
+        [Command]
+        public record RenameProject(string Name)
+        {
+            public ProjectRenamed Handle() => new(Name);
+        }
+        """;
+
+    const string ValidScenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_rejecting_registration;
+
+        public class when_rejecting_registration
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterProject(""));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    const string InvalidScenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Projects.Projects.Registration.RenameProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RenameProject.when_rejecting_rename;
+
+        public class when_rejecting_rename
+        {
+            readonly CommandScenario<RenameProject> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RenameProject(""));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because()
+    {
+        var compilation = Analyzed.Project(
+            "Projects",
+            [],
+            ("Source/Projects/Registration/RegisterProject/RegisterProject.cs", ValidSlice),
+            ("Source/Projects/Registration/ArchiveProject/RenameProject.cs", InvalidSlice),
+            ("Source/Projects/Registration/RegisterProject/when_rejecting_registration.cs", ValidScenario),
+            ("Source/Projects/Registration/RenameProject/when_rejecting_rename.cs", InvalidScenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source));
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        _contribution = new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions
+            {
+                FeatureRoot = "Source",
+                Module = "Projects",
+                NamespaceSegmentsToSkip = 1
+            });
+    }
+
+    [Fact] void should_report_only_the_invalid_target_placement() => _contribution.Diagnostics.Single().Code.ShouldEqual(DotNetSourceStructureDiagnosticCodes.ConflictingStructure);
+    [Fact] void should_keep_the_independently_valid_scenario() => _contribution.Facts.OfType<SpecificationScenarioFact>().Single().Definition.Name.ShouldEqual("when_rejecting_registration_when_rejecting_registration");
+    [Fact] void should_publish_only_the_valid_scenario_steps() => _contribution.Facts.OfType<SpecificationStepFact>().Count().ShouldEqual(2);
+    [Fact] void should_publish_only_the_valid_scenario_value() => _contribution.Facts.OfType<SpecificationValueFact>().Count().ShouldEqual(1);
+    [Fact] void should_publish_only_the_valid_target_placement() => _contribution.Facts.OfType<ArtifactPlacementFact>().Single().Placement.Slice.ShouldEqual("RegisterProject");
+    [Fact] void should_not_publish_the_blocked_target_artifact() => _contribution.Facts.OfType<ArtifactFact>().Any(_ => _.Definition.Name == "RenameProject").ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_placing_a_read_model_query_target.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_placing_a_read_model_query_target.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_placing_a_read_model_query_target : Specification
+{
+    const string StateView = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Projects.Projects.Overview.ListProjects;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [ReadModel]
+        [FromEvent<ProjectRegistered>]
+        public record ProjectOverview
+        {
+            public string Name { get; init; } = string.Empty;
+
+            public static IEnumerable<ProjectOverview> AllProjects() => [];
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.ReadModels;
+
+        namespace Projects.Projects.Overview.ListProjects.when_a_project_was_registered;
+
+        public class when_a_project_was_registered
+        {
+            readonly ReadModelScenario<ProjectOverview> _scenario = new();
+
+            async Task Because() =>
+                await _scenario.Given
+                    .ForEventSource(EventSourceId.New())
+                    .Events(new ProjectRegistered("Screenplay"));
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because()
+    {
+        var compilation = Analyzed.Project(
+            "Projects",
+            [],
+            ("Source/Projects/Overview/ListProjects/ListProjects.cs", StateView),
+            ("Source/Projects/Overview/ListProjects/when_a_project_was_registered.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source));
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        _contribution = new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions
+            {
+                FeatureRoot = "Source",
+                Module = "Projects",
+                NamespaceSegmentsToSkip = 1
+            });
+    }
+
+    [Fact] void should_report_no_adapter_diagnostics() => _contribution.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_identify_the_read_model_target() => _contribution.Facts.OfType<SpecificationScenarioFact>().Single().Definition.TargetArtifact.Kind.ShouldEqual(ArtifactKind.ReadModel);
+    [Fact] void should_place_the_read_model_and_its_query_as_a_state_view() => _contribution.Facts.OfType<ArtifactPlacementFact>().Single().Placement.SliceKind.ShouldEqual(GenerationSliceKind.StateView);
+    [Fact] void should_preserve_the_state_view_slice() => _contribution.Facts.OfType<ArtifactPlacementFact>().Single().Placement.Slice.ShouldEqual("ListProjects");
+    [Fact] void should_contribute_the_read_model_scenario_atomically() => _contribution.Facts.OfType<SpecificationScenarioFact>().Count().ShouldEqual(1);
+    [Fact] void should_preserve_the_read_model_outcome() => _contribution.Facts.OfType<SpecificationStepFact>().Single(_ => _.Definition.Kind == SpecificationStepKind.ReadModel).Definition.Artifact!.Kind.ShouldEqual(ArtifactKind.ReadModel);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_source_context_is_missing.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_source_context_is_missing.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_source_context_is_missing : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [Command]
+        public record RegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_rejecting;
+
+        public class when_rejecting
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterProject(""));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because()
+    {
+        var compilation = Analyzed.Project(
+            "Projects",
+            [],
+            ("Source/Projects/Registration/RegisterProject/RegisterProject.cs", Slice),
+            ("Source/Projects/Registration/RegisterProject/when_rejecting.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source));
+        var project = new DotNetProjectCompilation
+        {
+            Name = "Projects",
+            Role = DotNetProjectRole.Application,
+            Compilation = compilation,
+            AuthoredSyntaxTrees = compilation.SyntaxTrees.ToHashSet()
+        };
+        _contribution = new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions { FeatureRoot = "Source", Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    [Fact] void should_report_the_missing_source_context() => _contribution.Diagnostics.Single().Code.ShouldEqual(DotNetSourceStructureDiagnosticCodes.MissingSourceContext);
+    [Fact] void should_publish_no_scenario_without_target_context() => _contribution.Facts.OfType<SpecificationScenarioFact>().ShouldBeEmpty();
+    [Fact] void should_publish_no_placement_without_target_context() => _contribution.Facts.OfType<ArtifactPlacementFact>().ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_source_folder_and_namespace_placements_conflict.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_source_folder_and_namespace_placements_conflict.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_source_folder_and_namespace_placements_conflict : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RenameProject;
+
+        [EventType]
+        public record ProjectRenamed(string Name);
+
+        [Command]
+        public record RenameProject(string Name)
+        {
+            public ProjectRenamed Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Projects.Projects.Registration.RenameProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RenameProject.when_rejecting_an_empty_name;
+
+        public class when_rejecting_an_empty_name
+        {
+            readonly CommandScenario<RenameProject> _scenario = new();
+            Result _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RenameProject(""));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because()
+    {
+        var compilation = Analyzed.Project(
+            "Projects",
+            [],
+            ("Source/Projects/Registration/RegisterProject/RenameProject.cs", Slice),
+            ("Source/Projects/Registration/RenameProject/when_rejecting_an_empty_name.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source));
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        _contribution = new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions
+            {
+                FeatureRoot = "Source",
+                Module = "Projects",
+                NamespaceSegmentsToSkip = 1
+            });
+    }
+
+    [Fact] void should_report_the_typed_folder_namespace_conflict() => _contribution.Diagnostics.Single().Code.ShouldEqual(DotNetSourceStructureDiagnosticCodes.ConflictingStructure);
+    [Fact] void should_retain_the_target_subject() => _contribution.Diagnostics.Single().Subject.ShouldNotBeNull();
+    [Fact] void should_contribute_no_target_placement() => _contribution.Facts.OfType<ArtifactPlacementFact>().ShouldBeEmpty();
+    [Fact] void should_publish_no_partial_scenario() => _contribution.Facts.OfType<SpecificationScenarioFact>().ShouldBeEmpty();
+    [Fact] void should_publish_no_partial_steps() => _contribution.Facts.OfType<SpecificationStepFact>().ShouldBeEmpty();
+    [Fact] void should_publish_no_partial_values() => _contribution.Facts.OfType<SpecificationValueFact>().ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_the_feature_root_is_invalid.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_the_feature_root_is_invalid.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_the_feature_root_is_invalid : Specification
+{
+    AdapterContribution _rooted = null!;
+    AdapterContribution _traversing = null!;
+
+    void Because()
+    {
+        var compilation = Analyzed.Project(
+            "Projects",
+            [],
+            ("Source/Projects/Registration/RegisterProject/RegisterProject.cs", PlacementScenarioSources.Slice),
+            ("Source/Projects/Registration/RegisterProject/when_rejecting.cs", PlacementScenarioSources.Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source));
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        _rooted = Analyze(project, "/Source");
+        _traversing = Analyze(project, "../Source");
+    }
+
+    [Fact] void should_reject_a_rooted_feature_root() => _rooted.Diagnostics.Single().Code.ShouldEqual(DotNetSourceStructureDiagnosticCodes.InvalidPath);
+    [Fact] void should_reject_a_traversing_feature_root() => _traversing.Diagnostics.Single().Code.ShouldEqual(DotNetSourceStructureDiagnosticCodes.InvalidPath);
+    [Fact] void should_publish_no_scenario_for_either_invalid_root() => new[] { _rooted, _traversing }.All(_ => !_.Facts.OfType<SpecificationScenarioFact>().Any()).ShouldBeTrue();
+    [Fact] void should_publish_no_placement_for_either_invalid_root() => new[] { _rooted, _traversing }.All(_ => !_.Facts.OfType<ArtifactPlacementFact>().Any()).ShouldBeTrue();
+
+    static AdapterContribution Analyze(DotNetProjectCompilation project, string featureRoot) =>
+        new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions
+            {
+                FeatureRoot = featureRoot,
+                Module = "Projects",
+                NamespaceSegmentsToSkip = 1
+            });
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_preserving_legacy_placement_options.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_preserving_legacy_placement_options.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator;
+
+public class when_preserving_legacy_placement_options : Specification
+{
+    const string Accounts = """
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Accounts.Customers.Register;
+
+        [Command]
+        public record RegisterCustomer(string Name)
+        {
+            public void Handle()
+            {
+            }
+        }
+        """;
+
+    const string Shipping = """
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Shipping.Parcels.Dispatch;
+
+        [Command]
+        public record DispatchParcel(string TrackingNumber)
+        {
+            public void Handle()
+            {
+            }
+        }
+        """;
+
+    ScreenplayGenerationResult _legacyConfigured = null!;
+    ScreenplayGenerationResult _projectAwareConfigured = null!;
+    ScreenplayGenerationResult _legacyNamespaceRoots = null!;
+    ScreenplayGenerationResult _projectAwareNamespaceRoots = null!;
+
+    void Because()
+    {
+        var generator = new ScreenplayGenerator();
+        var accounts = Analyzed.Project(
+            "Accounts",
+            [],
+            ("Source/Accounts/Customers/Register/RegisterCustomer.cs", Accounts));
+        var shipping = Analyzed.Project(
+            "Shipping",
+            [],
+            ("Source/Shipping/Parcels/Dispatch/DispatchParcel.cs", Shipping));
+        var accountsProject = SourceProjects.Create("Accounts", DotNetProjectRole.Application, accounts);
+        var shippingProject = SourceProjects.Create("Shipping", DotNetProjectRole.Application, shipping);
+        var configured = new ScreenplayOptions
+        {
+            Domain = "Commerce",
+            Module = "Commerce",
+            SegmentsToSkip = 1
+        };
+
+        _legacyConfigured = generator.Generate(accounts, configured);
+        _projectAwareConfigured = generator.Generate(accountsProject, configured);
+        _legacyNamespaceRoots = generator.Generate([accounts, shipping], new ScreenplayOptions());
+        _projectAwareNamespaceRoots = generator.Generate([shippingProject, accountsProject], new ScreenplayOptions());
+    }
+
+    [Fact] void should_preserve_configured_module_and_segment_output_bytes() => _projectAwareConfigured.Source.ShouldEqual(_legacyConfigured.Source);
+    [Fact] void should_preserve_configured_diagnostics() => Diagnostics(_projectAwareConfigured).ShouldEqual(Diagnostics(_legacyConfigured));
+    [Fact] void should_preserve_namespace_root_module_output_bytes() => _projectAwareNamespaceRoots.Source.ShouldEqual(_legacyNamespaceRoots.Source);
+    [Fact] void should_preserve_namespace_root_diagnostics() => Diagnostics(_projectAwareNamespaceRoots).ShouldEqual(Diagnostics(_legacyNamespaceRoots));
+
+    static string Diagnostics(ScreenplayGenerationResult result) => string.Join(
+        '|',
+        result.Diagnostics.Select(_ => $"{_.Code}:{_.Severity}:{_.Location}:{_.Message}"));
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
@@ -15,15 +15,36 @@ namespace Cratis.Arc.Screenplay.Generation;
 /// <param name="context">The analyzed application projects.</param>
 /// <param name="scenarioProject">The project declaring the scenario.</param>
 /// <param name="adapter">The adapter identity.</param>
-/// <param name="options">The host placement options.</param>
+/// <param name="sourceStructures">The fixed source-structure snapshot.</param>
 /// <param name="facts">The facts to append.</param>
 internal sealed class ArcSpecificationArtifactFacts(
     DotNetAnalysisContext context,
     DotNetProjectCompilation scenarioProject,
     AdapterIdentity adapter,
-    DotNetAdapterOptions options,
+    DotNetSourceStructureSnapshot sourceStructures,
     List<GenerationFact> facts)
 {
+    /// <summary>
+    /// Creates the neutral placement fact from one exact shared placement.
+    /// </summary>
+    /// <param name="adapter">The contributing adapter.</param>
+    /// <param name="placement">The shared placement.</param>
+    /// <returns>The placement fact.</returns>
+    public static ArtifactPlacementFact Placement(AdapterIdentity adapter, DotNetSourcePlacement placement) => new()
+    {
+        Id = FactId("placement", placement.Artifact.Subject, placement.Artifact.Kind.ToString()),
+        Subject = placement.Artifact.Subject,
+        Evidence = new()
+        {
+            Adapter = adapter,
+            Strength = EvidenceStrength.Exact,
+            Source = placement.Structure.Source,
+            Explanation = "The shared source-placement derivation places the exact scenario target"
+        },
+        Artifact = placement.Artifact,
+        Placement = placement.Placement
+    };
+
     /// <summary>
     /// Adds or resolves one exact source artifact.
     /// </summary>
@@ -33,7 +54,12 @@ internal sealed class ArcSpecificationArtifactFacts(
     /// <returns>The artifact key, or <see langword="null"/> when source identity is ambiguous.</returns>
     public ArtifactKey? Artifact(INamedTypeSymbol type, ArtifactKind kind, Location source)
     {
-        var subject = context.SubjectForType(type);
+        var sourceProjects = context.Projects
+            .Where(project => type.DeclaringSyntaxReferences.Any(_ => project.AuthoredSyntaxTrees.Contains(_.SyntaxTree)))
+            .ToArray();
+        var subject = sourceProjects.Length == 1
+            ? sourceProjects[0].SubjectForType(type)
+            : context.SubjectForType(type);
         if (subject is null)
         {
             return null;
@@ -69,39 +95,27 @@ internal sealed class ArcSpecificationArtifactFacts(
     }
 
     /// <summary>
-    /// Adds the current compatibility placement for the exact scenario target.
+    /// Creates a shared placement request for the exact scenario target.
     /// </summary>
     /// <param name="target">The exact target artifact.</param>
-    /// <param name="type">The exact source type.</param>
-    /// <param name="source">The source evidence.</param>
-    public void AddPlacement(ArtifactKey target, INamedTypeSymbol type, Location source)
+    /// <param name="sliceKind">The independently established semantic slice kind.</param>
+    /// <param name="policy">The host-owned source-structure policy.</param>
+    /// <returns>The placement request, or <see langword="null"/> when no exact source structure exists.</returns>
+    public DotNetSourcePlacementRequest? PlacementRequest(
+        ArtifactKey target,
+        GenerationSliceKind sliceKind,
+        DotNetSourceStructurePolicy policy)
     {
-        var segments = type.ContainingNamespace.ToDisplayString().Split('.', StringSplitOptions.RemoveEmptyEntries)
-            .Skip(options.NamespaceSegmentsToSkip)
-            .ToArray();
-        if (segments.Length == 0)
-        {
-            return;
-        }
-
-        var module = options.Module ?? segments[0];
-        var remaining = segments.Skip(string.Equals(segments[0], module, StringComparison.Ordinal) ? 1 : 0).ToArray();
-        var slice = remaining.Length == 0 ? type.Name : remaining[^1];
-        var features = remaining.Length <= 1 ? [] : remaining[..^1];
-        facts.Add(new ArtifactPlacementFact
-        {
-            Id = FactId("placement", target.Subject, target.Kind.ToString()),
-            Subject = target.Subject,
-            Evidence = Evidence(source, "The target namespace places the specification under its exact owning slice"),
-            Artifact = target,
-            Placement = new ArtifactPlacement
+        var structure = sourceStructures.Structures.SingleOrDefault(_ => _.Subject == target.Subject);
+        return structure is null
+            ? null
+            : new()
             {
-                Module = module,
-                Features = features,
-                Slice = slice,
-                SliceKind = GenerationSliceKind.StateChange
-            }
-        });
+                Artifact = target,
+                Structure = structure,
+                SliceKind = sliceKind,
+                Policy = policy
+            };
     }
 
     Evidence Evidence(Location location, string? explanation = null)

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
@@ -23,13 +23,17 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
     /// <inheritdoc/>
     public bool CanAnalyze(DotNetAnalysisContext context) =>
         context.Projects.SelectMany(project => ArtifactCatalog.From(project.Compilation).Types)
-            .Any(type => SpecificationMembers.CommandOf(type) is not null || SpecificationMembers.ReadModelOf(type) is not null);
+            .Any(type => SpecificationMembers.CommandOf(SpecificationMembers.StepsOf(type)) is not null ||
+                         SpecificationMembers.ReadModelOf(SpecificationMembers.StepsOf(type)) is not null);
 
     /// <inheritdoc/>
     public AdapterContribution Analyze(DotNetAnalysisContext context, DotNetAdapterOptions options)
     {
         var facts = new List<GenerationFact>();
         var diagnostics = new List<GenerationDiagnostic>();
+        var candidates = new List<ArcSpecificationFactCandidate>();
+        var sourceStructures = DotNetSourceStructures.Create(context);
+        diagnostics.AddRange(sourceStructures.Diagnostics);
         var models = new SemanticModels([.. context.Projects.Select(project => project.Compilation)]);
         var readerDiagnostics = new ScreenplayDiagnostics();
         var reader = new SpecificationReader(models, readerDiagnostics);
@@ -38,7 +42,8 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
         {
             foreach (var type in ArtifactCatalog.From(project.Compilation).Types.Where(reader.IsSpecification))
             {
-                var target = SpecificationMembers.CommandOf(type) ?? SpecificationMembers.ReadModelOf(type);
+                var steps = SpecificationMembers.StepsOf(type);
+                var target = SpecificationMembers.CommandOf(steps) ?? SpecificationMembers.ReadModelOf(steps);
                 if (target is not INamedTypeSymbol namedTarget)
                 {
                     continue;
@@ -60,8 +65,37 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
                     continue;
                 }
 
-                new ArcSpecificationFactBuilder(context, project, Identity, options, facts, diagnostics)
-                    .Add(specification, evidence, namedTarget);
+                var candidate = new ArcSpecificationFactBuilder(context, project, Identity, options, sourceStructures, diagnostics)
+                    .Build(specification, evidence, namedTarget);
+                if (candidate is not null)
+                {
+                    candidates.Add(candidate);
+                }
+            }
+        }
+
+        var placements = DotNetSourcePlacementDerivation.Derive(candidates.Select(_ => _.PlacementRequest));
+        diagnostics.AddRange(placements.Diagnostics);
+        foreach (var candidate in candidates)
+        {
+            var placement = placements.Placements.SingleOrDefault(_ => _.Artifact == candidate.PlacementRequest.Artifact);
+            if (placement is null)
+            {
+                continue;
+            }
+
+            foreach (var fact in candidate.Facts)
+            {
+                if (!facts.Exists(_ => _.Id == fact.Id))
+                {
+                    facts.Add(fact);
+                }
+            }
+
+            var placementFact = ArcSpecificationArtifactFacts.Placement(Identity, placement);
+            if (!facts.Exists(_ => _.Id == placementFact.Id))
+            {
+                facts.Add(placementFact);
             }
         }
 

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
@@ -19,18 +19,20 @@ namespace Cratis.Arc.Screenplay.Generation;
 /// <param name="scenarioProject">The project declaring the scenario.</param>
 /// <param name="adapter">The adapter identity.</param>
 /// <param name="options">The host placement options.</param>
-/// <param name="facts">The facts to contribute atomically.</param>
+/// <param name="sourceStructures">The fixed source-structure snapshot.</param>
 /// <param name="diagnostics">The diagnostics to append.</param>
 internal sealed class ArcSpecificationFactBuilder(
     DotNetAnalysisContext context,
     DotNetProjectCompilation scenarioProject,
     AdapterIdentity adapter,
     DotNetAdapterOptions options,
-    List<GenerationFact> facts,
+    DotNetSourceStructureSnapshot sourceStructures,
     List<GenerationDiagnostic> diagnostics)
 {
-    readonly ArcSpecificationArtifactFacts _artifactFacts = new(context, scenarioProject, adapter, options, facts);
+    readonly List<GenerationFact> _facts = [];
     readonly ArcSpecificationEvidence _sourceEvidence = new(context, scenarioProject, adapter, diagnostics);
+
+    ArcSpecificationArtifactFacts ArtifactFacts => new(context, scenarioProject, adapter, sourceStructures, _facts);
 
     /// <summary>
     /// Adds one scenario only when every required step, value, artifact, and source location is exact.
@@ -38,24 +40,27 @@ internal sealed class ArcSpecificationFactBuilder(
     /// <param name="specification">The recovered legacy specification.</param>
     /// <param name="evidence">The exact source evidence.</param>
     /// <param name="target">The exact command or read-model target.</param>
-    public void Add(
+    /// <returns>The complete candidate, or <see langword="null"/> when the scenario cannot be proven exactly.</returns>
+    public ArcSpecificationFactCandidate? Build(
         SpecificationModel specification,
         SpecificationScenarioEvidence evidence,
         INamedTypeSymbol target)
     {
-        if (evidence.Blockers.Count > 0 || SpecificationMembers.ReadModelOf(evidence.SourceType) is not null ||
-            HasUnrepresentedEventPredicate(specification, evidence))
+        if (evidence.Blockers.Count > 0 || HasUnrepresentedEventPredicate(specification, evidence))
         {
             _sourceEvidence.Block(specification, evidence, "the existing Arc analyzer cannot prove every authored step and value exactly");
-            return;
+            return null;
         }
 
+        var targetsStateView = SpecificationMembers.ReadModelOf(SpecificationMembers.StepsOf(evidence.SourceType)) is not null;
+        var targetKind = targetsStateView ? ArtifactKind.ReadModel : ArtifactKind.Command;
+        var sliceKind = targetsStateView ? GenerationSliceKind.StateView : GenerationSliceKind.StateChange;
         var scenarioSubject = scenarioProject.SubjectForType(evidence.SourceType);
-        var targetKey = _artifactFacts.Artifact(target, ArtifactKind.Command, evidence.Source);
+        var targetKey = ArtifactFacts.Artifact(target, targetKind, evidence.Source);
         if (targetKey is null)
         {
             _sourceEvidence.Block(specification, evidence, "the target artifact has no unique analyzed source identity");
-            return;
+            return null;
         }
 
         var stepFacts = new List<SpecificationStepFact>();
@@ -65,21 +70,22 @@ internal sealed class ArcSpecificationFactBuilder(
         {
             if (!TryAddState(specification, evidence, scenarioSubject, state, SpecificationStepPhase.Given, stepIndex++, stepFacts, valueFacts))
             {
-                return;
+                return null;
             }
         }
 
-        if (specification.When is null ||
-            !TryAddState(specification, evidence, scenarioSubject, specification.When, SpecificationStepPhase.When, stepIndex++, stepFacts, valueFacts))
+        if (!targetsStateView &&
+            (specification.When is null ||
+             !TryAddState(specification, evidence, scenarioSubject, specification.When, SpecificationStepPhase.When, stepIndex++, stepFacts, valueFacts)))
         {
-            return;
+            return null;
         }
 
         foreach (var state in specification.Then)
         {
             if (!TryAddState(specification, evidence, scenarioSubject, state, SpecificationStepPhase.Then, stepIndex++, stepFacts, valueFacts))
             {
-                return;
+                return null;
             }
         }
 
@@ -114,10 +120,22 @@ internal sealed class ArcSpecificationFactBuilder(
                 Steps = [.. stepFacts.Select(step => step.Definition.Key)]
             }
         };
-        facts.Add(scenario);
-        facts.AddRange(stepFacts);
-        facts.AddRange(valueFacts);
-        _artifactFacts.AddPlacement(targetKey, target, evidence.Source);
+        _facts.Add(scenario);
+        _facts.AddRange(stepFacts);
+        _facts.AddRange(valueFacts);
+
+        var placement = ArtifactFacts.PlacementRequest(targetKey, sliceKind, options.SourceStructurePolicy);
+        if (placement is null)
+        {
+            if (sourceStructures.Diagnostics.Count == 0)
+            {
+                _sourceEvidence.Block(specification, evidence, "the target artifact has no exact shared source structure");
+            }
+
+            return null;
+        }
+
+        return new(placement, _facts);
     }
 
     bool TryAddState(
@@ -137,14 +155,14 @@ internal sealed class ArcSpecificationFactBuilder(
         }
 
         var kind = Kind(state.Kind);
-        var artifactKey = _artifactFacts.Artifact(artifact, ArtifactKindFor(kind), stateEvidence.Source);
+        var artifactKey = ArtifactFacts.Artifact(artifact, ArtifactKindFor(kind), stateEvidence.Source);
         if (kind == SpecificationStepKind.Unknown || artifactKey is null)
         {
             _sourceEvidence.Block(specification, evidence, $"step {index} has an unsupported or ambiguous artifact");
             return false;
         }
 
-        if (!HasEveryRequiredConstructionValue(artifact, state.Values.Count()))
+        if (kind != SpecificationStepKind.ReadModel && !HasEveryRequiredConstructionValue(artifact, state.Values.Count()))
         {
             _sourceEvidence.Block(specification, evidence, $"step {index} omits a required computed or unreadable construction value");
             return false;

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactCandidate.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactCandidate.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Represents one complete scenario contribution awaiting exact shared placement.
+/// </summary>
+/// <param name="PlacementRequest">The exact target placement request.</param>
+/// <param name="Facts">The scenario facts staged atomically.</param>
+internal sealed record ArcSpecificationFactCandidate(
+    DotNetSourcePlacementRequest PlacementRequest,
+    IReadOnlyList<GenerationFact> Facts);

--- a/Source/DotNET/Screenplay/IScreenplayGenerator.cs
+++ b/Source/DotNET/Screenplay/IScreenplayGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
 
 namespace Cratis.Arc.Screenplay;
@@ -9,9 +10,10 @@ namespace Cratis.Arc.Screenplay;
 /// Defines a system that generates a Screenplay document from the source of an application.
 /// </summary>
 /// <remarks>
-/// The generator never loads an MSBuild workspace - the caller supplies the <see cref="Compilation"/>. That single
-/// seam is what lets the same generator run from a command line tool, from an MSBuild task, from an analyzer and
-/// from a specification built with <c>CSharpCompilation.Create</c>.
+/// The generator never loads an MSBuild workspace - the caller supplies a <see cref="Compilation"/> or a
+/// <see cref="DotNetProjectCompilation"/> carrying host-owned source context. That seam lets the same generator run
+/// from a command line tool, from an MSBuild task, from an analyzer and from a specification built with
+/// <c>CSharpCompilation.Create</c>.
 /// </remarks>
 public interface IScreenplayGenerator
 {
@@ -22,6 +24,14 @@ public interface IScreenplayGenerator
     /// <param name="options">The options to generate with.</param>
     /// <returns>The <see cref="ScreenplayGenerationResult"/>.</returns>
     ScreenplayGenerationResult Generate(Compilation compilation, ScreenplayOptions options);
+
+    /// <summary>
+    /// Generates the Screenplay document describing one project-aware application source set.
+    /// </summary>
+    /// <param name="project">The project compilation and its host-owned source context.</param>
+    /// <param name="options">The options to generate with.</param>
+    /// <returns>The <see cref="ScreenplayGenerationResult"/>.</returns>
+    ScreenplayGenerationResult Generate(DotNetProjectCompilation project, ScreenplayOptions options);
 
     /// <summary>
     /// Generates the Screenplay document describing an application written as several projects.
@@ -42,4 +52,16 @@ public interface IScreenplayGenerator
     /// </para>
     /// </remarks>
     ScreenplayGenerationResult Generate(IReadOnlyList<Compilation> compilations, ScreenplayOptions options);
+
+    /// <summary>
+    /// Generates the Screenplay document describing a project-aware application source set.
+    /// </summary>
+    /// <param name="projects">The project compilations and their host-owned source contexts.</param>
+    /// <param name="options">The options to generate with.</param>
+    /// <returns>The <see cref="ScreenplayGenerationResult"/>.</returns>
+    /// <remarks>
+    /// The compatibility document retains the established compilation-only behavior. Project roles and source
+    /// contexts travel with this overload so hosts can use the neutral adapters without reconstructing them.
+    /// </remarks>
+    ScreenplayGenerationResult Generate(IReadOnlyList<DotNetProjectCompilation> projects, ScreenplayOptions options);
 }

--- a/Source/DotNET/Screenplay/ScreenplayGenerator.cs
+++ b/Source/DotNET/Screenplay/ScreenplayGenerator.cs
@@ -4,6 +4,7 @@
 using Cratis.Arc.Screenplay.Analysis;
 using Cratis.Arc.Screenplay.Emission;
 using Cratis.Arc.Screenplay.Verification;
+using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
 
 namespace Cratis.Arc.Screenplay;
@@ -41,6 +42,10 @@ public class ScreenplayGenerator(IApplicationModelAnalyzer analyzer, IScreenplay
         Generate([compilation], options);
 
     /// <inheritdoc/>
+    public ScreenplayGenerationResult Generate(DotNetProjectCompilation project, ScreenplayOptions options) =>
+        Generate(project.Compilation, options);
+
+    /// <inheritdoc/>
     /// <remarks>
     /// A generation is the entry point that knows what a name falls back to - the assembly being read, or nothing at
     /// all when several projects are the application together - so the options resolve here and both halves run with
@@ -61,6 +66,10 @@ public class ScreenplayGenerator(IApplicationModelAnalyzer analyzer, IScreenplay
 
         return new(emission.Source, analysis.Model, diagnostics.All);
     }
+
+    /// <inheritdoc/>
+    public ScreenplayGenerationResult Generate(IReadOnlyList<DotNetProjectCompilation> projects, ScreenplayOptions options) =>
+        Generate([.. projects.Select(_ => _.Compilation)], options);
 
     /// <summary>
     /// Reads the printed document back and reports one the Screenplay compiler rejects.


### PR DESCRIPTION
# Summary
Arc now uses the released Generation source-structure contract for neutral specification placement while keeping existing Screenplay output stable.

## Added
- Add project-aware Screenplay generator overloads without changing compatibility output.

## Changed
- Derive neutral Arc specification placement through Generation 0.12.0 with typed, atomic fail-closed behavior. (Cratis/Screenplay.Generation#26)