### PR TITLE
Add job timeouts and PR concurrency to workflows

### DIFF
--- a/.github/workflows/auto-approve-publish-deployments.yml
+++ b/.github/workflows/auto-approve-publish-deployments.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   approve:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Approve pending npm/nuget deployments
         env:

--- a/.github/workflows/chronicle-published.yml
+++ b/.github/workflows/chronicle-published.yml
@@ -35,6 +35,7 @@ env:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup-pr-artifacts.yml
+++ b/.github/workflows/cleanup-pr-artifacts.yml
@@ -1,5 +1,9 @@
 name: Cleanup PR Artifacts
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: 30
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Trigger Documentation Build
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -48,6 +48,7 @@ on:
 jobs:
   dotnet-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       proxy-namespaces: ${{ steps.discover-namespaces.outputs.namespaces }}
       spec-projects: ${{ steps.discover-specs.outputs.projects }}
@@ -161,6 +162,7 @@ jobs:
   specs:
     needs: [dotnet-build]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -200,6 +202,7 @@ jobs:
   screenplay-end-to-end:
     needs: [dotnet-build]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -270,6 +273,7 @@ jobs:
   proxy-specs:
     needs: [dotnet-build]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-build.yml
+++ b/.github/workflows/javascript-build.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/markdown-verification.yml
+++ b/.github/workflows/markdown-verification.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,6 +30,7 @@ jobs:
 
   link-verification:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       version: ${{ steps.release.outputs.version }}
       publish: ${{ steps.release.outputs.should-publish }}
@@ -85,6 +86,7 @@ jobs:
   publish-dotnet-packages:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
     permissions:
       # Required for NuGet trusted publishing using OIDC tokens
@@ -144,6 +146,7 @@ jobs:
   publish-npm-packages:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
     permissions:
       contents: read
@@ -233,6 +236,7 @@ jobs:
     # as a commit pushed straight to main, a Dependabot merge, or a re-run of a run that already released.
     if: always() && needs.release.result == 'success' && contains(fromJSON('["no-label", "error"]'), needs.release.outputs.reason)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
 
     steps:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       version: ${{ steps.release.outputs.version }}
       publish: ${{ steps.release.outputs.should-publish }}
@@ -43,6 +44,7 @@ jobs:
   publish-nuget-packages:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [release]
 
     steps:
@@ -105,6 +107,7 @@ jobs:
   publish-npm-packages:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [release]
 
     steps:

--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Require exactly one semantic version label


### PR DESCRIPTION
Part of the org-wide Actions throttling remediation. Mechanical, rule-based sweep:

- **timeout-minutes** on every job that had none (previously 6 h default): quick checks 15, builds 30, publish/release 60, integration/benchmarks 120.
- **concurrency + cancel-in-progress** only on pull-request-triggered verification workflows — never on publish/release/deploy, `pull_request_target`, `workflow_run` or reusable (`workflow_call`) workflows.

Every edited file re-parsed as YAML before commit. Files changed:
- .github/workflows/auto-approve-publish-deployments.yml
- .github/workflows/chronicle-published.yml
- .github/workflows/cleanup-pr-artifacts.yml
- .github/workflows/codeql.yml
- .github/workflows/documentation.yml
- .github/workflows/dotnet-build.yml
- .github/workflows/javascript-build.yml
- .github/workflows/markdown-verification.yml
- .github/workflows/publish.yml
- .github/workflows/pull-requests.yml
- .github/workflows/verify-semver-label.yml