### PR TITLE
Complete generated specification recovery

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,9 +23,9 @@
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.0" />
     <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.12.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.12.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.12.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.14.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.14.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.14.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,9 +23,9 @@
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.0" />
     <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.14.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.14.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.14.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.15.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.15.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.15.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />

--- a/Source/DotNET/Screenplay.Specs/IntegrationTesting.cs
+++ b/Source/DotNET/Screenplay.Specs/IntegrationTesting.cs
@@ -36,7 +36,7 @@ public static class IntegrationTesting
 
                 public IEventSequence EventSequence => null!;
 
-                public Task<Result> Execute(TCommand command) => Task.FromResult(new Result());
+                public Task<CommandResult> Execute(TCommand command) => Task.FromResult(new CommandResult());
 
                 public Task<Result> Validate(TCommand command) => Task.FromResult(new Result());
             }
@@ -45,10 +45,20 @@ public static class IntegrationTesting
             {
                 public bool IsSuccess => true;
             }
+
+            public class CommandResult : Result;
+
         }
 
         namespace Cratis.Arc.Chronicle.Testing.Commands
         {
+            public static class CommandResultExtensions
+            {
+                public static void ShouldBeSuccessful(this Cratis.Arc.Testing.Commands.CommandResult result)
+                {
+                }
+            }
+
             public class CommandScenarioChronicleGivenBuilder<TCommand>
             {
                 public CommandScenarioSourceGivenBuilder<TCommand> ForEventSource(EventSourceId eventSourceId) => new();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_constructing_a_concept_literal.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_handler_constructing_a_concept_literal.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+public class a_handler_constructing_a_concept_literal : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Projects.Registration;
+
+        public record ProjectName(string Value) : ConceptAs<string>(Value);
+
+        [EventType]
+        public record ProjectRegistered(ProjectName Name);
+
+        [Command]
+        public record RegisterProject
+        {
+            public ProjectRegistered Handle() => new(new ProjectName("Screenplay"));
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Because() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn((Analyzed.SlicePath, Source)).ShouldBeEmpty();
+    [Fact] void should_not_treat_direct_concept_construction_as_a_global_mapping_literal() => _analysis.Slice().Commands.Single().Produces.Single().Mappings.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_read_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_specification_of_a_read_model.cs
@@ -43,27 +43,21 @@ public class a_specification_of_a_read_model : Specification
         using System.Threading.Tasks;
         using Cratis.Chronicle.Events;
         using Cratis.Chronicle.Testing.ReadModels;
+        using Cratis.Specifications;
         using Xunit;
 
         namespace Library.Authors.Listing.when_an_author_is_archived;
 
-        public class and_the_author_was_registered_first
+        public class and_the_author_was_registered_first : Specification
         {
             readonly ReadModelScenario<Author> _scenario = new();
 
-            async Task Because() =>
+            async Task Establish() =>
                 await _scenario.Given
                     .ForEventSource(EventSourceId.New())
                     .Events(new AuthorRegistered("Jane Austen"), new AuthorArchived());
 
-            [Fact] void should_hold_the_author() => _scenario.Instance!.Id.ShouldEqualTheExpected(string.Empty);
-        }
-
-        public static class Assertions
-        {
-            public static void ShouldEqualTheExpected(this string actual, string expected)
-            {
-            }
+            [Fact] void should_hold_the_author() => _scenario.Instance!.Id.ShouldEqual("");
         }
         """;
 
@@ -90,6 +84,7 @@ public class a_specification_of_a_read_model : Specification
     [Fact] void should_issue_no_command() => _specification.When.ShouldBeNull();
     [Fact] void should_say_the_read_model_followed() => _specification.Then.Single().Name.ShouldEqual("Author");
     [Fact] void should_state_it_as_a_read_model() => _specification.Then.Single().Kind.ShouldEqual(SpecificationStateKind.ReadModel);
+    [Fact] void should_state_every_exact_read_model_value() => _specification.Then.Single().Values.ShouldContainOnly([new PropertyMappingModel("Id", new LiteralSource(string.Empty))]);
     [Fact] void should_retain_the_exact_read_model_symbol() => SpecificationEvidence.For(_specification).States[_specification.Then.Single()].Artifact.Name.ShouldEqual("Author");
     [Fact] void should_retain_read_model_step_evidence() => SpecificationEvidence.For(_specification).States[_specification.Then.Single()].Source.IsInSource.ShouldBeTrue();
     [Fact] void should_report_no_scenario_left_out() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.UnreadableSpecification).ShouldBeFalse();

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/GeneratedEventAssertionSources.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/GeneratedEventAssertionSources.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+static class GeneratedEventAssertionSources
+{
+    public const string Assertions = """
+        using System;
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Events;
+
+        namespace Cratis.Arc.Chronicle.Testing.Commands;
+
+        public static class CommandScenarioChronicleAssertionExtensions
+        {
+            public static Task ShouldHaveAppendedEvent<TCommand, TEvent>(
+                this CommandScenario<TCommand> scenario,
+                EventSourceId eventSourceId,
+                Func<TEvent, bool> predicate) => Task.CompletedTask;
+        }
+        """;
+
+    public static AdapterContribution Analyze(string scenario)
+    {
+        var compilation = Analyzed.Compile(
+        [
+            ("Projects/Registration/RegisterProject/RegisterProject.cs", PlacementScenarioSources.Slice),
+            ("Projects/Registration/RegisterProject/when_registering.cs", scenario),
+            ("Integration/Assertions.cs", Assertions),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        ]);
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        return new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/GeneratedQuerySpecificationSources.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/GeneratedQuerySpecificationSources.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+static class GeneratedQuerySpecificationSources
+{
+    public const string Framework = """
+        namespace Projects.Framework
+        {
+            public static class Marker;
+        }
+
+        namespace Microsoft.AspNetCore.Mvc
+        {
+            public abstract class ActionResult;
+            public sealed class ActionResult<T> : ActionResult;
+        }
+        """;
+
+    public const string Application = """
+        using System;
+        using System.Threading.Tasks;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.ReadModels;
+        using Cratis.Concepts;
+
+        namespace Projects.Projects.Overview.ListProjects;
+
+        public record ProjectId(Guid Value) : EventSourceId<Guid>(Value);
+
+        public record ProjectName(string Value) : ConceptAs<string>(Value);
+
+        [ReadModel]
+        public record ProjectOverview(ProjectId ProjectId, ProjectName Name, int Number, DateOnly StartedOn, DateTimeOffset UpdatedAt)
+        {
+            public static async Task<ProjectOverview?> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                await readModels.GetInstanceById<ProjectOverview>((EventSourceId)projectId);
+        }
+        """;
+
+    public const string Scenario = """
+        using System;
+        using System.Globalization;
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.ReadModels;
+        using Cratis.Specifications;
+        using NSubstitute;
+        using Projects.Projects.Overview.ListProjects;
+        using Xunit;
+
+        namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+        public class when_project_by_id_is_queried : Specification
+        {
+            readonly IReadModels _readModels = Substitute.For<IReadModels>();
+            readonly ProjectOverview _expected = new(
+                new ProjectId(Guid.Parse("f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e")),
+                new ProjectName("Screenplay"),
+                42,
+                DateOnly.Parse("2026-02-14", CultureInfo.InvariantCulture),
+                DateTimeOffset.Parse("2026-02-14T10:15:30+00:00", CultureInfo.InvariantCulture));
+            ProjectOverview? _result;
+
+            void Establish() => _readModels.GetInstanceById<ProjectOverview>((EventSourceId)new ProjectId(Guid.Parse("f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e"))).Returns(_expected);
+
+            async Task Because() => _result = await ProjectOverview.ProjectById(_readModels, new ProjectId(Guid.Parse("f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e")));
+
+            [Fact] void should_return_the_expected_read_model() => _result.ShouldEqual(_expected);
+        }
+        """;
+
+    public const string PartialScenarioFields = """
+        using System;
+        using System.Globalization;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.ReadModels;
+        using Cratis.Specifications;
+        using NSubstitute;
+        using Projects.Projects.Overview.ListProjects;
+
+        namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+        public partial class when_project_by_id_is_queried : Specification
+        {
+            readonly IReadModels _readModels = Substitute.For<IReadModels>();
+            readonly ProjectOverview _expected = new(
+                new ProjectId(Guid.Parse("f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e")),
+                new ProjectName("Screenplay"),
+                42,
+                DateOnly.Parse("2026-02-14", CultureInfo.InvariantCulture),
+                DateTimeOffset.Parse("2026-02-14T10:15:30+00:00", CultureInfo.InvariantCulture));
+            ProjectOverview? _result;
+
+            void Establish() => _readModels.GetInstanceById<ProjectOverview>((EventSourceId)new ProjectId(Guid.Parse("f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e"))).Returns(_expected);
+        }
+        """;
+
+    public const string PartialScenarioBehavior = """
+        using System;
+        using System.Threading.Tasks;
+        using Cratis.Specifications;
+        using Projects.Projects.Overview.ListProjects;
+        using Xunit;
+
+        namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+        public partial class when_project_by_id_is_queried
+        {
+            async Task Because() => _result = await ProjectOverview.ProjectById(_readModels, new ProjectId(Guid.Parse("f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e")));
+
+            [Fact] void should_return_the_expected_read_model() => _result.ShouldEqual(_expected);
+        }
+        """;
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_a_generated_query_specification_is_not_exact.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_a_generated_query_specification_is_not_exact.cs
@@ -1,0 +1,349 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_a_generated_query_specification_is_not_exact : Specification
+{
+    const string Query = """
+            public static async Task<ProjectOverview?> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                await readModels.GetInstanceById<ProjectOverview>((EventSourceId)projectId);
+        """;
+
+    const string Key = "new ProjectId(Guid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\"))";
+    const string EstablishCall = "_readModels.GetInstanceById<ProjectOverview>((EventSourceId)new ProjectId(Guid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\"))).Returns(_expected)";
+    const string Establish = $"void Establish() => {EstablishCall};";
+    const string QueryCall = "ProjectOverview.ProjectById(_readModels, new ProjectId(Guid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\")))";
+
+    Dictionary<string, InvalidRecovery> _recoveries = null!;
+
+    void Because() => _recoveries = Cases().ToDictionary(_ => _.Name, Analyze, StringComparer.Ordinal);
+
+    [Fact] void should_compile_every_negative_source() => string.Join('\n', _recoveries.Values.SelectMany(_ => _.CompilationErrors)).ShouldEqual(string.Empty);
+    [Fact] void should_report_every_negative_once_as_arcsp0001() => string.Join('\n', _recoveries.Where(_ => !_.Value.Contribution.Diagnostics.Select(diagnostic => diagnostic.Code).SequenceEqual(["ARCSP0001"])).Select(_ => $"{_.Key}: {string.Join(',', _.Value.Contribution.Diagnostics.Select(diagnostic => diagnostic.Code))}")).ShouldEqual(string.Empty);
+    [Fact] void should_emit_no_partial_recovery_fact_for_any_negative() => string.Join('\n', _recoveries.Where(_ => _.Value.Contribution.Facts.Count != 0).Select(_ => $"{_.Key}: {_.Value.Contribution.Facts.Count}")).ShouldEqual(string.Empty);
+    [Fact] void should_cover_every_required_negative_shape() => _recoveries.Keys.ShouldContainOnly([
+        "computed argument", "user parse argument", "conditional call", "repeated call", "multiple calls", "unassigned call",
+        "incomplete expected", "computed expected", "duplicate assertion", "conditional assertion", "lookalike assertion",
+        "property assertion", "reversed assertion", "unrelated same-name query", "spec-only query", "required return",
+        "observable return", "collection return", "transport return", "unsupported return", "default input", "extra input",
+        "non-specification base", "null read models", "uninitialized read models", "nonreadonly read models",
+        "indirect substitute", "nonmatching establish", "conflicting establish", "object expected", "nullable result property",
+        "collection result property", "normalized result collision", "key name mismatch", "key type mismatch",
+        "null literal", "invalid enum member", "custom concept constructor", "custom read-model constructor",
+        "extra await in because", "extra helper in because", "extra establish method", "extra establish statement",
+        "block-bodied assertion", "indirect base", "static fields", "required nullable input", "collection input"]);
+
+    static IEnumerable<InvalidCase> Cases()
+    {
+        const string scenario = GeneratedQuerySpecificationSources.Scenario;
+        const string lookalikeAssertion = """
+            namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+            public static class LookalikeAssertions
+            {
+                public static void ShouldEqual<T>(T actual, T expected)
+                {
+                }
+            }
+            """;
+        const string userParse = """
+            using System;
+
+            namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+            public static class UserGuid
+            {
+                public static Guid Parse(string value) => Guid.Parse(value);
+            }
+            """;
+        const string unrelatedQuery = """
+            using System.Threading.Tasks;
+            using Cratis.Chronicle.ReadModels;
+            using Projects.Projects.Overview.ListProjects;
+
+            namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+            public static class QueryLookalike
+            {
+                public static Task<ProjectOverview?> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                    readModels.GetInstanceById<ProjectOverview>((Cratis.Chronicle.Events.EventSourceId)projectId);
+            }
+            """;
+        const string specificationOnlyQuery = """
+            using System;
+            using System.Threading.Tasks;
+            using Cratis.Arc.Queries.ModelBound;
+            using Cratis.Chronicle.ReadModels;
+            using Projects.Projects.Overview.ListProjects;
+
+            namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+            [ReadModel]
+            public record SpecificationOverview(ProjectId Id, ProjectName Name, int Number, DateOnly StartedOn, DateTimeOffset UpdatedAt)
+            {
+                public static Task<SpecificationOverview?> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                    readModels.GetInstanceById<SpecificationOverview>((Cratis.Chronicle.Events.EventSourceId)projectId);
+            }
+            """;
+        const string requiredQuery = """
+                public static async Task<ProjectOverview> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                    await readModels.GetInstanceById<ProjectOverview>((EventSourceId)projectId);
+            """;
+        const string observableQuery = """
+                public static Task<System.Reactive.Subjects.ISubject<ProjectOverview>> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                    Task.FromResult<System.Reactive.Subjects.ISubject<ProjectOverview>>(null!);
+            """;
+        const string collectionQuery = """
+                public static Task<System.Collections.Generic.IReadOnlyList<ProjectOverview>> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                    Task.FromResult<System.Collections.Generic.IReadOnlyList<ProjectOverview>>([]);
+            """;
+        const string transportQuery = """
+                public static Task<Microsoft.AspNetCore.Mvc.ActionResult<ProjectOverview>> ProjectById(IReadModels readModels, ProjectId projectId) =>
+                    Task.FromResult<Microsoft.AspNetCore.Mvc.ActionResult<ProjectOverview>>(null!);
+            """;
+        const string unsupportedQuery = """
+                public static Task<object> ProjectById(IReadModels readModels, ProjectId projectId) => Task.FromResult<object>(new());
+            """;
+        const string defaultInputQuery = """
+                public static async Task<ProjectOverview?> ProjectById(IReadModels readModels, ProjectId? projectId = null) =>
+                    await readModels.GetInstanceById<ProjectOverview>((EventSourceId)projectId!);
+            """;
+        const string extraInputQuery = """
+                public static async Task<ProjectOverview?> ProjectById(IReadModels readModels, ProjectId projectId, int version) =>
+                    await readModels.GetInstanceById<ProjectOverview>((EventSourceId)projectId);
+            """;
+        const string nullableInputQuery = """
+                public static async Task<ProjectOverview?> ProjectById(IReadModels readModels, ProjectId? projectId) =>
+                    await readModels.GetInstanceById<ProjectOverview>((EventSourceId)projectId!);
+            """;
+        const string collectionInputQuery = """
+                public static async Task<ProjectOverview?> ProjectById(IReadModels readModels, ProjectId[] projectIds) =>
+                    await readModels.GetInstanceById<ProjectOverview>((EventSourceId)projectIds[0]);
+            """;
+
+        var computedArgument = scenario
+            .Replace(QueryCall, "ProjectOverview.ProjectById(_readModels, Key())", StringComparison.Ordinal)
+            .Replace("\n    [Fact]", $"\n    static ProjectId Key() => {Key};\n\n    [Fact]", StringComparison.Ordinal);
+        var userParseArgument = scenario.Replace(
+            QueryCall,
+            "ProjectOverview.ProjectById(_readModels, new ProjectId(UserGuid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\")))",
+            StringComparison.Ordinal);
+        var conditionalCall = scenario.Replace(
+            $"async Task Because() => _result = await {QueryCall};",
+            $"async Task Because()\n    {{\n        if (_readModels is not null)\n        {{\n            _result = await {QueryCall};\n        }}\n    }}",
+            StringComparison.Ordinal);
+        var repeatedCall = scenario.Replace(
+            $"async Task Because() => _result = await {QueryCall};",
+            $"async Task Because()\n    {{\n        while (_result is null)\n        {{\n            _result = await {QueryCall};\n        }}\n    }}",
+            StringComparison.Ordinal);
+        var multipleCalls = scenario.Replace(
+            $"async Task Because() => _result = await {QueryCall};",
+            $"async Task Because()\n    {{\n        _result = await {QueryCall};\n        _result = await {QueryCall};\n    }}",
+            StringComparison.Ordinal);
+        var unassignedCall = scenario.Replace($"async Task Because() => _result = await {QueryCall};", $"async Task Because() => await {QueryCall};", StringComparison.Ordinal);
+        var incompleteApplication = GeneratedQuerySpecificationSources.Application.Replace("DateTimeOffset UpdatedAt)", "DateTimeOffset UpdatedAt = default)", StringComparison.Ordinal);
+        var incompleteExpected = scenario.Replace(",\n        DateTimeOffset.Parse(\"2026-02-14T10:15:30+00:00\", CultureInfo.InvariantCulture));", ");", StringComparison.Ordinal);
+        var computedExpected = scenario
+            .Replace("new ProjectName(\"Screenplay\")", "Name()", StringComparison.Ordinal)
+            .Replace("ProjectOverview? _result;", "ProjectOverview? _result;\n\n    static ProjectName Name() => new(\"Screenplay\");", StringComparison.Ordinal);
+        var duplicateAssertion = scenario.Replace("[Fact] void should_return_the_expected_read_model() => _result.ShouldEqual(_expected);", "[Fact] void should_return_the_expected_read_model() => _result.ShouldEqual(_expected);\n    [Fact] void should_return_the_same_expected_read_model() => _result.ShouldEqual(_expected);", StringComparison.Ordinal);
+        var conditionalAssertion = scenario.Replace("[Fact] void should_return_the_expected_read_model() => _result.ShouldEqual(_expected);", "[Fact] void should_return_the_expected_read_model()\n    {\n        if (_result is not null)\n        {\n            _result.ShouldEqual(_expected);\n        }\n    }", StringComparison.Ordinal);
+        var lookalikeAssertionScenario = scenario.Replace("_result.ShouldEqual(_expected)", "LookalikeAssertions.ShouldEqual(_result, _expected)", StringComparison.Ordinal);
+        var propertyAssertion = scenario.Replace("_result.ShouldEqual(_expected)", "_result!.Name.ShouldEqual(_expected.Name)", StringComparison.Ordinal);
+        var reversedAssertion = scenario.Replace("_result.ShouldEqual(_expected)", "_expected.ShouldEqual(_result)", StringComparison.Ordinal);
+        var unrelatedQueryScenario = scenario.Replace("ProjectOverview.ProjectById(_readModels", "QueryLookalike.ProjectById(_readModels", StringComparison.Ordinal);
+        var specificationOnlyScenario = scenario.Replace("ProjectOverview", "SpecificationOverview", StringComparison.Ordinal);
+        var requiredApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, requiredQuery, StringComparison.Ordinal);
+        var observableApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, observableQuery, StringComparison.Ordinal);
+        var collectionApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, collectionQuery, StringComparison.Ordinal);
+        var transportApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, transportQuery, StringComparison.Ordinal);
+        var unsupportedApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, unsupportedQuery, StringComparison.Ordinal);
+        var defaultInputApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, defaultInputQuery, StringComparison.Ordinal);
+        var extraInputApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, extraInputQuery, StringComparison.Ordinal);
+        var extraInputScenario = scenario.Replace(QueryCall, $"ProjectOverview.ProjectById(_readModels, {Key}, 1)", StringComparison.Ordinal);
+        var nonSpecificationBase = scenario.Replace(" : Specification", string.Empty, StringComparison.Ordinal);
+        var nullReadModels = scenario.Replace("Substitute.For<IReadModels>()", "null!", StringComparison.Ordinal);
+        var uninitializedReadModels = scenario.Replace("readonly IReadModels _readModels = Substitute.For<IReadModels>();", "readonly IReadModels _readModels;", StringComparison.Ordinal);
+        var nonreadonlyReadModels = scenario.Replace("readonly IReadModels _readModels = Substitute.For<IReadModels>();", "IReadModels _readModels = Substitute.For<IReadModels>();", StringComparison.Ordinal);
+        var indirectSubstitute = scenario
+            .Replace("Substitute.For<IReadModels>()", "CreateReadModels()", StringComparison.Ordinal)
+            .Replace("readonly ProjectOverview _expected", "static IReadModels CreateReadModels() => Substitute.For<IReadModels>();\n\n    readonly ProjectOverview _expected", StringComparison.Ordinal);
+        var nonmatchingEstablish = scenario.Replace(Establish, "void Establish() { }", StringComparison.Ordinal);
+        var conflictingEstablish = scenario.Replace("f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\"))).Returns(_expected)", "4d533cc3-df2c-420f-9fab-5883c666dd23\"))).Returns(_expected)", StringComparison.Ordinal);
+        var objectExpected = WithoutEstablish(scenario).Replace(
+            "readonly ProjectOverview _expected = new(",
+            "readonly object _expected = new ProjectOverview(",
+            StringComparison.Ordinal);
+        var nullablePropertyApplication = GeneratedQuerySpecificationSources.Application.Replace("ProjectName Name", "ProjectName? Name", StringComparison.Ordinal);
+        var collectionPropertyApplication = GeneratedQuerySpecificationSources.Application.Replace("ProjectName Name", "System.Collections.Generic.IReadOnlyList<ProjectName> Names", StringComparison.Ordinal);
+        var collectionPropertyScenario = scenario.Replace("new ProjectName(\"Screenplay\"),", "[new ProjectName(\"Screenplay\")],", StringComparison.Ordinal);
+        var collidingApplication = GeneratedQuerySpecificationSources.Application.Replace("DateTimeOffset UpdatedAt)", "DateTimeOffset UpdatedAt, string URL, string Url)", StringComparison.Ordinal);
+        var collidingScenario = scenario.Replace("DateTimeOffset.Parse(\"2026-02-14T10:15:30+00:00\", CultureInfo.InvariantCulture));", "DateTimeOffset.Parse(\"2026-02-14T10:15:30+00:00\", CultureInfo.InvariantCulture), \"upper\", \"camel\");", StringComparison.Ordinal);
+        var keyNameApplication = GeneratedQuerySpecificationSources.Application.Replace("ProjectOverview(ProjectId ProjectId", "ProjectOverview(ProjectId OtherId", StringComparison.Ordinal);
+        var keyTypeApplication = GeneratedQuerySpecificationSources.Application.Replace("ProjectOverview(ProjectId ProjectId", "ProjectOverview(Guid ProjectId", StringComparison.Ordinal);
+        var keyTypeScenario = scenario.Replace(
+            "readonly ProjectOverview _expected = new(\n        new ProjectId(Guid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\")),",
+            "readonly ProjectOverview _expected = new(\n        Guid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\"),",
+            StringComparison.Ordinal);
+        var nullLiteral = WithoutEstablish(scenario).Replace(QueryCall, "ProjectOverview.ProjectById(_readModels, null!)", StringComparison.Ordinal);
+        var enumApplication = GeneratedQuerySpecificationSources.Application
+            .Replace("[ReadModel]", "public enum ProjectStatus { Active }\n\n[ReadModel]", StringComparison.Ordinal)
+            .Replace("DateTimeOffset UpdatedAt)", "DateTimeOffset UpdatedAt, ProjectStatus Status)", StringComparison.Ordinal);
+        var invalidEnumMember = scenario.Replace(
+            "DateTimeOffset.Parse(\"2026-02-14T10:15:30+00:00\", CultureInfo.InvariantCulture));",
+            "DateTimeOffset.Parse(\"2026-02-14T10:15:30+00:00\", CultureInfo.InvariantCulture), (ProjectStatus)99);",
+            StringComparison.Ordinal);
+        var customConceptApplication = GeneratedQuerySpecificationSources.Application.Replace(
+            "public record ProjectId(Guid Value) : EventSourceId<Guid>(Value);",
+            "public record ProjectId(Guid Value) : EventSourceId<Guid>(Value)\n{\n    public ProjectId(string value) : this(Guid.Parse(value)) { }\n}",
+            StringComparison.Ordinal);
+        var customConceptScenario = scenario.Replace(
+            "new ProjectId(Guid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\"))",
+            "new ProjectId(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\")",
+            StringComparison.Ordinal);
+        const string customReadModel = """
+            public record ProjectOverview
+            {
+                public ProjectId ProjectId { get; }
+                public ProjectName Name { get; }
+                public int Number { get; }
+                public DateOnly StartedOn { get; }
+                public DateTimeOffset UpdatedAt { get; }
+
+                public ProjectOverview(ProjectId ProjectId, ProjectName Name, int Number, DateOnly StartedOn, DateTimeOffset UpdatedAt)
+                {
+                    this.ProjectId = ProjectId;
+                    this.Name = Name;
+                    this.Number = Number;
+                    this.StartedOn = StartedOn;
+                    this.UpdatedAt = UpdatedAt;
+                }
+            """;
+        var customReadModelApplication = GeneratedQuerySpecificationSources.Application.Replace(
+            "public record ProjectOverview(ProjectId ProjectId, ProjectName Name, int Number, DateOnly StartedOn, DateTimeOffset UpdatedAt)\n{",
+            customReadModel,
+            StringComparison.Ordinal);
+        var extraAwait = scenario.Replace(
+            $"async Task Because() => _result = await {QueryCall};",
+            $"async Task Because()\n    {{\n        await Task.Yield();\n        _result = await {QueryCall};\n    }}",
+            StringComparison.Ordinal);
+        var extraHelper = scenario
+            .Replace(
+                $"async Task Because() => _result = await {QueryCall};",
+                $"async Task Because()\n    {{\n        Observe();\n        _result = await {QueryCall};\n    }}",
+                StringComparison.Ordinal)
+            .Replace("\n    [Fact]", "\n    static void Observe() { }\n\n    [Fact]", StringComparison.Ordinal);
+        var extraEstablishMethod = scenario.Replace(Establish, $"{Establish}\n\n    void Establish(int ignored) {{ }}", StringComparison.Ordinal);
+        var extraEstablishStatement = scenario.Replace(
+            Establish,
+            $"void Establish()\n    {{\n        {EstablishCall};\n        _ = _expected;\n    }}",
+            StringComparison.Ordinal);
+        var blockBodiedAssertion = scenario.Replace(
+            "[Fact] void should_return_the_expected_read_model() => _result.ShouldEqual(_expected);",
+            "[Fact] void should_return_the_expected_read_model()\n    {\n        _result.ShouldEqual(_expected);\n    }",
+            StringComparison.Ordinal);
+        var indirectBase = scenario.Replace(" : Specification", " : QuerySpecification", StringComparison.Ordinal);
+        const string indirectBaseType = """
+            using Cratis.Specifications;
+
+            namespace Projects.Projects.Overview.ListProjects.when_project_by_id_is_queried;
+
+            public abstract class QuerySpecification : Specification;
+            """;
+        var staticFields = scenario
+            .Replace("readonly IReadModels _readModels", "static readonly IReadModels _readModels", StringComparison.Ordinal)
+            .Replace("readonly ProjectOverview _expected", "static readonly ProjectOverview _expected", StringComparison.Ordinal)
+            .Replace("ProjectOverview? _result;", "static ProjectOverview? _result;", StringComparison.Ordinal);
+        var nullableInputApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, nullableInputQuery, StringComparison.Ordinal);
+        var collectionInputApplication = GeneratedQuerySpecificationSources.Application.Replace(Query, collectionInputQuery, StringComparison.Ordinal);
+        var collectionInputScenario = scenario.Replace(QueryCall, $"ProjectOverview.ProjectById(_readModels, [{Key}])", StringComparison.Ordinal);
+
+        return
+        [
+            new("computed argument", GeneratedQuerySpecificationSources.Application, computedArgument),
+            new("user parse argument", GeneratedQuerySpecificationSources.Application, userParseArgument, userParse),
+            new("conditional call", GeneratedQuerySpecificationSources.Application, conditionalCall),
+            new("repeated call", GeneratedQuerySpecificationSources.Application, repeatedCall),
+            new("multiple calls", GeneratedQuerySpecificationSources.Application, multipleCalls),
+            new("unassigned call", GeneratedQuerySpecificationSources.Application, unassignedCall),
+            new("incomplete expected", incompleteApplication, incompleteExpected),
+            new("computed expected", GeneratedQuerySpecificationSources.Application, computedExpected),
+            new("duplicate assertion", GeneratedQuerySpecificationSources.Application, duplicateAssertion),
+            new("conditional assertion", GeneratedQuerySpecificationSources.Application, conditionalAssertion),
+            new("lookalike assertion", GeneratedQuerySpecificationSources.Application, lookalikeAssertionScenario, lookalikeAssertion),
+            new("property assertion", GeneratedQuerySpecificationSources.Application, propertyAssertion),
+            new("reversed assertion", GeneratedQuerySpecificationSources.Application, reversedAssertion),
+            new("unrelated same-name query", GeneratedQuerySpecificationSources.Application, unrelatedQueryScenario, unrelatedQuery),
+            new("spec-only query", GeneratedQuerySpecificationSources.Application, specificationOnlyScenario, specificationOnlyQuery),
+            new("required return", requiredApplication, scenario),
+            new("observable return", observableApplication, ResultOf(scenario, "System.Reactive.Subjects.ISubject<ProjectOverview>")),
+            new("collection return", collectionApplication, ResultOf(scenario, "System.Collections.Generic.IReadOnlyList<ProjectOverview>")),
+            new("transport return", transportApplication, ResultOf(scenario, "Microsoft.AspNetCore.Mvc.ActionResult<ProjectOverview>")),
+            new("unsupported return", unsupportedApplication, ResultOf(scenario, "object")),
+            new("default input", defaultInputApplication, scenario),
+            new("extra input", extraInputApplication, extraInputScenario),
+            new("non-specification base", GeneratedQuerySpecificationSources.Application, nonSpecificationBase),
+            new("null read models", GeneratedQuerySpecificationSources.Application, nullReadModels),
+            new("uninitialized read models", GeneratedQuerySpecificationSources.Application, uninitializedReadModels),
+            new("nonreadonly read models", GeneratedQuerySpecificationSources.Application, nonreadonlyReadModels),
+            new("indirect substitute", GeneratedQuerySpecificationSources.Application, indirectSubstitute),
+            new("nonmatching establish", GeneratedQuerySpecificationSources.Application, nonmatchingEstablish),
+            new("conflicting establish", GeneratedQuerySpecificationSources.Application, conflictingEstablish),
+            new("object expected", GeneratedQuerySpecificationSources.Application, objectExpected),
+            new("nullable result property", nullablePropertyApplication, scenario),
+            new("collection result property", collectionPropertyApplication, collectionPropertyScenario),
+            new("normalized result collision", collidingApplication, collidingScenario),
+            new("key name mismatch", keyNameApplication, scenario),
+            new("key type mismatch", keyTypeApplication, keyTypeScenario),
+            new("null literal", GeneratedQuerySpecificationSources.Application, nullLiteral),
+            new("invalid enum member", enumApplication, invalidEnumMember),
+            new("custom concept constructor", customConceptApplication, customConceptScenario),
+            new("custom read-model constructor", customReadModelApplication, scenario),
+            new("extra await in because", GeneratedQuerySpecificationSources.Application, extraAwait),
+            new("extra helper in because", GeneratedQuerySpecificationSources.Application, extraHelper),
+            new("extra establish method", GeneratedQuerySpecificationSources.Application, extraEstablishMethod),
+            new("extra establish statement", GeneratedQuerySpecificationSources.Application, extraEstablishStatement),
+            new("block-bodied assertion", GeneratedQuerySpecificationSources.Application, blockBodiedAssertion),
+            new("indirect base", GeneratedQuerySpecificationSources.Application, indirectBase, indirectBaseType),
+            new("static fields", GeneratedQuerySpecificationSources.Application, staticFields),
+            new("required nullable input", nullableInputApplication, scenario),
+            new("collection input", collectionInputApplication, collectionInputScenario)
+        ];
+    }
+
+    static string WithoutEstablish(string scenario) => scenario.Replace($"\n    {Establish}\n", string.Empty, StringComparison.Ordinal);
+
+    static string ResultOf(string scenario, string type) => scenario
+        .Replace("ProjectOverview? _result;", $"{type}? _result;", StringComparison.Ordinal)
+        .Replace("_result.ShouldEqual(_expected)", $"Cratis.Specifications.ShouldEqualityExtensions.ShouldEqual<{type}?>(_result, null)", StringComparison.Ordinal);
+
+    static InvalidRecovery Analyze(InvalidCase invalid)
+    {
+        var application = Analyzed.Project(
+            "Projects",
+            [],
+            ("Testing/Framework.cs", GeneratedQuerySpecificationSources.Framework),
+            ("Projects/Overview/ListProjects/ProjectOverview.cs", invalid.Application));
+        var specificationSources = invalid.ExtraSources
+            .Select((source, index) => ($"Projects/Overview/ListProjects/Extra{index}.cs", source))
+            .Append(("Projects/Overview/ListProjects/when_project_by_id_is_queried.cs", invalid.Scenario))
+            .ToArray();
+        var specifications = Analyzed.Project("Projects.Specifications", [application.ToMetadataReference()], specificationSources);
+        var errors = Analyzed.ErrorsIn(application).Concat(Analyzed.ErrorsIn(specifications)).ToArray();
+        var contribution = new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([
+                SourceProjects.Create("Projects", DotNetProjectRole.Application, application),
+                SourceProjects.Create("Projects.Specifications", DotNetProjectRole.Specifications, specifications)
+            ]),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+        return new(contribution, errors);
+    }
+
+    sealed record InvalidCase(string Name, string Application, string Scenario, params string[] ExtraSources);
+    sealed record InvalidRecovery(AdapterContribution Contribution, IReadOnlyList<string> CompilationErrors);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_a_generated_read_model_assertion_is_computed.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_a_generated_read_model_assertion_is_computed.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_a_generated_read_model_assertion_is_computed : Specification
+{
+    const string Application = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Projects.Projects.Overview.ListProjects;
+
+        [EventType]
+        public record ProjectRegistered(string Name, int Number);
+
+        [Command]
+        public record RegisterProject(string Name, int Number)
+        {
+            public ProjectRegistered Handle() => new(Name, Number);
+        }
+
+        [ReadModel]
+        [FromEvent<ProjectRegistered>]
+        public record ProjectOverview
+        {
+            public string Name { get; init; } = string.Empty;
+            public int Number { get; init; }
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.ReadModels;
+        using Cratis.Specifications;
+        using Projects.Projects.Overview.ListProjects;
+        using Xunit;
+
+        namespace Projects.Projects.Overview.ListProjects.when_a_project_was_registered;
+
+        public class when_a_project_was_registered : Specification
+        {
+            readonly ReadModelScenario<ProjectOverview> _scenario = new();
+
+            static int ExpectedNumber() => 42;
+
+            async Task Establish() => await _scenario.Given
+                .ForEventSource(EventSourceId.New())
+                .Events(new ProjectRegistered("Screenplay", 42));
+
+            [Fact] void should_project_name() => _scenario.Instance!.Name.ShouldEqual("Screenplay");
+            [Fact] void should_project_number() => _scenario.Instance!.Number.ShouldEqual(ExpectedNumber());
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because()
+    {
+        var compilation = Analyzed.Compile(
+        [
+            ("Projects/Overview/ListProjects/ListProjects.cs", Application),
+            ("Projects/Overview/ListProjects/when_a_project_was_registered.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        ]);
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        _contribution = new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    [Fact] void should_contribute_no_partial_facts() => _contribution.Facts.ShouldBeEmpty();
+    [Fact] void should_report_only_the_unsupported_scenario() => _contribution.Diagnostics.Select(_ => _.Code).ShouldContainOnly("ARCSP0001");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_an_appended_event_is_expected_repeatedly.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_an_appended_event_is_expected_repeatedly.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_an_appended_event_is_expected_repeatedly : Specification
+{
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Testing.Commands;
+        using Cratis.Arc.Testing.Commands;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_registering;
+
+        public class when_registering
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+
+            async Task Because() => await _scenario.Execute(new RegisterProject("Screenplay"));
+
+            [Fact] Task should_append() => _scenario.ShouldHaveAppendedEvent<RegisterProject, ProjectRegistered>(
+                "project",
+                @event => @event.Name == "Screenplay");
+
+            [Fact] Task should_append_again() => _scenario.ShouldHaveAppendedEvent<RegisterProject, ProjectRegistered>(
+                "project",
+                @event => @event.Name == "Other");
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because() => _contribution = GeneratedEventAssertionSources.Analyze(Scenario);
+
+    [Fact] void should_contribute_no_partial_facts() => _contribution.Facts.ShouldBeEmpty();
+    [Fact] void should_report_only_the_unsupported_scenario() => _contribution.Diagnostics.Select(_ => _.Code).ShouldContainOnly("ARCSP0001");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_an_appended_event_predicate_is_conditional.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_an_appended_event_predicate_is_conditional.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_an_appended_event_predicate_is_conditional : Specification
+{
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Testing.Commands;
+        using Cratis.Arc.Testing.Commands;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_registering;
+
+        public class when_registering
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+
+            async Task Because() => await _scenario.Execute(new RegisterProject("Screenplay"));
+
+            [Fact] Task should_append()
+            {
+                var compareName = true;
+                return _scenario.ShouldHaveAppendedEvent<RegisterProject, ProjectRegistered>(
+                    "project",
+                    @event => compareName ? @event.Name == "Screenplay" : @event.Name == "Other");
+            }
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because() => _contribution = GeneratedEventAssertionSources.Analyze(Scenario);
+
+    [Fact] void should_contribute_no_partial_facts() => _contribution.Facts.ShouldBeEmpty();
+    [Fact] void should_report_only_the_unsupported_scenario() => _contribution.Diagnostics.Select(_ => _.Code).ShouldContainOnly("ARCSP0001");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_an_unrelated_helper_uses_the_appended_event_name.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_an_unrelated_helper_uses_the_appended_event_name.cs
@@ -7,7 +7,7 @@ using Cratis.Screenplay.Generation.DotNet;
 
 namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
 
-public class when_analyzing_event_predicate_values : Specification
+public class when_an_unrelated_helper_uses_the_appended_event_name : Specification
 {
     const string Slice = """
         using Cratis.Arc.Commands.ModelBound;
@@ -27,7 +27,7 @@ public class when_analyzing_event_predicate_values : Specification
 
     const string Scenario = """
         using System.Threading.Tasks;
-        using Cratis.Arc.Chronicle.Testing.Commands;
+        using Application.Assertions;
         using Cratis.Arc.Testing.Commands;
         using Projects.Projects.Registration.RegisterProject;
         using Xunit;
@@ -40,21 +40,19 @@ public class when_analyzing_event_predicate_values : Specification
 
             async Task Because() => await _scenario.Execute(new RegisterProject("Screenplay"));
 
-            static string ExpectedName() => "Screenplay";
-
             [Fact] Task should_append() => _scenario.ShouldHaveAppendedEvent<RegisterProject, ProjectRegistered>(
                 "project",
-                @event => @event.Name == ExpectedName());
+                @event => @event.Name == "Screenplay");
         }
         """;
 
-    const string Assertions = """
+    const string Lookalike = """
         using System;
         using System.Threading.Tasks;
         using Cratis.Arc.Testing.Commands;
         using Cratis.Chronicle.Events;
 
-        namespace Cratis.Arc.Chronicle.Testing.Commands;
+        namespace Application.Assertions;
 
         public static class CommandScenarioChronicleAssertionExtensions
         {
@@ -73,7 +71,7 @@ public class when_analyzing_event_predicate_values : Specification
         [
             ("Projects/Registration/RegisterProject/RegisterProject.cs", Slice),
             ("Projects/Registration/RegisterProject/when_registering.cs", Scenario),
-            ("Integration/Assertions.cs", Assertions),
+            ("Application/Assertions.cs", Lookalike),
             (IntegrationTesting.Path, IntegrationTesting.Source)
         ]);
         var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
@@ -83,6 +81,6 @@ public class when_analyzing_event_predicate_values : Specification
     }
 
     [Fact] void should_contribute_no_partial_facts() => _contribution.Facts.ShouldBeEmpty();
-    [Fact] void should_report_only_the_unrepresented_predicate_values() => _contribution.Diagnostics.Select(_ => _.Code).ShouldContainOnly("ARCSP0001");
+    [Fact] void should_report_only_the_unsupported_scenario() => _contribution.Diagnostics.Select(_ => _.Code).ShouldContainOnly("ARCSP0001");
     [Fact] void should_retain_the_scenario_source() => _contribution.Diagnostics.Single().Source!.Path.ShouldEqual("Projects/Registration/RegisterProject/when_registering.cs");
 }

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_query_specification.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_query_specification.cs
@@ -70,7 +70,7 @@ public class when_analyzing_a_generated_query_specification : Specification
         _withoutEstablishSource = Source([_withoutEstablish]);
         _partialSource = Source([_partial]);
         _partialReversedSource = Source([_partialReversed]);
-        _reversedFactsSource = Source([_separateProject with { Facts = [.. _separateProject.Facts.Reverse()] }]);
+        _reversedFactsSource = Source([_separateProject with { Facts = [.. Reversed(_separateProject.Facts)] }]);
         _reversedAdaptersSource = SourceRaw([_concepts, _separateProject]);
     }
 
@@ -151,7 +151,7 @@ public class when_analyzing_a_generated_query_specification : Specification
         };
         if (reverseProjects)
         {
-            projects = [.. projects.Reverse()];
+            projects = [.. Reversed(projects)];
         }
 
         return new ArcSpecificationFactAdapter().Analyze(
@@ -170,7 +170,7 @@ public class when_analyzing_a_generated_query_specification : Specification
         ];
         if (reverseTrees)
         {
-            scenarios = [.. scenarios.Reverse()];
+            scenarios = [.. Reversed(scenarios)];
         }
 
         return new ArcSpecificationFactAdapter().Analyze(
@@ -192,8 +192,8 @@ public class when_analyzing_a_generated_query_specification : Specification
     {
         if (reverseTrees)
         {
-            applicationSources = [.. applicationSources.Reverse()];
-            specificationSources = [.. specificationSources.Reverse()];
+            applicationSources = [.. Reversed(applicationSources)];
+            specificationSources = [.. Reversed(specificationSources)];
         }
 
         var application = Analyzed.Project("Projects", [], applicationSources);
@@ -214,9 +214,9 @@ public class when_analyzing_a_generated_query_specification : Specification
     {
         if (reverseTrees)
         {
-            frameworkSources = [.. frameworkSources.Reverse()];
-            applicationSources = [.. applicationSources.Reverse()];
-            specificationSources = [.. specificationSources.Reverse()];
+            frameworkSources = [.. Reversed(frameworkSources)];
+            applicationSources = [.. Reversed(applicationSources)];
+            specificationSources = [.. Reversed(specificationSources)];
         }
 
         var framework = Analyzed.Project("Projects.Framework", [], frameworkSources);
@@ -308,6 +308,8 @@ public class when_analyzing_a_generated_query_specification : Specification
             .ToArray();
         return new AdapterContribution { Adapter = adapter, Facts = concepts };
     }
+
+    static IEnumerable<T> Reversed<T>(IEnumerable<T> values) => values.Reverse();
 
     static string[] FactEvidence(AdapterContribution contribution) =>
     [

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_query_specification.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_query_specification.cs
@@ -1,0 +1,325 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Cratis.Screenplay.Printing;
+using Cratis.Screenplay.Syntax;
+using Cratis.Screenplay.Syntax.Specifications;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_analyzing_a_generated_query_specification : Specification
+{
+    AdapterContribution _sameProject = null!;
+    bool _canAnalyze;
+    AdapterContribution _separateProject = null!;
+    AdapterContribution _siblingProject = null!;
+    AdapterContribution _reversed = null!;
+    AdapterContribution _relocated = null!;
+    AdapterContribution _withoutEstablish = null!;
+    AdapterContribution _partial = null!;
+    AdapterContribution _partialReversed = null!;
+    AdapterContribution _concepts = null!;
+    ResolvedApplicationGraph _graph = null!;
+    ScreenplayLoweringResult _lowering = null!;
+    CompilationResult<Cratis.Screenplay.Syntax.ApplicationSyntax> _compiled = null!;
+    string _source = null!;
+    string _reprinted = null!;
+    string _sameProjectSource = null!;
+    string _siblingProjectSource = null!;
+    string _reversedSource = null!;
+    string _relocatedSource = null!;
+    string _withoutEstablishSource = null!;
+    string _partialSource = null!;
+    string _partialReversedSource = null!;
+    string _reversedFactsSource = null!;
+    string _reversedAdaptersSource = null!;
+
+    void Because()
+    {
+        _canAnalyze = CanAnalyze();
+        _sameProject = Analyze(ProjectShape.Same, false, false, string.Empty);
+        _separateProject = Analyze(ProjectShape.Separate, false, false, string.Empty);
+        _siblingProject = Analyze(ProjectShape.Sibling, false, false, string.Empty);
+        _reversed = Analyze(ProjectShape.Separate, true, true, string.Empty);
+        _relocated = Analyze(ProjectShape.Separate, false, false, "/another/checkout/");
+        _withoutEstablish = Analyze(
+            ProjectShape.Separate,
+            false,
+            false,
+            string.Empty,
+            GeneratedQuerySpecificationSources.Scenario.Replace(
+                "\n    void Establish() => _readModels.GetInstanceById<ProjectOverview>((EventSourceId)new ProjectId(Guid.Parse(\"f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e\"))).Returns(_expected);\n",
+                string.Empty,
+                StringComparison.Ordinal));
+        _partial = AnalyzePartial(reverseTrees: false);
+        _partialReversed = AnalyzePartial(reverseTrees: true);
+        _concepts = Concepts(_separateProject);
+        _graph = new GenerationResolver().Resolve([_separateProject, _concepts]);
+        _lowering = new ScreenplayLowerer().Lower(_graph, "Projects");
+        _source = new ScreenplayPrinter().Print(_lowering.Application);
+        _compiled = new ScreenplayCompiler().Compile(_source);
+        _reprinted = _compiled.Value is null ? string.Empty : new ScreenplayPrinter().Print(_compiled.Value);
+        _sameProjectSource = Source([_sameProject]);
+        _siblingProjectSource = Source([_siblingProject]);
+        _reversedSource = Source([_reversed]);
+        _relocatedSource = Source([_relocated]);
+        _withoutEstablishSource = Source([_withoutEstablish]);
+        _partialSource = Source([_partial]);
+        _partialReversedSource = Source([_partialReversed]);
+        _reversedFactsSource = Source([_separateProject with { Facts = [.. _separateProject.Facts.Reverse()] }]);
+        _reversedAdaptersSource = SourceRaw([_concepts, _separateProject]);
+    }
+
+    [Fact] void should_recognize_an_application_query_with_a_specification_shaped_type() => _canAnalyze.ShouldBeTrue();
+    [Fact] void should_report_no_adapter_diagnostics() => _separateProject.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_emit_only_the_complete_query_recovery_facts() => _separateProject.Facts.Count.ShouldEqual(13);
+    [Fact] void should_emit_the_query_and_read_model_artifacts() => _separateProject.Facts.OfType<ArtifactFact>().Select(_ => _.Definition.Key.Kind).ShouldContainOnly([ArtifactKind.Query, ArtifactKind.ReadModel]);
+    [Fact] void should_identify_the_query_by_its_exact_method_subject() => QueryArtifact().Subject.Value.ShouldContain("#method:");
+    [Fact] void should_not_treat_the_query_source_file_as_a_performer() => QueryArtifact().Definition.File.ShouldBeNull();
+    [Fact] void should_mark_the_single_required_query_input_as_the_identifier() => QueryArtifact().Definition.Properties.Single().IsIdentifier.ShouldBeTrue();
+    [Fact] void should_align_the_query_key_with_the_exact_read_model_property() => (QueryArtifact().Definition.Properties.Single().Name, ReadModelArtifact().Definition.Properties.Single(_ => _.Name == "projectId").Name).ShouldEqual(("projectId", "projectId"));
+    [Fact] void should_emit_exact_supported_query_result_types() => ReadModelArtifact().Definition.Properties.Select(_ => _.Type.Name).ShouldEqual(["ProjectId", "ProjectName", "Int", "Date", "DateTime"]);
+    [Fact] void should_emit_the_exact_returns_relationship() => Returns().Definition.Key.ShouldEqual(new RelationshipKey { Kind = RelationshipKind.Returns, Source = QueryArtifact().Subject, Target = ReadModelArtifact().Subject });
+    [Fact] void should_preserve_the_optional_single_result_flags() => (Returns().Definition.IsOptional, Returns().Definition.IsCollection).ShouldEqual((true, false));
+    [Fact] void should_target_the_scenario_at_the_query() => Scenario().Definition.TargetArtifact.ShouldEqual(QueryArtifact().Definition.Key);
+    [Fact] void should_emit_one_then_read_step() => (Step().Definition.Phase, Step().Definition.Kind).ShouldEqual((SpecificationStepPhase.Then, SpecificationStepKind.Read));
+    [Fact] void should_emit_no_given_or_when_step() => _separateProject.Facts.OfType<SpecificationStepFact>().Any(_ => _.Definition.Phase is SpecificationStepPhase.Given or SpecificationStepPhase.When).ShouldBeFalse();
+    [Fact] void should_preserve_formal_argument_and_property_order() => Step().Definition.Values.Select(_ => string.Join('/', _.Path)).ShouldEqual(["arguments/projectId", "result/0/projectId", "result/0/name", "result/0/number", "result/0/startedOn", "result/0/updatedAt"]);
+    [Fact] void should_preserve_the_exact_concept_and_scalar_values() => Step().Definition.Values.Select(key => Value(key).Definition.Scalar).ShouldEqual(["f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e", "f5a0c7ef-2e5f-4c4d-8d25-62b477b75f4e", "Screenplay", "42", "2026-02-14", "2026-02-14T10:15:30+00:00"]);
+    [Fact] void should_place_the_query_and_read_model_together_as_a_state_view() => _separateProject.Facts.OfType<ArtifactPlacementFact>().Select(_ => (_.Placement.Slice, _.Placement.SliceKind)).ShouldContainOnly([("ListProjects", GenerationSliceKind.StateView), ("ListProjects", GenerationSliceKind.StateView)]);
+    [Fact] void should_resolve_one_atomic_scenario() => _graph.Specifications.Count.ShouldEqual(1);
+    [Fact] void should_resolve_without_diagnostics() => _graph.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_lower_without_diagnostics() => _lowering.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_lower_the_query_without_a_when() => Lowered().When.ShouldBeNull();
+    [Fact] void should_lower_the_query_without_a_performer() => LoweredQuery().Performer.ShouldBeNull();
+    [Fact] void should_print_the_query_without_a_performer() => _source.ShouldNotContain("performer");
+    [Fact] void should_lower_the_exact_query_argument() => Lowered().ThenQueries.Single().Arguments.Single().Property.ShouldEqual("projectId");
+    [Fact] void should_lower_one_expected_snapshot() => Lowered().ThenQueries.Single().Results.Count().ShouldEqual(1);
+    [Fact] void should_compile_the_printed_document() => _compiled.Success.ShouldBeTrue();
+    [Fact] void should_reprint_byte_identically() => _reprinted.ShouldEqual(_source);
+    [Fact] void should_be_identical_when_query_and_specification_share_a_project() => _sameProjectSource.ShouldEqual(_source);
+    [Fact] void should_be_identical_with_a_sibling_framework_project() => _siblingProjectSource.ShouldEqual(_source);
+    [Fact] void should_be_independent_of_project_and_syntax_tree_order() => _reversedSource.ShouldEqual(_source);
+    [Fact] void should_be_independent_of_fact_order() => _reversedFactsSource.ShouldEqual(_source);
+    [Fact] void should_be_independent_of_adapter_order() => _reversedAdaptersSource.ShouldEqual(_source);
+    [Fact] void should_be_independent_of_checkout_location() => _relocatedSource.ShouldEqual(_source);
+    [Fact] void should_allow_the_corroborating_establish_to_be_absent() => _withoutEstablish.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_recover_the_same_scenario_without_corroborating_establish() => _withoutEstablishSource.ShouldEqual(_source);
+    [Fact] void should_recover_the_complete_partial_scenario() => _partial.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_be_independent_of_partial_syntax_tree_order() => _partialReversedSource.ShouldEqual(_partialSource);
+    [Fact] void should_preserve_partial_scenario_evidence_when_reversed() => FactEvidence(_partialReversed).ShouldEqual(FactEvidence(_partial));
+    [Fact] void should_preserve_identical_fact_evidence_when_reversed() => FactEvidence(_reversed).ShouldEqual(FactEvidence(_separateProject));
+    [Fact] void should_preserve_identical_fact_evidence_when_relocated() => FactEvidence(_relocated).ShouldEqual(FactEvidence(_separateProject));
+
+    ArtifactFact QueryArtifact() => _separateProject.Facts.OfType<ArtifactFact>().Single(_ => _.Definition.Key.Kind == ArtifactKind.Query);
+    ArtifactFact ReadModelArtifact() => _separateProject.Facts.OfType<ArtifactFact>().Single(_ => _.Definition.Key.Kind == ArtifactKind.ReadModel);
+    RelationshipFact Returns() => _separateProject.Facts.OfType<RelationshipFact>().Single();
+    SpecificationScenarioFact Scenario() => _separateProject.Facts.OfType<SpecificationScenarioFact>().Single();
+    SpecificationStepFact Step() => _separateProject.Facts.OfType<SpecificationStepFact>().Single();
+    SpecificationValueFact Value(SpecificationValueKey key) => _separateProject.Facts.OfType<SpecificationValueFact>().Single(_ => _.Definition.Key == key);
+    SpecificationSyntax Lowered() => _lowering.Application.Modules.SelectMany(_ => _.Features).SelectMany(_ => _.Slices).Single(_ => _.Specifications.Any()).Specifications.Single();
+    QuerySyntax LoweredQuery() => _lowering.Application.Modules.SelectMany(_ => _.Features).SelectMany(_ => _.Slices).Single(_ => _.Queries.Any()).Queries.Single();
+
+    static bool CanAnalyze()
+    {
+        var framework = Source(string.Empty, "Testing/Framework.cs", GeneratedQuerySpecificationSources.Framework);
+        var applicationSource = Source(string.Empty, "Projects/Overview/ListProjects/ProjectOverview.cs", GeneratedQuerySpecificationSources.Application);
+        var scenario = Source(string.Empty, "Projects/Overview/ListProjects/when_project_by_id_is_queried.cs", GeneratedQuerySpecificationSources.Scenario);
+        var application = Analyzed.Project("Projects", [], framework, applicationSource);
+        var specifications = Analyzed.Project("Projects.Specifications", [application.ToMetadataReference()], scenario);
+        return new ArcSpecificationFactAdapter().CanAnalyze(new DotNetAnalysisContext([
+            Project("Projects", DotNetProjectRole.Application, application, string.Empty),
+            Project("Projects.Specifications", DotNetProjectRole.Specifications, specifications, string.Empty)
+        ]));
+    }
+
+    static AdapterContribution Analyze(ProjectShape shape, bool reverseProjects, bool reverseTrees, string root, string? scenarioSource = null)
+    {
+        var framework = Source(root, "Testing/Framework.cs", GeneratedQuerySpecificationSources.Framework);
+        var application = Source(root, "Projects/Overview/ListProjects/ProjectOverview.cs", GeneratedQuerySpecificationSources.Application);
+        var scenario = Source(root, "Projects/Overview/ListProjects/when_project_by_id_is_queried.cs", scenarioSource ?? GeneratedQuerySpecificationSources.Scenario);
+        var projects = shape switch
+        {
+            ProjectShape.Same => SameProject([framework, application, scenario], root),
+            ProjectShape.Separate => SeparateProjects([framework, application], [scenario], reverseTrees, root),
+            ProjectShape.Sibling => SiblingProjects([framework], [application], [scenario], reverseTrees, root),
+            _ => []
+        };
+        if (reverseProjects)
+        {
+            projects = [.. projects.Reverse()];
+        }
+
+        return new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext(projects),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    static AdapterContribution AnalyzePartial(bool reverseTrees)
+    {
+        var framework = Source(string.Empty, "Testing/Framework.cs", GeneratedQuerySpecificationSources.Framework);
+        var application = Source(string.Empty, "Projects/Overview/ListProjects/ProjectOverview.cs", GeneratedQuerySpecificationSources.Application);
+        (string Path, string Text)[] scenarios =
+        [
+            Source(string.Empty, "Projects/Overview/ListProjects/when_project_by_id_is_queried.cs", GeneratedQuerySpecificationSources.PartialScenarioFields),
+            Source(string.Empty, "Projects/Overview/ListProjects/Z.when_project_by_id_is_queried.cs", GeneratedQuerySpecificationSources.PartialScenarioBehavior)
+        ];
+        if (reverseTrees)
+        {
+            scenarios = [.. scenarios.Reverse()];
+        }
+
+        return new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext(SeparateProjects([framework, application], scenarios, reverseTrees: false, string.Empty)),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    static DotNetProjectCompilation[] SameProject((string Path, string Text)[] sources, string root)
+    {
+        var compilation = Analyzed.Project("Projects", [], sources);
+        return [Project("Projects", DotNetProjectRole.Application, compilation, root)];
+    }
+
+    static DotNetProjectCompilation[] SeparateProjects(
+        (string Path, string Text)[] applicationSources,
+        (string Path, string Text)[] specificationSources,
+        bool reverseTrees,
+        string root)
+    {
+        if (reverseTrees)
+        {
+            applicationSources = [.. applicationSources.Reverse()];
+            specificationSources = [.. specificationSources.Reverse()];
+        }
+
+        var application = Analyzed.Project("Projects", [], applicationSources);
+        var specifications = Analyzed.Project("Projects.Specifications", [application.ToMetadataReference()], specificationSources);
+        return
+        [
+            Project("Projects", DotNetProjectRole.Application, application, root),
+            Project("Projects.Specifications", DotNetProjectRole.Specifications, specifications, root)
+        ];
+    }
+
+    static DotNetProjectCompilation[] SiblingProjects(
+        (string Path, string Text)[] frameworkSources,
+        (string Path, string Text)[] applicationSources,
+        (string Path, string Text)[] specificationSources,
+        bool reverseTrees,
+        string root)
+    {
+        if (reverseTrees)
+        {
+            frameworkSources = [.. frameworkSources.Reverse()];
+            applicationSources = [.. applicationSources.Reverse()];
+            specificationSources = [.. specificationSources.Reverse()];
+        }
+
+        var framework = Analyzed.Project("Projects.Framework", [], frameworkSources);
+        var application = Analyzed.Project("Projects", [framework.ToMetadataReference()], applicationSources);
+        var specifications = Analyzed.Project("Projects.Specifications", [framework.ToMetadataReference(), application.ToMetadataReference()], specificationSources);
+        return
+        [
+            Project("Projects.Framework", DotNetProjectRole.Application, framework, root),
+            Project("Projects", DotNetProjectRole.Application, application, root),
+            Project("Projects.Specifications", DotNetProjectRole.Specifications, specifications, root)
+        ];
+    }
+
+    static DotNetProjectCompilation Project(string name, DotNetProjectRole role, Microsoft.CodeAnalysis.Compilation compilation, string root) =>
+        SourceProjects.Create(name, role, compilation, relativePathFor: tree => Relative(tree.FilePath, root));
+
+    static (string Path, string Text) Source(string root, string path, string text) => ($"{root}{path}", text);
+
+    static string Relative(string path, string root) => string.IsNullOrEmpty(root) ? path : path[root.Length..];
+
+    static string Source(IReadOnlyList<AdapterContribution> contributions)
+    {
+        var source = contributions.FirstOrDefault(_ => _.Facts.OfType<ArtifactFact>().Any());
+        return source is null ? SourceRaw(contributions) : SourceRaw([.. contributions, Concepts(source)]);
+    }
+
+    static string SourceRaw(IReadOnlyList<AdapterContribution> contributions)
+    {
+        var graph = new GenerationResolver().Resolve(contributions);
+        var lowering = new ScreenplayLowerer().Lower(graph, "Projects");
+        return new ScreenplayPrinter().Print(lowering.Application);
+    }
+
+    static AdapterContribution Concepts(AdapterContribution contribution)
+    {
+        var adapter = new AdapterIdentity { Id = "test.query-concepts", Version = "1.0.0" };
+        var artifactEvidence = contribution.Facts.OfType<ArtifactFact>().First().Evidence;
+        var concepts = contribution.Facts
+            .OfType<ArtifactFact>()
+            .SelectMany(_ => _.Definition.Properties)
+            .Select(_ => _.Type)
+            .Where(_ => _.Subject is not null &&
+                (string.Equals(_.Name, "ProjectId", StringComparison.Ordinal) ||
+                 string.Equals(_.Name, "ProjectName", StringComparison.Ordinal)))
+            .GroupBy(_ => _.Subject!)
+            .Select(group => (
+                Subject: group.Key,
+                group.First().Name,
+                Primitive: string.Equals(group.First().Name, "ProjectId", StringComparison.Ordinal)
+                    ? GenerationPrimitiveKind.Uuid
+                    : GenerationPrimitiveKind.Text))
+            .OrderBy(_ => _.Subject.Value, StringComparer.Ordinal)
+            .SelectMany(concept => new GenerationFact[]
+            {
+                new ArtifactFact
+                {
+                    Id = new FactId { Value = $"test.query-concept-artifact:{concept.Subject.Value}" },
+                    Subject = concept.Subject,
+                    Evidence = new Evidence
+                    {
+                        Adapter = adapter,
+                        Strength = EvidenceStrength.Exact,
+                        Source = artifactEvidence.Source
+                    },
+                    Definition = new ArtifactDefinition
+                    {
+                        Key = new ArtifactKey { Subject = concept.Subject, Kind = ArtifactKind.Concept },
+                        Name = concept.Name
+                    }
+                },
+                new ConceptRepresentationFact
+                {
+                    Id = new FactId { Value = $"test.query-concept-representation:{concept.Subject.Value}" },
+                    Subject = concept.Subject,
+                    Evidence = new Evidence
+                    {
+                        Adapter = adapter,
+                        Strength = EvidenceStrength.Exact,
+                        Source = artifactEvidence.Source
+                    },
+                    Definition = new ConceptRepresentationDefinition
+                    {
+                        Concept = concept.Subject,
+                        Kind = ConceptRepresentationKind.Primitive,
+                        Primitive = concept.Primitive
+                    }
+                }
+            })
+            .ToArray();
+        return new AdapterContribution { Adapter = adapter, Facts = concepts };
+    }
+
+    static string[] FactEvidence(AdapterContribution contribution) =>
+    [
+        .. contribution.Facts
+            .OrderBy(_ => _.Id.Value, StringComparer.Ordinal)
+            .Select(_ => $"{_.Id.Value}|{_.Evidence.Source?.Path}:{_.Evidence.Source?.StartLine}:{_.Evidence.Source?.StartColumn}:{_.Evidence.Source?.EndLine}:{_.Evidence.Source?.EndColumn}")
+    ];
+
+    enum ProjectShape
+    {
+        Same = 0,
+        Separate = 1,
+        Sibling = 2
+    }
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_read_model_scenario.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_read_model_scenario.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_analyzing_a_generated_read_model_scenario : Specification
+{
+    const string Event = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name, int Number);
+
+        [Command]
+        public record RegisterProject(string Name, int Number)
+        {
+            public ProjectRegistered Handle() => new(Name, Number);
+        }
+        """;
+
+    const string StateView = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Projections.ModelBound;
+        using Projects.Projects.Registration.RegisterProject;
+
+        namespace Projects.Projects.Overview.ListProjects;
+
+        [ReadModel]
+        [FromEvent<ProjectRegistered>]
+        public record ProjectOverview
+        {
+            public string Name { get; init; } = string.Empty;
+            public int Number { get; init; }
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.ReadModels;
+        using Cratis.Specifications;
+        using Projects.Projects.Overview.ListProjects;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Overview.ListProjects.when_a_project_was_registered;
+
+        public class when_a_project_was_registered : Specification
+        {
+            readonly EventSourceId _projectId = EventSourceId.New();
+            readonly ReadModelScenario<ProjectOverview> _scenario = new();
+
+            async Task Establish() => await _scenario.Given
+                .ForEventSource(_projectId)
+                .Events(new ProjectRegistered("Screenplay", 42));
+
+            [Fact] void should_project_name() => _scenario.Instance!.Name.ShouldEqual("Screenplay");
+            [Fact] void should_project_number() => _scenario.Instance!.Number.ShouldEqual(42);
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+    ResolvedApplicationGraph _graph = null!;
+    ScreenplayLoweringResult _lowering = null!;
+    bool _canAnalyze;
+
+    void Because()
+    {
+        var compilation = Analyzed.Compile(
+        [
+            ("Projects/Registration/RegisterProject/ProjectRegistered.cs", Event),
+            ("Projects/Overview/ListProjects/ProjectOverview.cs", StateView),
+            ("Projects/Overview/ListProjects/when_a_project_was_registered.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        ]);
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        var context = new DotNetAnalysisContext([project]);
+        var adapter = new ArcSpecificationFactAdapter();
+        _canAnalyze = adapter.CanAnalyze(context);
+        _contribution = adapter.Analyze(
+            context,
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+        _graph = new GenerationResolver().Resolve([_contribution]);
+        _lowering = new ScreenplayLowerer().Lower(_graph, "Projects");
+    }
+
+    [Fact] void should_recognize_the_generated_scenario() => _canAnalyze.ShouldBeTrue();
+    [Fact] void should_have_no_adapter_diagnostics() => _contribution.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_contribute_one_scenario() => _contribution.Facts.OfType<SpecificationScenarioFact>().Count().ShouldEqual(1);
+    [Fact] void should_contribute_the_ordered_given_event_and_then_read_model() => _contribution.Facts.OfType<SpecificationStepFact>().OrderBy(_ => _.Definition.Key.Index).Select(_ => (_.Definition.Phase, _.Definition.Kind)).ShouldEqual([(SpecificationStepPhase.Given, SpecificationStepKind.Event), (SpecificationStepPhase.Then, SpecificationStepKind.ReadModel)]);
+    [Fact] void should_contribute_every_exact_event_and_read_model_value() => _contribution.Facts.OfType<SpecificationValueFact>().Count().ShouldEqual(4);
+    [Fact] void should_contribute_the_event_and_read_model_artifacts() => _contribution.Facts.OfType<ArtifactFact>().Select(_ => _.Definition.Key.Kind).ShouldContainOnly([ArtifactKind.Event, ArtifactKind.ReadModel]);
+    [Fact] void should_place_the_event_and_read_model_in_their_exact_slices() => _contribution.Facts.OfType<ArtifactPlacementFact>().Select(_ => (_.Placement.Slice, _.Placement.SliceKind)).ShouldContainOnly([("RegisterProject", GenerationSliceKind.StateChange), ("ListProjects", GenerationSliceKind.StateView)]);
+    [Fact] void should_preserve_the_exact_scenario_source_range() => Range(_contribution.Facts.OfType<SpecificationScenarioFact>().Single()).ShouldEqual((11, 14, 11, 43));
+    [Fact] void should_preserve_the_exact_given_event_source_range() => Range(_contribution.Facts.OfType<SpecificationStepFact>().Single(_ => _.Definition.Kind == SpecificationStepKind.Event)).ShouldEqual((18, 17, 18, 56));
+    [Fact] void should_preserve_the_exact_given_event_value_ranges() => _contribution.Facts.OfType<SpecificationValueFact>().Where(_ => _.Definition.Key.Step.Index == 0).OrderBy(_ => _.Definition.Key.Path.Single(), StringComparer.Ordinal).Select(Range).ShouldEqual([(18, 39, 18, 51), (18, 53, 18, 55)]);
+    [Fact] void should_preserve_the_exact_read_model_source_range() => Range(_contribution.Facts.OfType<SpecificationStepFact>().Single(_ => _.Definition.Kind == SpecificationStepKind.ReadModel)).ShouldEqual((14, 32, 14, 47));
+    [Fact] void should_preserve_the_exact_read_model_value_ranges() => _contribution.Facts.OfType<SpecificationValueFact>().Where(_ => _.Definition.Key.Step.Index == 1).OrderBy(_ => _.Definition.Key.Path.Single(), StringComparer.Ordinal).Select(Range).ShouldEqual([(20, 79, 20, 91), (21, 83, 21, 85)]);
+    [Fact] void should_resolve_one_atomic_scenario() => _graph.Specifications.Count.ShouldEqual(1);
+    [Fact] void should_lower_without_diagnostics() => _lowering.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_lower_no_when_step() => Lowered().When.ShouldBeNull();
+    [Fact] void should_lower_the_given_event() => Lowered().Given.Single().EventType.ShouldEqual("ProjectRegistered");
+    [Fact] void should_lower_every_read_model_value() => Lowered().ThenReadModels.Single().Properties.Count().ShouldEqual(2);
+
+    Cratis.Screenplay.Syntax.Specifications.SpecificationSyntax Lowered() =>
+        _lowering.Application.Modules.SelectMany(_ => _.Features).SelectMany(_ => _.Slices).Single(_ => _.Specifications.Any()).Specifications.Single();
+
+    static (int StartLine, int StartColumn, int EndLine, int EndColumn) Range(GenerationFact fact) =>
+        (fact.Evidence.Source!.StartLine, fact.Evidence.Source.StartColumn, fact.Evidence.Source.EndLine, fact.Evidence.Source.EndColumn);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_successful_event_scenario.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_a_generated_successful_event_scenario.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Cratis.Screenplay.Printing;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_analyzing_a_generated_successful_event_scenario : Specification
+{
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name, int Number);
+
+        [Command]
+        public record RegisterProject(string Name, int Number)
+        {
+            public ProjectRegistered Handle() => new(Name, Number);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Chronicle.Testing.Commands;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Specifications;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Registration.RegisterProject.when_registering;
+
+        public class when_registering : Specification
+        {
+            readonly CommandScenario<RegisterProject> _scenario = new();
+            CommandResult _result = null!;
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterProject("Screenplay", 42));
+
+            [Fact] void should_succeed() => _result.ShouldBeSuccessful();
+            [Fact] async Task should_append() => await _scenario.ShouldHaveAppendedEvent<RegisterProject, ProjectRegistered>(
+                "project",
+                @event => @event.Name == "Screenplay" &&
+                          @event.Number == 42);
+        }
+        """;
+
+    const string Assertions = """
+        using System;
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Events;
+
+        namespace Cratis.Arc.Chronicle.Testing.Commands;
+
+        public static class CommandScenarioChronicleAssertionExtensions
+        {
+            public static Task ShouldHaveAppendedEvent<TCommand, TEvent>(
+                this CommandScenario<TCommand> scenario,
+                EventSourceId eventSourceId,
+                Func<TEvent, bool> predicate) => Task.CompletedTask;
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+    AdapterContribution _reversed = null!;
+    ResolvedApplicationGraph _graph = null!;
+    ScreenplayLoweringResult _lowering = null!;
+    string _source = null!;
+    string _reversedSource = null!;
+    string _reversedAdapterSource = null!;
+    string _reversedFactSource = null!;
+
+    void Because()
+    {
+        _contribution = AnalyzeSeparateProjects(reverseProjects: false, reverseSyntaxTrees: false);
+        _reversed = AnalyzeSeparateProjects(reverseProjects: true, reverseSyntaxTrees: true);
+        _graph = new GenerationResolver().Resolve([_contribution]);
+        _lowering = new ScreenplayLowerer().Lower(_graph, "Projects");
+        var empty = new AdapterContribution
+        {
+            Adapter = new AdapterIdentity { Id = "test.empty", Version = "1.0.0" }
+        };
+        _source = Source([_contribution, empty]);
+        _reversedSource = Source([_reversed, empty]);
+        _reversedAdapterSource = Source([empty, _contribution]);
+        _reversedFactSource = Source([_contribution with { Facts = [.. _contribution.Facts.Reverse()] }, empty]);
+    }
+
+    [Fact] void should_have_no_adapter_diagnostics() => _contribution.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_contribute_one_scenario() => _contribution.Facts.OfType<SpecificationScenarioFact>().Count().ShouldEqual(1);
+    [Fact] void should_contribute_the_ordered_command_and_event_steps() => _contribution.Facts.OfType<SpecificationStepFact>().OrderBy(_ => _.Definition.Key.Index).Select(_ => (_.Definition.Phase, _.Definition.Kind)).ShouldEqual([(SpecificationStepPhase.When, SpecificationStepKind.Command), (SpecificationStepPhase.Then, SpecificationStepKind.Event)]);
+    [Fact] void should_contribute_the_exact_command_and_event_values() => _contribution.Facts.OfType<SpecificationValueFact>().OrderBy(_ => _.Definition.Key.Step.Index).ThenBy(_ => _.Definition.Key.Path.Single(), StringComparer.Ordinal).Select(_ => (_.Definition.Key.Path.Single(), _.Definition.Scalar)).ShouldEqual([("Name", "Screenplay"), ("Number", "42"), ("Name", "Screenplay"), ("Number", "42")]);
+    [Fact] void should_contribute_the_command_and_event_artifacts() => _contribution.Facts.OfType<ArtifactFact>().Select(_ => _.Definition.Key.Kind).ShouldContainOnly([ArtifactKind.Command, ArtifactKind.Event]);
+    [Fact] void should_contribute_exact_command_and_event_placements() => _contribution.Facts.OfType<ArtifactPlacementFact>().Count().ShouldEqual(2);
+    [Fact] void should_place_both_artifacts_in_the_exact_slice() => _contribution.Facts.OfType<ArtifactPlacementFact>().All(_ => _.Placement.Slice == "RegisterProject").ShouldBeTrue();
+    [Fact] void should_preserve_exact_scenario_step_and_value_source_evidence() => _contribution.Facts.Where(_ => _ is SpecificationScenarioFact or SpecificationStepFact or SpecificationValueFact).All(_ => _.Evidence.Source?.Path == "Projects/Registration/RegisterProject/when_registering.cs").ShouldBeTrue();
+    [Fact] void should_preserve_the_exact_scenario_source_range() => Range(_contribution.Facts.OfType<SpecificationScenarioFact>().Single()).ShouldEqual((10, 14, 10, 30));
+    [Fact] void should_preserve_the_exact_command_step_source_range() => Range(_contribution.Facts.OfType<SpecificationStepFact>().Single(_ => _.Definition.Kind == SpecificationStepKind.Command)).ShouldEqual((15, 45, 15, 101));
+    [Fact] void should_preserve_the_exact_command_value_source_ranges() => _contribution.Facts.OfType<SpecificationValueFact>().Where(_ => _.Definition.Key.Step.Index == 0).OrderBy(_ => _.Definition.Key.Path.Single(), StringComparer.Ordinal).Select(Range).ShouldEqual([(15, 83, 15, 95), (15, 97, 15, 99)]);
+    [Fact] void should_preserve_the_exact_event_step_source_range() => Range(_contribution.Facts.OfType<SpecificationStepFact>().Single(_ => _.Definition.Kind == SpecificationStepKind.Event)).ShouldEqual((18, 48, 21, 39));
+    [Fact] void should_preserve_the_exact_event_value_source_ranges() => _contribution.Facts.OfType<SpecificationValueFact>().Where(_ => _.Definition.Key.Step.Index == 1).OrderBy(_ => _.Definition.Key.Path.Single(), StringComparer.Ordinal).Select(Range).ShouldEqual([(20, 34, 20, 46), (21, 36, 21, 38)]);
+    [Fact] void should_resolve_one_atomic_scenario() => _graph.Specifications.Count.ShouldEqual(1);
+    [Fact] void should_attach_the_scenario_to_the_exact_slice() => _graph.Specifications.Single().Placement.Slice.ShouldEqual("RegisterProject");
+    [Fact] void should_preserve_the_scenario_name() => _graph.Specifications.Single().Definition.Name.ShouldEqual("when_registering_when_registering");
+    [Fact] void should_lower_without_diagnostics() => _lowering.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_lower_the_exact_command_values() => Lowered().When!.Values.OrderBy(_ => _.Property, StringComparer.Ordinal).Select(_ => ((Cratis.Screenplay.Syntax.LiteralExpressionSyntax)_.Source).Value).ShouldEqual(["Screenplay", 42m]);
+    [Fact] void should_lower_the_exact_event_values() => Lowered().ThenEvents.Single().Values.OrderBy(_ => _.Property, StringComparer.Ordinal).Select(_ => ((Cratis.Screenplay.Syntax.LiteralExpressionSyntax)_.Source).Value).ShouldEqual(["Screenplay", 42m]);
+    [Fact] void should_be_independent_of_project_and_syntax_tree_order() => _reversedSource.ShouldEqual(_source);
+    [Fact] void should_preserve_identical_fact_and_source_evidence_under_project_and_tree_reversal() => FactEvidence(_reversed).ShouldEqual(FactEvidence(_contribution));
+    [Fact] void should_be_independent_of_adapter_order() => _reversedAdapterSource.ShouldEqual(_source);
+    [Fact] void should_be_independent_of_neutral_fact_order() => _reversedFactSource.ShouldEqual(_source);
+
+    static AdapterContribution AnalyzeSeparateProjects(bool reverseProjects, bool reverseSyntaxTrees)
+    {
+        var application = Analyzed.Project(
+            "Projects",
+            [],
+            ("Projects/Registration/RegisterProject/RegisterProject.cs", Slice));
+        var specificationSources = new[]
+        {
+            ("Projects/Registration/RegisterProject/when_registering.cs", Scenario),
+            ("Integration/Assertions.cs", Assertions),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        };
+        if (reverseSyntaxTrees)
+        {
+            specificationSources = [.. specificationSources.AsEnumerable().Reverse()];
+        }
+
+        var specifications = Analyzed.Project(
+            "Projects.Specifications",
+            [application.ToMetadataReference()],
+            specificationSources);
+        DotNetProjectCompilation[] projects =
+        [
+            SourceProjects.Create("Projects", DotNetProjectRole.Application, application),
+            SourceProjects.Create("Projects.Specifications", DotNetProjectRole.Specifications, specifications)
+        ];
+        if (reverseProjects)
+        {
+            projects = [.. projects.AsEnumerable().Reverse()];
+        }
+
+        return new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext(projects),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    static string Source(IReadOnlyList<AdapterContribution> contributions)
+    {
+        var graph = new GenerationResolver().Resolve(contributions);
+        var lowering = new ScreenplayLowerer().Lower(graph, "Projects");
+        return new ScreenplayPrinter().Print(lowering.Application);
+    }
+
+    static string[] FactEvidence(AdapterContribution contribution) =>
+    [
+        .. contribution.Facts
+            .OrderBy(_ => _.Id.Value, StringComparer.Ordinal)
+            .Select(_ => $"{_.Id.Value}|{_.Evidence.Source?.Path}:{_.Evidence.Source?.StartLine}:{_.Evidence.Source?.StartColumn}:{_.Evidence.Source?.EndLine}:{_.Evidence.Source?.EndColumn}")
+    ];
+
+    Cratis.Screenplay.Syntax.Specifications.SpecificationSyntax Lowered() =>
+        _lowering.Application.Modules.Single().Features.Single().Slices.Single().Specifications.Single();
+
+    static (int StartLine, int StartColumn, int EndLine, int EndColumn) Range(GenerationFact fact) =>
+        (fact.Evidence.Source!.StartLine, fact.Evidence.Source.StartColumn, fact.Evidence.Source.EndLine, fact.Evidence.Source.EndColumn);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_exact_rejection_scenario.cs
@@ -10,8 +10,11 @@ namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
 public class when_analyzing_an_exact_rejection_scenario : Specification
 {
     const string Slice = """
+        using System.Threading.Tasks;
         using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Arc.Queries.ModelBound;
         using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.ReadModels;
 
         namespace Projects.Projects.Registration.RegisterProject;
 
@@ -23,12 +26,21 @@ public class when_analyzing_an_exact_rejection_scenario : Specification
         {
             public ProjectRegistered Handle() => new(Name);
         }
+
+        [ReadModel]
+        public record ProjectOverview(string Name)
+        {
+            public static Task<ProjectOverview?> ProjectByName(IReadModels readModels, string name) =>
+                readModels.GetInstanceById<ProjectOverview>(name);
+        }
         """;
 
     const string Scenario = """
         using System.Threading.Tasks;
         using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.ReadModels;
         using Cratis.Chronicle.Testing.EventSequences;
+        using NSubstitute;
         using Projects.Projects.Registration.RegisterProject;
         using Xunit;
 
@@ -37,9 +49,15 @@ public class when_analyzing_an_exact_rejection_scenario : Specification
         public class when_rejecting_an_empty_project_name
         {
             readonly CommandScenario<RegisterProject> _scenario = new();
+            readonly IReadModels _readModels = Substitute.For<IReadModels>();
+            ProjectOverview? _queryResult;
             Result _result = null!;
 
-            async Task Because() => _result = await _scenario.Execute(new RegisterProject(""));
+            async Task Because()
+            {
+                _queryResult = await ProjectOverview.ProjectByName(_readModels, "Screenplay");
+                _result = await _scenario.Execute(new RegisterProject(""));
+            }
 
             [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
         }

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_inherited_partial_read_model_scenario.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_analyzing_an_inherited_partial_read_model_scenario.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_analyzing_an_inherited_partial_read_model_scenario : Specification
+{
+    const string EventAndCommand = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Projects.Projects.Registration.RegisterProject;
+
+        [EventType]
+        public record ProjectRegistered(string Name, int Number);
+
+        [Command]
+        public record RegisterProject(string Name, int Number)
+        {
+            public ProjectRegistered Handle() => new(Name, Number);
+        }
+        """;
+
+    const string BaseReadModel = """
+        namespace Projects.Projects.Overview.ListProjects;
+
+        public record ProjectOverviewBase
+        {
+            public string Name { get; init; } = string.Empty;
+        }
+        """;
+
+    const string FirstReadModelPart = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Projections.ModelBound;
+        using Projects.Projects.Registration.RegisterProject;
+
+        namespace Projects.Projects.Overview.ListProjects;
+
+        [ReadModel]
+        [FromEvent<ProjectRegistered>]
+        public partial record ProjectOverview : ProjectOverviewBase
+        {
+            public int Number { get; init; }
+        }
+        """;
+
+    const string SecondReadModelPart = """
+        namespace Projects.Projects.Overview.ListProjects;
+
+        public enum ProjectStatus
+        {
+            Active
+        }
+
+        public partial record ProjectOverview
+        {
+            public ProjectStatus Status { get; init; }
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.ReadModels;
+        using Cratis.Specifications;
+        using Projects.Projects.Overview.ListProjects;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
+
+        namespace Projects.Projects.Overview.ListProjects.when_a_project_was_registered;
+
+        public class when_a_project_was_registered : Specification
+        {
+            readonly ReadModelScenario<ProjectOverview> _scenario = new();
+
+            async Task Establish() => await _scenario.Given
+                .ForEventSource(EventSourceId.New())
+                .Events(new ProjectRegistered("Screenplay", 42));
+
+            [Fact] void should_project_name() => _scenario.Instance!.Name.ShouldEqual("Screenplay");
+            [Fact] void should_project_number() => _scenario.Instance!.Number.ShouldEqual(42);
+            [Fact] void should_project_status() => _scenario.Instance!.Status.ShouldEqual(ProjectStatus.Active);
+        }
+        """;
+
+    AdapterContribution _forward = null!;
+    AdapterContribution _reversed = null!;
+
+    void Because()
+    {
+        _forward = Analyze(reverseSyntaxTrees: false);
+        _reversed = Analyze(reverseSyntaxTrees: true);
+    }
+
+    [Fact] void should_report_no_diagnostics() => _forward.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_recover_inherited_and_partial_properties_in_deterministic_declaration_order() => ReadModelValuePaths(_forward).ShouldEqual(["Name", "Number", "Status"]);
+    [Fact] void should_preserve_the_same_declaration_order_when_syntax_trees_are_reversed() => ReadModelValuePaths(_reversed).ShouldEqual(["Name", "Number", "Status"]);
+    [Fact] void should_preserve_identical_values_when_syntax_trees_are_reversed() => ReadModelValues(_reversed).ShouldEqual(ReadModelValues(_forward));
+    [Fact] void should_preserve_identical_source_evidence_when_syntax_trees_are_reversed() => ReadModelEvidence(_reversed).ShouldEqual(ReadModelEvidence(_forward));
+    [Fact] void should_preserve_inherited_and_partial_artifact_properties() => ReadModelArtifact().Definition.Properties.Select(_ => _.Name).ShouldEqual(["Name", "Number", "Status"]);
+    [Fact] void should_preserve_exact_read_model_value_types() => ReadModelValueFacts(_forward).Select(_ => _.Definition.Type.Name).ShouldEqual(["String", "Int", "ProjectStatus"]);
+    [Fact] void should_preserve_the_enumeration_member_instead_of_its_number() => ReadModelValueFacts(_forward).Single(_ => _.Definition.Key.Path.Single() == "Status").Definition.Scalar.ShouldEqual("Active");
+
+    static AdapterContribution Analyze(bool reverseSyntaxTrees)
+    {
+        (string Path, string Text)[] sources =
+        [
+            ("Projects/Registration/RegisterProject/RegisterProject.cs", EventAndCommand),
+            ("Projects/Overview/ListProjects/ProjectOverviewBase.cs", BaseReadModel),
+            ("Projects/Overview/ListProjects/A.ProjectOverview.cs", FirstReadModelPart),
+            ("Projects/Overview/ListProjects/B.ProjectOverview.cs", SecondReadModelPart),
+            ("Projects/Overview/ListProjects/when_a_project_was_registered.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source)
+        ];
+        if (reverseSyntaxTrees)
+        {
+            sources = [.. sources.AsEnumerable().Reverse()];
+        }
+
+        var compilation = Analyzed.Project("Projects", [], sources);
+        var project = SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation);
+        return new ArcSpecificationFactAdapter().Analyze(
+            new DotNetAnalysisContext([project]),
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    static string[] ReadModelValuePaths(AdapterContribution contribution) =>
+    [
+        .. contribution.Facts.OfType<SpecificationValueFact>()
+            .Where(_ => _.Definition.Key.Step.Index == 1)
+            .Select(_ => _.Definition.Key.Path.Single())
+    ];
+
+    static string[] ReadModelValues(AdapterContribution contribution) =>
+    [
+        .. ReadModelValueFacts(contribution)
+            .Select(_ => $"{_.Definition.Key.Path.Single()}:{_.Definition.Scalar}")
+    ];
+
+    static string[] ReadModelEvidence(AdapterContribution contribution) =>
+    [
+        .. ReadModelValueFacts(contribution)
+            .Select(_ => $"{_.Evidence.Source!.Path}:{_.Evidence.Source.StartLine}:{_.Evidence.Source.StartColumn}:{_.Evidence.Source.EndLine}:{_.Evidence.Source.EndColumn}")
+    ];
+
+    ArtifactFact ReadModelArtifact() =>
+        _forward.Facts.OfType<ArtifactFact>().Single(_ => _.Definition.Key.Kind == ArtifactKind.ReadModel);
+
+    static SpecificationValueFact[] ReadModelValueFacts(AdapterContribution contribution) =>
+    [
+        .. contribution.Facts.OfType<SpecificationValueFact>()
+            .Where(_ => _.Definition.Key.Step.Index == 1)
+    ];
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_only_a_specification_project_command_produces_a_given_event.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_only_a_specification_project_command_produces_a_given_event.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_only_a_specification_project_command_produces_a_given_event : Specification
+{
+    const string Application = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Projects.Projects.Overview.ListProjects;
+
+        [EventType]
+        public record ProjectRegistered(string Name);
+
+        [ReadModel]
+        [FromEvent<ProjectRegistered>]
+        public record ProjectOverview
+        {
+            public string Name { get; init; } = string.Empty;
+        }
+        """;
+
+    const string FixtureCommand = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Projects.Projects.Overview.ListProjects;
+
+        namespace Projects.Specifications.Fixtures;
+
+        [Command]
+        public record FixtureRegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Testing.ReadModels;
+        using Cratis.Specifications;
+        using Projects.Projects.Overview.ListProjects;
+        using Xunit;
+
+        namespace Projects.Projects.Overview.ListProjects.when_a_project_was_registered;
+
+        public class when_a_project_was_registered : Specification
+        {
+            readonly ReadModelScenario<ProjectOverview> _scenario = new();
+
+            async Task Establish() => await _scenario.Given
+                .ForEventSource(EventSourceId.New())
+                .Events(new ProjectRegistered("Screenplay"));
+
+            [Fact] void should_project_name() => _scenario.Instance!.Name.ShouldEqual("Screenplay");
+        }
+        """;
+
+    AdapterContribution _contribution = null!;
+
+    void Because()
+    {
+        var application = Analyzed.Project(
+            "Projects",
+            [],
+            ("Projects/Overview/ListProjects/ListProjects.cs", Application));
+        var specifications = Analyzed.Project(
+            "Projects.Specifications",
+            [application.ToMetadataReference()],
+            ("Fixtures/FixtureRegisterProject.cs", FixtureCommand),
+            ("Projects/Overview/ListProjects/when_a_project_was_registered.cs", Scenario),
+            (IntegrationTesting.Path, IntegrationTesting.Source));
+        var context = new DotNetAnalysisContext(
+        [
+            SourceProjects.Create("Projects", DotNetProjectRole.Application, application),
+            SourceProjects.Create("Projects.Specifications", DotNetProjectRole.Specifications, specifications)
+        ]);
+        _contribution = new ArcSpecificationFactAdapter().Analyze(
+            context,
+            new DotNetAdapterOptions { Module = "Projects", NamespaceSegmentsToSkip = 1 });
+    }
+
+    [Fact] void should_contribute_no_partial_facts() => _contribution.Facts.ShouldBeEmpty();
+    [Fact] void should_report_only_the_unproven_event_placement() => _contribution.Diagnostics.Select(_ => _.Code).ShouldContainOnly("ARCSP0001");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_only_an_application_query_exists.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_only_an_application_query_exists.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
+
+public class when_only_an_application_query_exists : Specification
+{
+    bool _canAnalyze;
+
+    void Because()
+    {
+        var compilation = Analyzed.Project(
+            "Projects",
+            [],
+            ("Testing/Framework.cs", GeneratedQuerySpecificationSources.Framework),
+            ("Projects/Overview/ListProjects/ProjectOverview.cs", GeneratedQuerySpecificationSources.Application));
+        var context = new DotNetAnalysisContext([
+            SourceProjects.Create("Projects", DotNetProjectRole.Application, compilation)
+        ]);
+        _canAnalyze = new ArcSpecificationFactAdapter().CanAnalyze(context);
+    }
+
+    [Fact] void should_not_analyze_without_a_specification_shaped_type() => _canAnalyze.ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_placing_a_read_model_query_target.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ArcSpecificationFactAdapter/when_placing_a_read_model_query_target.cs
@@ -9,16 +9,29 @@ namespace Cratis.Arc.Screenplay.for_ArcSpecificationFactAdapter;
 
 public class when_placing_a_read_model_query_target : Specification
 {
-    const string StateView = """
-        using System.Collections.Generic;
-        using Cratis.Arc.Queries.ModelBound;
+    const string StateChange = """
+        using Cratis.Arc.Commands.ModelBound;
         using Cratis.Chronicle.Events;
-        using Cratis.Chronicle.Projections.ModelBound;
 
-        namespace Projects.Projects.Overview.ListProjects;
+        namespace Projects.Projects.Registration.RegisterProject;
 
         [EventType]
         public record ProjectRegistered(string Name);
+
+        [Command]
+        public record RegisterProject(string Name)
+        {
+            public ProjectRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string StateView = """
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Projections.ModelBound;
+        using Projects.Projects.Registration.RegisterProject;
+
+        namespace Projects.Projects.Overview.ListProjects;
 
         [ReadModel]
         [FromEvent<ProjectRegistered>]
@@ -34,17 +47,22 @@ public class when_placing_a_read_model_query_target : Specification
         using System.Threading.Tasks;
         using Cratis.Chronicle.Events;
         using Cratis.Chronicle.Testing.ReadModels;
+        using Cratis.Specifications;
+        using Projects.Projects.Registration.RegisterProject;
+        using Xunit;
 
         namespace Projects.Projects.Overview.ListProjects.when_a_project_was_registered;
 
-        public class when_a_project_was_registered
+        public class when_a_project_was_registered : Specification
         {
             readonly ReadModelScenario<ProjectOverview> _scenario = new();
 
-            async Task Because() =>
+            async Task Establish() =>
                 await _scenario.Given
                     .ForEventSource(EventSourceId.New())
                     .Events(new ProjectRegistered("Screenplay"));
+
+            [Fact] void should_project_name() => _scenario.Instance!.Name.ShouldEqual("Screenplay");
         }
         """;
 
@@ -55,6 +73,7 @@ public class when_placing_a_read_model_query_target : Specification
         var compilation = Analyzed.Project(
             "Projects",
             [],
+            ("Source/Projects/Registration/RegisterProject/RegisterProject.cs", StateChange),
             ("Source/Projects/Overview/ListProjects/ListProjects.cs", StateView),
             ("Source/Projects/Overview/ListProjects/when_a_project_was_registered.cs", Scenario),
             (IntegrationTesting.Path, IntegrationTesting.Source));
@@ -71,8 +90,12 @@ public class when_placing_a_read_model_query_target : Specification
 
     [Fact] void should_report_no_adapter_diagnostics() => _contribution.Diagnostics.ShouldBeEmpty();
     [Fact] void should_identify_the_read_model_target() => _contribution.Facts.OfType<SpecificationScenarioFact>().Single().Definition.TargetArtifact.Kind.ShouldEqual(ArtifactKind.ReadModel);
-    [Fact] void should_place_the_read_model_and_its_query_as_a_state_view() => _contribution.Facts.OfType<ArtifactPlacementFact>().Single().Placement.SliceKind.ShouldEqual(GenerationSliceKind.StateView);
-    [Fact] void should_preserve_the_state_view_slice() => _contribution.Facts.OfType<ArtifactPlacementFact>().Single().Placement.Slice.ShouldEqual("ListProjects");
+    [Fact] void should_place_the_read_model_and_its_query_as_a_state_view() => ReadModelPlacement().Placement.SliceKind.ShouldEqual(GenerationSliceKind.StateView);
+    [Fact] void should_preserve_the_state_view_slice() => ReadModelPlacement().Placement.Slice.ShouldEqual("ListProjects");
+    [Fact] void should_place_the_proven_command_event_in_its_state_change_slice() => _contribution.Facts.OfType<ArtifactPlacementFact>().Single(_ => _.Artifact.Kind == ArtifactKind.Event).Placement.Slice.ShouldEqual("RegisterProject");
     [Fact] void should_contribute_the_read_model_scenario_atomically() => _contribution.Facts.OfType<SpecificationScenarioFact>().Count().ShouldEqual(1);
     [Fact] void should_preserve_the_read_model_outcome() => _contribution.Facts.OfType<SpecificationStepFact>().Single(_ => _.Definition.Kind == SpecificationStepKind.ReadModel).Definition.Artifact!.Kind.ShouldEqual(ArtifactKind.ReadModel);
+
+    ArtifactPlacementFact ReadModelPlacement() =>
+        _contribution.Facts.OfType<ArtifactPlacementFact>().Single(_ => _.Artifact.Kind == ArtifactKind.ReadModel);
 }

--- a/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Commands/MappingSourceReader.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis.Aggregates;
+using Cratis.Arc.Screenplay.Analysis.Types;
 using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -114,6 +116,275 @@ public class MappingSourceReader(ScreenplayDiagnostics diagnostics)
 
         return path is null ? null : new PropertyPathSource(path);
     }
+
+    /// <summary>
+    /// Reads the exact literal a Stage-generated query specification authors for one exact declared type.
+    /// </summary>
+    /// <param name="expression">The expression to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="expectedType">The exact formal or property type in the specification compilation.</param>
+    /// <param name="sourceExpectedType">The corresponding exact type declared by the application.</param>
+    /// <returns>The literal, or <see langword="null"/> when the expression is not an exact supported query value.</returns>
+    /// <remarks>
+    /// This is deliberately additive rather than part of <see cref="Read"/>. Direct concept construction and
+    /// framework parse calls are syntax emitted by Stage query specifications, not globally valid mapping sources
+    /// for commands, events, or projections. Unlike the legacy literal reader, this reader proves that the authored
+    /// value has the exact type Stage rendered it for before returning the value.
+    /// </remarks>
+    public LiteralSource? ReadQueryLiteral(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol expectedType,
+        ITypeSymbol sourceExpectedType)
+    {
+        if (!IsExactScalarType(expectedType) ||
+            !IsExactScalarType(sourceExpectedType) ||
+            !TypesHaveSameIdentity(expectedType, sourceExpectedType))
+        {
+            return null;
+        }
+
+        var unwrapped = UnwrapQueryValue(expression);
+        if (expectedType.TypeKind == TypeKind.Enum)
+        {
+            return EnumValueOf(unwrapped, semanticModel, expectedType, sourceExpectedType) is { } enumeration
+                ? new LiteralSource(enumeration)
+                : null;
+        }
+
+        if (expectedType is not INamedTypeSymbol namedExpected || sourceExpectedType is not INamedTypeSymbol namedSourceExpected)
+        {
+            return null;
+        }
+
+        if (namedExpected.FindBase(WellKnownTypeNames.ConceptAs) is { TypeArguments: [var backing] } &&
+            namedSourceExpected.FindBase(WellKnownTypeNames.ConceptAs) is { TypeArguments: [var sourceBacking] })
+        {
+            return ConceptValueOf(unwrapped, semanticModel, namedExpected, namedSourceExpected, backing, sourceBacking) is { } conceptValue
+                ? ReadQueryLiteral(conceptValue, semanticModel, backing, sourceBacking)
+                : null;
+        }
+
+        if (ParsedTextOf(unwrapped, semanticModel, namedExpected) is { } parsed)
+        {
+            return new LiteralSource(parsed);
+        }
+
+        return PrimitiveValueOf(unwrapped, semanticModel, namedExpected) is { } primitive
+            ? new LiteralSource(primitive)
+            : null;
+    }
+
+    /// <summary>
+    /// Gets the single exact backing value a strongly typed concept is constructed from.
+    /// </summary>
+    /// <param name="expression">The expression to inspect.</param>
+    /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
+    /// <param name="expectedType">The exact concept type in the specification compilation.</param>
+    /// <param name="sourceExpectedType">The corresponding application-declared concept type.</param>
+    /// <param name="backing">The exact backing type in the specification compilation.</param>
+    /// <param name="sourceBacking">The corresponding application-declared backing type.</param>
+    /// <returns>The exact backing expression, or <see langword="null"/> when the expression is not a direct Stage concept construction.</returns>
+    static ExpressionSyntax? ConceptValueOf(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        INamedTypeSymbol expectedType,
+        INamedTypeSymbol sourceExpectedType,
+        ITypeSymbol backing,
+        ITypeSymbol sourceBacking)
+    {
+        if (expression is not ObjectCreationExpressionSyntax
+            {
+                ArgumentList.Arguments: [var argument],
+                Initializer: null
+            } creation ||
+            argument.NameColon is not null ||
+            semanticModel.GetTypeInfo(creation).Type is not INamedTypeSymbol constructed ||
+            !SymbolEqualityComparer.IncludeNullability.Equals(constructed, expectedType) ||
+            semanticModel.GetSymbolInfo(creation).Symbol is not IMethodSymbol { Parameters: [var selectedParameter] } selectedConstructor ||
+            !SymbolEqualityComparer.IncludeNullability.Equals(selectedParameter.Type, backing) ||
+            !IsExactStageConcept(sourceExpectedType, sourceBacking, out var primaryConstructor) ||
+            !ConstructorMatches(selectedConstructor, primaryConstructor))
+        {
+            return null;
+        }
+
+        return argument.Expression;
+    }
+
+    /// <summary>
+    /// Reads one exact enumeration member.
+    /// </summary>
+    /// <param name="expression">The authored member expression.</param>
+    /// <param name="semanticModel">The semantic model owning it.</param>
+    /// <param name="expectedType">The exact enumeration in the specification compilation.</param>
+    /// <param name="sourceExpectedType">The corresponding application enumeration.</param>
+    /// <returns>The named enumeration member, or <see langword="null"/> for casts and undeclared values.</returns>
+    static EnumValue? EnumValueOf(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ITypeSymbol expectedType,
+        ITypeSymbol sourceExpectedType)
+    {
+        if (semanticModel.GetSymbolInfo(expression).Symbol is not IFieldSymbol
+            {
+                HasConstantValue: true,
+                ContainingType: { } containingType
+            } member ||
+            !SymbolEqualityComparer.IncludeNullability.Equals(containingType, expectedType) ||
+            !sourceExpectedType.GetMembers(member.Name).OfType<IFieldSymbol>().Any(_ => _.HasConstantValue))
+        {
+            return null;
+        }
+
+        return new(member.Name);
+    }
+
+    /// <summary>
+    /// Reads one primitive literal with the exact runtime semantics Stage emits for its declared primitive.
+    /// </summary>
+    /// <param name="expression">The authored primitive expression.</param>
+    /// <param name="semanticModel">The semantic model owning it.</param>
+    /// <param name="expectedType">The exact expected primitive type.</param>
+    /// <returns>The primitive value, or <see langword="null"/> when its syntax or runtime type does not match.</returns>
+    static object? PrimitiveValueOf(ExpressionSyntax expression, SemanticModel semanticModel, INamedTypeSymbol expectedType)
+    {
+        if (!IsPrimitiveLiteral(expression) ||
+            !SymbolEqualityComparer.IncludeNullability.Equals(semanticModel.GetTypeInfo(expression).Type, expectedType) ||
+            semanticModel.GetConstantValue(expression) is not { HasValue: true } constant ||
+            constant.Value is null)
+        {
+            return null;
+        }
+
+        return expectedType.FullMetadataName() switch
+        {
+            "System.String" when constant.Value is string => constant.Value,
+            "System.Int32" when constant.Value is int => constant.Value,
+            "System.Decimal" when constant.Value is decimal => constant.Value,
+            "System.Boolean" when constant.Value is bool => constant.Value,
+            _ => null
+        };
+    }
+
+    static bool IsPrimitiveLiteral(ExpressionSyntax expression)
+    {
+        if (expression is LiteralExpressionSyntax)
+        {
+            return true;
+        }
+
+        return expression is PrefixUnaryExpressionSyntax { Operand: LiteralExpressionSyntax } prefix &&
+            (prefix.RawKind == (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.UnaryMinusExpression ||
+             prefix.RawKind == (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.UnaryPlusExpression);
+    }
+
+    /// <summary>
+    /// Reads the canonical text from the exact parse calls Stage emits for non-constant scalar values.
+    /// </summary>
+    /// <param name="expression">The expression to inspect.</param>
+    /// <param name="semanticModel">The semantic model owning the expression.</param>
+    /// <param name="expectedType">The exact primitive type the parsed text must produce.</param>
+    /// <returns>The canonical parsed text, or <see langword="null"/> for every other call shape.</returns>
+    static string? ParsedTextOf(ExpressionSyntax expression, SemanticModel semanticModel, INamedTypeSymbol expectedType)
+    {
+        if (expression is not InvocationExpressionSyntax invocation ||
+            DotNetInvocations.MethodFor(invocation, semanticModel) is not { } method ||
+            invocation.ArgumentList.Arguments is not [var textArgument, ..] ||
+            textArgument.Expression is not LiteralExpressionSyntax ||
+            semanticModel.GetConstantValue(textArgument.Expression) is not { HasValue: true, Value: string text })
+        {
+            return null;
+        }
+
+        var definition = DotNetInvocations.DefinitionOf(method);
+        if (definition is not { IsStatic: true, Name: "Parse", TypeParameters.Length: 0 } ||
+            definition.Parameters.FirstOrDefault()?.Type.SpecialType != SpecialType.System_String ||
+            !SymbolEqualityComparer.IncludeNullability.Equals(method.ReturnType, expectedType))
+        {
+            return null;
+        }
+
+        var containingType = definition.ContainingType.FullMetadataName();
+        if (containingType == "System.Guid" &&
+            expectedType.FullMetadataName() == containingType &&
+            definition.Parameters.Length == 1 &&
+            invocation.ArgumentList.Arguments.Count == 1 &&
+            Guid.TryParse(text, out _))
+        {
+            return text;
+        }
+
+        if (containingType is not ("System.DateOnly" or "System.DateTimeOffset") ||
+            expectedType.FullMetadataName() != containingType ||
+            definition.Parameters.Length != 2 ||
+            invocation.ArgumentList.Arguments is not [_, var cultureArgument] ||
+            semanticModel.GetSymbolInfo(UnwrapQueryValue(cultureArgument.Expression)).Symbol is not IPropertySymbol
+            {
+                IsStatic: true,
+                Name: "InvariantCulture"
+            } culture ||
+            culture.ContainingType.FullMetadataName() != "System.Globalization.CultureInfo")
+        {
+            return null;
+        }
+
+        var valid = containingType == "System.DateOnly"
+            ? DateOnly.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out _)
+            : DateTimeOffset.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out _);
+        return valid ? text : null;
+    }
+
+    static bool IsExactScalarType(ITypeSymbol type) =>
+        type.NullableAnnotation != NullableAnnotation.Annotated &&
+        type is not INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } &&
+        CollectionElements.ElementOf(type) is null;
+
+    static bool IsExactStageConcept(INamedTypeSymbol type, ITypeSymbol backing, out IMethodSymbol primaryConstructor)
+    {
+        primaryConstructor = null!;
+        if (!type.IsRecord ||
+            type.BaseType is not { TypeArguments: [var directBacking] } directBase ||
+            directBase.OriginalDefinition.FullMetadataName() is not (WellKnownTypeNames.ConceptAs or WellKnownTypeNames.EventSourceIdOfT) ||
+            !SymbolEqualityComparer.IncludeNullability.Equals(directBacking, backing) ||
+            type.InstanceConstructors.SingleOrDefault(IsPrimaryRecordConstructor) is not { Parameters: [var parameter] } found ||
+            !SymbolEqualityComparer.IncludeNullability.Equals(parameter.Type, backing) ||
+            found.DeclaringSyntaxReferences.Select(_ => _.GetSyntax()).OfType<RecordDeclarationSyntax>().SingleOrDefault() is not { } declaration ||
+            declaration.BaseList?.Types.OfType<PrimaryConstructorBaseTypeSyntax>().SingleOrDefault() is not
+            {
+                ArgumentList.Arguments: [var baseArgument]
+            } ||
+            baseArgument.Expression is not IdentifierNameSyntax identifier ||
+            !string.Equals(identifier.Identifier.ValueText, parameter.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        primaryConstructor = found;
+        return true;
+    }
+
+    static bool IsPrimaryRecordConstructor(IMethodSymbol constructor) =>
+        constructor.DeclaringSyntaxReferences.Any(_ => _.GetSyntax() is RecordDeclarationSyntax { ParameterList: not null });
+
+    static bool ConstructorMatches(IMethodSymbol selected, IMethodSymbol primary) =>
+        selected.Parameters.Length == primary.Parameters.Length &&
+        selected.Parameters.Zip(primary.Parameters).All(pair =>
+            string.Equals(pair.First.Name, pair.Second.Name, StringComparison.Ordinal) &&
+            TypesHaveSameIdentity(pair.First.Type, pair.Second.Type));
+
+    static bool TypesHaveSameIdentity(ITypeSymbol first, ITypeSymbol second) =>
+        first.NullableAnnotation == second.NullableAnnotation &&
+        string.Equals(
+            first.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            second.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            StringComparison.Ordinal);
+
+    static ExpressionSyntax UnwrapQueryValue(ExpressionSyntax expression) => expression switch
+    {
+        ParenthesizedExpressionSyntax parenthesized => UnwrapQueryValue(parenthesized.Expression),
+        _ => expression
+    };
 
     /// <summary>
     /// Determines whether an identifier names a property of the command itself.

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
@@ -48,12 +48,53 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
     /// would put routes in the document that no application serves, while a query that happens not to be public is a
     /// route the application really does serve.
     /// </remarks>
-    public static IEnumerable<IMethodSymbol> MethodsOf(INamedTypeSymbol type) =>
-        type.GetMembers()
+    public static IEnumerable<IMethodSymbol> MethodsOf(INamedTypeSymbol type)
+    {
+        return type.GetMembers()
             .OfType<IMethodSymbol>()
-            .Where(_ => _ is { MethodKind: MethodKind.Ordinary, IsStatic: true } &&
-                !_.ReturnsVoid && _.TypeParameters.Length == 0 && Returns(_, type))
+            .Where(method =>
+            {
+                if (method is not { MethodKind: MethodKind.Ordinary, IsStatic: true } ||
+                    method.ReturnsVoid || method.TypeParameters.Length != 0)
+                {
+                    return false;
+                }
+
+                var collection = false;
+                return SymbolEqualityComparer.Default.Equals(QueryReturnTypes.Unwrap(method.ReturnType, ref collection), type);
+            })
             .OrderBy(_ => _.ToDisplayString(), StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Determines whether a parameter is part of what a caller sends.
+    /// </summary>
+    /// <param name="parameter">The parameter to check.</param>
+    /// <returns>True when the parameter is input rather than infrastructure.</returns>
+    /// <remarks>
+    /// Arc decides this at run time by asking the container whether the parameter's type is a service, which is not a
+    /// question source can answer - so what is asked instead is whether a caller could possibly send one. An interface
+    /// and an abstract type both fail that outright: neither has a value to send, and both are how a collaborator the
+    /// host injects is written - <c>TimeProvider</c>, the clock a query measures a threshold against, is abstract
+    /// rather than an interface and reached the document as a parameter no caller has ever sent. Being uninstantiable
+    /// is not the whole of it though: a cancellation token, the page asked for and the order asked for are all filled
+    /// in by the host from the request, and all three are concrete values. Stating any of them as caller input puts a
+    /// parameter in the document that no caller sends, typed by a name the document never declares.
+    /// <para>
+    /// A concrete class the container happens to resolve still comes through as input, because nothing in the source
+    /// tells it apart from a value a caller sends. That is the residue of approximating a container lookup statically,
+    /// and it is the narrow side of the trade: a parameter wrongly stated is visible in the document, while one
+    /// wrongly dropped is not.
+    /// </para>
+    /// <para>
+    /// An interface parameter is never input by the same reasoning - there is no value a caller could have sent for
+    /// it, only a collaborator the host resolves - which is what excludes <c>IReadModels</c> from a recovered
+    /// specification's own arguments without naming it specially.
+    /// </para>
+    /// </remarks>
+    public static bool IsInput(IParameterSymbol parameter) =>
+        parameter.Type is { TypeKind: not TypeKind.Interface, IsAbstract: false } &&
+        !Array.Exists(InfrastructureTypes, parameter.Type.Is);
 
     /// <summary>
     /// Reads a query.
@@ -82,44 +123,6 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
             [.. parameters.Where(_ => !SymbolEqualityComparer.Default.Equals(_, required)).Select(ToParameter)],
             AuthorizationReader.Read(method, declaring),
             QueryReturnTypes.IsObservable(method.ReturnType));
-    }
-
-    /// <summary>
-    /// Determines whether a parameter is part of what a caller sends.
-    /// </summary>
-    /// <param name="parameter">The parameter to check.</param>
-    /// <returns>True when the parameter is input rather than infrastructure.</returns>
-    /// <remarks>
-    /// Arc decides this at run time by asking the container whether the parameter's type is a service, which is not a
-    /// question source can answer - so what is asked instead is whether a caller could possibly send one. An interface
-    /// and an abstract type both fail that outright: neither has a value to send, and both are how a collaborator the
-    /// host injects is written - <c>TimeProvider</c>, the clock a query measures a threshold against, is abstract
-    /// rather than an interface and reached the document as a parameter no caller has ever sent. Being uninstantiable
-    /// is not the whole of it though: a cancellation token, the page asked for and the order asked for are all filled
-    /// in by the host from the request, and all three are concrete values. Stating any of them as caller input puts a
-    /// parameter in the document that no caller sends, typed by a name the document never declares.
-    /// <para>
-    /// A concrete class the container happens to resolve still comes through as input, because nothing in the source
-    /// tells it apart from a value a caller sends. That is the residue of approximating a container lookup statically,
-    /// and it is the narrow side of the trade: a parameter wrongly stated is visible in the document, while one
-    /// wrongly dropped is not.
-    /// </para>
-    /// </remarks>
-    static bool IsInput(IParameterSymbol parameter) =>
-        parameter.Type is { TypeKind: not TypeKind.Interface, IsAbstract: false } &&
-        !Array.Exists(InfrastructureTypes, parameter.Type.Is);
-
-    /// <summary>
-    /// Determines whether a method returns the read model declaring it.
-    /// </summary>
-    /// <param name="method">The method to check.</param>
-    /// <param name="readModel">The read model declaring it.</param>
-    /// <returns>True when the method returns the read model.</returns>
-    static bool Returns(IMethodSymbol method, INamedTypeSymbol readModel)
-    {
-        var collection = false;
-
-        return SymbolEqualityComparer.Default.Equals(QueryReturnTypes.Unwrap(method.ReturnType, ref collection), readModel);
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Queries/SpecificationQueryCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/SpecificationQueryCatalog.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Queries;
+
+/// <summary>
+/// Catalogues every query the application itself declares, for matching a generated specification's call against.
+/// </summary>
+/// <remarks>
+/// Only queries the application declares - never a specification project - are catalogued. A specification calling
+/// a lookalike declared only where specifications live is calling something the application never serves, and the
+/// call is left unmatched rather than admitted on the strength of a name alone.
+/// </remarks>
+public static class SpecificationQueryCatalog
+{
+    /// <summary>
+    /// Builds the catalog of every query an application declares.
+    /// </summary>
+    /// <param name="context">The analyzed source context.</param>
+    /// <returns>The catalog, one entry per declared query.</returns>
+    public static IReadOnlyList<Entry> From(DotNetAnalysisContext context) =>
+        [.. context.Projects
+            .Where(project => project.Role == DotNetProjectRole.Application)
+            .SelectMany(project => ArtifactCatalog.From(project.Compilation).Types)
+            .Where(QueryReader.IsReadModel)
+            .SelectMany(readModel => QueryReader.MethodsOf(readModel)
+                .Select(method => new Entry(readModel, method, DotNetMethodSignatures.From(method))))];
+
+    /// <summary>
+    /// Represents one exact query the application declares.
+    /// </summary>
+    /// <param name="ReadModel">The read model exposing it.</param>
+    /// <param name="Method">The exact application method.</param>
+    /// <param name="Signature">The exact cross-compilation signature.</param>
+    public sealed record Entry(INamedTypeSymbol ReadModel, IMethodSymbol Method, DotNetMethodSignature Signature);
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationAssertions.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationAssertions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -59,10 +60,26 @@ public static class SpecificationAssertions
     /// The event is the last type argument rather than the only one, because the helper taking the scenario also
     /// takes the command it is a scenario for, which has to be named ahead of it.
     /// </remarks>
-    public static ITypeSymbol? AppendedEventOf(IMethodSymbol method) =>
-        string.Equals(method.Name, AppendedEventAssertion, StringComparison.Ordinal)
+    public static ITypeSymbol? AppendedEventOf(IMethodSymbol method)
+    {
+        if (!HasAppendedEventAssertionName(method))
+        {
+            return null;
+        }
+
+        var definition = DotNetInvocations.DefinitionOf(method);
+        return IsCommandScenarioAssertion(definition) || IsEventSequenceAssertion(definition)
             ? method.TypeArguments.LastOrDefault()
             : null;
+    }
+
+    /// <summary>
+    /// Determines whether a method uses the reserved appended-event assertion name.
+    /// </summary>
+    /// <param name="method">The method being called.</param>
+    /// <returns><see langword="true"/> when the reserved name is used.</returns>
+    public static bool HasAppendedEventAssertionName(IMethodSymbol method) =>
+        string.Equals(method.Name, AppendedEventAssertion, StringComparison.Ordinal);
 
     /// <summary>
     /// Determines whether an assertion says the command was rejected.
@@ -82,6 +99,37 @@ public static class SpecificationAssertions
     /// <returns>True when the assertion names a reason.</returns>
     public static bool IsNamedRejection(IMethodSymbol method) =>
         Array.Exists(NamedRejections, _ => string.Equals(_, method.Name, StringComparison.Ordinal));
+
+    static bool IsCommandScenarioAssertion(IMethodSymbol method) =>
+        method.ContainingType.ToDisplayString() == "Cratis.Arc.Chronicle.Testing.Commands.CommandScenarioChronicleAssertionExtensions" &&
+        method.IsExtensionMethod &&
+        method.TypeParameters.Length == 2 &&
+        method.Parameters.Length is 2 or 3 &&
+        IsGeneric(method.Parameters[0].Type, "Cratis.Arc.Testing.Commands.CommandScenario<TCommand>", method.TypeParameters[0]) &&
+        method.Parameters[1].Type.ToDisplayString() == "Cratis.Chronicle.Events.EventSourceId" &&
+        (method.Parameters.Length == 2 || IsPredicate(method.Parameters[2], method.TypeParameters[1]));
+
+    static bool IsEventSequenceAssertion(IMethodSymbol method) =>
+        method.ContainingType.ToDisplayString() == "Cratis.Chronicle.Testing.EventSequences.EventSequenceShouldExtensions" &&
+        method.IsExtensionMethod &&
+        method.TypeParameters.Length == 1 &&
+        method.Parameters.Length is 2 or 3 &&
+        method.Parameters[0].Type.ToDisplayString() == "Cratis.Chronicle.EventSequences.IEventSequence" &&
+        method.Parameters[1].Type.ToDisplayString() == "Cratis.Chronicle.Events.EventSourceId" &&
+        (method.Parameters.Length == 2 || IsPredicate(method.Parameters[2], method.TypeParameters[0]));
+
+    static bool IsGeneric(ITypeSymbol type, string definition, ITypeParameterSymbol argument) =>
+        type is INamedTypeSymbol named &&
+        named.OriginalDefinition.ToDisplayString() == definition &&
+        named.TypeArguments.Length == 1 &&
+        SymbolEqualityComparer.Default.Equals(named.TypeArguments[0], argument);
+
+    static bool IsPredicate(IParameterSymbol parameter, ITypeParameterSymbol eventType) =>
+        string.Equals(parameter.Name, "predicate", StringComparison.Ordinal) &&
+        parameter.Type is INamedTypeSymbol { TypeArguments: [var input, var result] } predicate &&
+        predicate.OriginalDefinition.ToDisplayString() == "System.Func<T, TResult>" &&
+        SymbolEqualityComparer.Default.Equals(input, eventType) &&
+        result.SpecialType == SpecialType.System_Boolean;
 
     /// <summary>
     /// Determines whether an assertion says the result of the command was not a success.

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationEventPredicateValues.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationEventPredicateValues.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Reads exact direct event-property values from an appended-event predicate.
+/// </summary>
+static class SpecificationEventPredicateValues
+{
+    const string PredicateParameter = "predicate";
+
+    /// <summary>
+    /// Reads every exact event value stated by an optional predicate.
+    /// </summary>
+    /// <param name="invocation">The appended-event assertion.</param>
+    /// <param name="method">The exactly bound assertion method.</param>
+    /// <param name="eventType">The event type the assertion names.</param>
+    /// <param name="semanticModel">The semantic model owning the assertion.</param>
+    /// <param name="draft">The scenario collecting exact value evidence.</param>
+    /// <param name="values">The values in authored predicate order.</param>
+    /// <param name="reason">The blocking reason when the predicate is not exact.</param>
+    /// <returns><see langword="true"/> when the predicate is absent or every value is exact.</returns>
+    public static bool TryRead(
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method,
+        ITypeSymbol eventType,
+        SemanticModel semanticModel,
+        SpecificationDraft draft,
+        out IReadOnlyList<PropertyMappingModel> values,
+        out string? reason)
+    {
+        values = [];
+        reason = null;
+        var predicateParameters = DotNetInvocations.DefinitionOf(method).Parameters
+            .Where(_ => string.Equals(_.Name, PredicateParameter, StringComparison.Ordinal))
+            .ToArray();
+        if (predicateParameters.Length == 0)
+        {
+            return true;
+        }
+
+        if (predicateParameters.Length != 1 ||
+            DotNetInvocations.ArgumentForParameter(invocation, method, PredicateParameter, semanticModel)?.Expression is not LambdaExpressionSyntax predicate ||
+            predicate.Body is not ExpressionSyntax body ||
+            ParameterOf(predicate, semanticModel) is not { } parameter ||
+            !SymbolEqualityComparer.Default.Equals(parameter.Type, eventType))
+        {
+            reason = "an expected event predicate is not an exact single-parameter expression";
+            return false;
+        }
+
+        var recovered = new List<(PropertyMappingModel Value, Location Source)>();
+        var properties = new HashSet<string>(StringComparer.Ordinal);
+        if (!TryRead(body, eventType, parameter, semanticModel, recovered, properties))
+        {
+            reason = "an expected event predicate is not a conjunction of direct event-property equalities to exact constants";
+            return false;
+        }
+
+        foreach (var (value, source) in recovered)
+        {
+            draft.AddValue(value, source);
+        }
+
+        values = [.. recovered.Select(_ => _.Value)];
+        return true;
+    }
+
+    static IParameterSymbol? ParameterOf(LambdaExpressionSyntax predicate, SemanticModel semanticModel) => predicate switch
+    {
+        SimpleLambdaExpressionSyntax simple => semanticModel.GetDeclaredSymbol(simple.Parameter),
+        ParenthesizedLambdaExpressionSyntax { ParameterList.Parameters: [var parameter] } => semanticModel.GetDeclaredSymbol(parameter),
+        _ => null
+    };
+
+    static bool TryRead(
+        ExpressionSyntax expression,
+        ITypeSymbol eventType,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        List<(PropertyMappingModel Value, Location Source)> values,
+        HashSet<string> properties)
+    {
+        expression = Unwrap(expression);
+        if (expression is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalAndExpression } conjunction)
+        {
+            return TryRead(conjunction.Left, eventType, parameter, semanticModel, values, properties) &&
+                   TryRead(conjunction.Right, eventType, parameter, semanticModel, values, properties);
+        }
+
+        if (expression is not BinaryExpressionSyntax { RawKind: (int)SyntaxKind.EqualsExpression } equality)
+        {
+            return false;
+        }
+
+        return TryRead(equality.Left, equality.Right, eventType, parameter, semanticModel, values, properties) ||
+               TryRead(equality.Right, equality.Left, eventType, parameter, semanticModel, values, properties);
+    }
+
+    static bool TryRead(
+        ExpressionSyntax memberExpression,
+        ExpressionSyntax valueExpression,
+        ITypeSymbol eventType,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        List<(PropertyMappingModel Value, Location Source)> values,
+        HashSet<string> properties)
+    {
+        memberExpression = Unwrap(memberExpression);
+        valueExpression = Unwrap(valueExpression);
+        if (memberExpression is not MemberAccessExpressionSyntax { Expression: IdentifierNameSyntax receiver } member ||
+            !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(receiver).Symbol, parameter) ||
+            semanticModel.GetSymbolInfo(member).Symbol is not IPropertySymbol property ||
+            !SymbolEqualityComparer.Default.Equals(property.ContainingType, eventType) ||
+            semanticModel.GetConstantValue(valueExpression) is not { HasValue: true } constant ||
+            !properties.Add(property.Name))
+        {
+            return false;
+        }
+
+        values.Add((new(property.Name, new LiteralSource(constant.Value)), valueExpression.GetLocation()));
+        return true;
+    }
+
+    static ExpressionSyntax Unwrap(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            expression = parenthesized.Expression;
+        }
+
+        return expression;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationMembers.cs
@@ -105,10 +105,9 @@ public static class SpecificationMembers
     /// <param name="type">The type to check.</param>
     /// <returns>The read model, or <see langword="null"/> when the type holds no read model scenario.</returns>
     /// <remarks>
-    /// A read model scenario says which read model it is about in its own type argument, which is the whole of what
-    /// the outcome of such a specification is: the events went in and this is what they built. Nothing in the body
-    /// has to be read to know it, so a scenario whose assertions are written in a way this cannot follow still says
-    /// exactly as much as the language holds for it.
+    /// A read model scenario says which read model it is about in its own type argument. Exact generated assertions
+    /// against the scenario instance state what the events built; those values are read separately and an incomplete
+    /// or unsupported assertion blocks the whole scenario.
     /// </remarks>
     public static ITypeSymbol? ReadModelOf(INamedTypeSymbol type) =>
         Holds(type, WellKnownTypeNames.ReadModelScenario) is INamedTypeSymbol { TypeArguments.Length: 1 } scenario

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
@@ -50,9 +50,16 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
     /// Adds an event a specification says followed, or records that it cannot be read.
     /// </summary>
     /// <param name="appended">The type the assertion names.</param>
-    /// <param name="source">The exact authored assertion location.</param>
+    /// <param name="invocation">The appended-event assertion.</param>
+    /// <param name="method">The exactly bound assertion method.</param>
+    /// <param name="semanticModel">The semantic model owning the assertion.</param>
     /// <param name="draft">The scenario collected so far.</param>
-    static void AddEvent(ITypeSymbol appended, Location source, SpecificationDraft draft)
+    static void AddEvent(
+        ITypeSymbol appended,
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method,
+        SemanticModel semanticModel,
+        SpecificationDraft draft)
     {
         if (!EventReader.IsEvent(appended))
         {
@@ -60,11 +67,27 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
             return;
         }
 
-        if (!draft.Then.Any(_ => string.Equals(_.Name, appended.Name, StringComparison.Ordinal)))
+        if (draft.Then.Any(_ => string.Equals(_.Name, appended.Name, StringComparison.Ordinal)))
         {
-            var state = new SpecificationStateModel(appended.Name, SpecificationStateKind.Event, []);
-            draft.AddThen(state, appended, source);
+            draft.CannotRead($"it expects '{appended.Name}' more than once, and repeated event expectations are ambiguous");
+            return;
         }
+
+        if (!SpecificationEventPredicateValues.TryRead(
+                invocation,
+                method,
+                appended,
+                semanticModel,
+                draft,
+                out var values,
+                out var reason))
+        {
+            draft.CannotRead(reason!);
+            return;
+        }
+
+        var state = new SpecificationStateModel(appended.Name, SpecificationStateKind.Event, values);
+        draft.AddThen(state, appended, invocation.GetLocation());
     }
 
     /// <summary>
@@ -86,6 +109,12 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
 
             var appended = SpecificationAssertions.AppendedEventOf(method);
             var rejection = SpecificationAssertions.IsRejection(invocation, method);
+            if (appended is null && SpecificationAssertions.HasAppendedEventAssertionName(method))
+            {
+                draft.CannotRead("an appended-event assertion does not match an exact allowlisted testing API signature");
+                return;
+            }
+
             if (appended is null && !rejection)
             {
                 continue;
@@ -99,7 +128,7 @@ public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnos
 
             if (appended is not null)
             {
-                AddEvent(appended, invocation.GetLocation(), draft);
+                AddEvent(appended, invocation, method, semanticModel, draft);
                 continue;
             }
 

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationQueryEvidence.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationQueryEvidence.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Represents one exact generated query scenario - a substitute read model, the exact query it calls, the input it
+/// calls it with, and the read model instance it expects back.
+/// </summary>
+/// <param name="SourceType">The exact authored specification type.</param>
+/// <param name="Source">The exact authored specification declaration.</param>
+/// <param name="Query">The exact application-declared query method matched cross-compilation.</param>
+/// <param name="QueryInvocationSource">The exact authored query call location.</param>
+/// <param name="ReadModel">The exact application-declared read model type the query returns.</param>
+/// <param name="ExpectedSource">The exact authored expected read-model construction location.</param>
+/// <param name="IsOptional">Whether the query may answer with no read model at all.</param>
+/// <param name="Arguments">The exact query call arguments, in the query's own formal parameter order.</param>
+/// <param name="Result">The exact expected read-model values, in its declaration order.</param>
+/// <param name="ValueEvidence">Every argument and result value's exact authored expression location.</param>
+internal sealed record SpecificationQueryEvidence(
+    INamedTypeSymbol SourceType,
+    Location Source,
+    IMethodSymbol Query,
+    Location QueryInvocationSource,
+    INamedTypeSymbol ReadModel,
+    Location ExpectedSource,
+    bool IsOptional,
+    IReadOnlyList<PropertyMappingModel> Arguments,
+    IReadOnlyList<PropertyMappingModel> Result,
+    IReadOnlyDictionary<PropertyMappingModel, Location> ValueEvidence);

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationQueryReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationQueryReader.cs
@@ -1,0 +1,898 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Analysis.Queries;
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Reads a generated query specification directly from its exact Stage-generated shape - a substituted
+/// <c>IReadModels</c>, an expected read model construction, an exact call to a declared query, and a single
+/// whole-result equality assertion.
+/// </summary>
+/// <param name="models">The <see cref="SemanticModels"/> every body is read through.</param>
+/// <param name="catalog">Every query the application itself declares, matched cross-compilation.</param>
+/// <remarks>
+/// This is not a scenario stated through <c>ReadModelScenario&lt;T&gt;</c> - there is no given, no when, and the
+/// read model comes back from a substitute rather than from replaying events. What is read is exact and narrow by
+/// design: one awaited call to one declared query, captured into one result, compared whole against one expected
+/// read model construction. Anything else - a second call, a conditional one, an unassigned one, a per-property
+/// assertion, a computed argument - is not this shape, and the whole scenario is left out rather than read partly.
+/// </remarks>
+internal class SpecificationQueryReader(SemanticModels models, IReadOnlyList<SpecificationQueryCatalog.Entry> catalog)
+{
+    const string ReturnsMethod = "Returns";
+    const string GetInstanceByIdMethod = "GetInstanceById";
+    const string SubstituteExtensionsType = "NSubstitute.SubstituteExtensions";
+    const string ShouldEqualityExtensionsType = "Cratis.Specifications.ShouldEqualityExtensions";
+    const string ShouldEqualMethod = "ShouldEqual";
+    const string ExpectedParameter = "expected";
+    const string ReturnThisParameter = "returnThis";
+    const string SubstituteType = "NSubstitute.Substitute";
+    const string SubstituteForMethod = "For";
+
+    readonly HeldValues _held = new(models);
+    readonly ScreenplayNaming _naming = new();
+
+    /// <summary>
+    /// Reads a generated query scenario.
+    /// </summary>
+    /// <param name="type">The type declaring the specification.</param>
+    /// <param name="evidence">The exact scenario evidence, when the scenario is read.</param>
+    /// <param name="reason">The blocking reason, set only when the type attempted this shape and could not be read exactly.</param>
+    /// <returns><see langword="true"/> when the scenario was read exactly.</returns>
+    /// <remarks>
+    /// A type that attempts nothing of this shape yields neither an evidence nor a reason, so the caller can tell a
+    /// specification of another kind - which is silently none of this reader's concern - from one that tried and
+    /// fell short of it, which is reported.
+    /// </remarks>
+    public bool TryRead(INamedTypeSymbol type, out SpecificationQueryEvidence? evidence, out string? reason)
+    {
+        evidence = null;
+        reason = null;
+
+        if (type is not { TypeKind: TypeKind.Class, IsAbstract: false, ContainingType: null })
+        {
+            return false;
+        }
+
+        var steps = SpecificationMembers.StepsOf(type);
+        var becauseMethods = SpecificationMembers.MethodsIn(steps, SpecificationMembers.BecauseMethod).ToArray();
+        if (becauseMethods.Length == 0 || !SpecificationMembers.AssertionsIn(type).Any())
+        {
+            return false;
+        }
+
+        if (!TryFindQueryCall(
+                becauseMethods,
+                out var assignment,
+                out var invocation,
+                out var calledMethod,
+                out var matched,
+                out var becauseModel,
+                out var becauseBody,
+                out reason))
+        {
+            return false;
+        }
+
+        if (!type.BaseType.Is(WellKnownTypeNames.Specification))
+        {
+            reason = "the scenario type does not derive directly from Cratis.Specifications.Specification";
+            return false;
+        }
+
+        if (!StepsTaken.Always(assignment, becauseBody))
+        {
+            reason = "the query it calls is only called under a condition, and a generated query scenario captures what always happened";
+            return false;
+        }
+
+        if (becauseModel.GetSymbolInfo(assignment.Left).Symbol is not IFieldSymbol resultSymbol ||
+            resultSymbol.Name != "_result" ||
+            resultSymbol.IsStatic ||
+            resultSymbol.IsReadOnly ||
+            !SymbolEqualityComparer.Default.Equals(resultSymbol.ContainingType, type) ||
+            resultSymbol.DeclaringSyntaxReferences.Select(_ => _.GetSyntax()).OfType<VariableDeclaratorSyntax>().SingleOrDefault() is not { Initializer: null } ||
+            AssignmentsTo(type, resultSymbol).ToArray() is not [var onlyAssignment] ||
+            onlyAssignment != assignment)
+        {
+            reason = "the query result is not captured once by the exact uninitialized field a generated query scenario declares";
+            return false;
+        }
+
+        if (matched is null)
+        {
+            reason = "the query it calls does not match exactly one query the application itself declares";
+            return false;
+        }
+
+        var inputParameters = matched.Method.Parameters.Where(QueryReader.IsInput).ToArray();
+        if (inputParameters is not [var input])
+        {
+            reason = "the application query does not declare exactly one caller input";
+            return false;
+        }
+
+        if (input.HasExplicitDefaultValue)
+        {
+            reason = "the application query input has an explicit default instead of being its required identifier";
+            return false;
+        }
+
+        if (!IsNonNullableScalar(input.Type))
+        {
+            reason = "the application query input is nullable or a collection instead of one required scalar identifier";
+            return false;
+        }
+
+        if (ContainsTransport(matched.Method.ReturnType))
+        {
+            reason = "the query returns a transport level result, which is not a read model";
+            return false;
+        }
+
+        if (QueryReturnTypes.IsObservable(matched.Method.ReturnType))
+        {
+            reason = "the query is observable, and a generated query scenario is of a single answer";
+            return false;
+        }
+
+        var isCollection = false;
+        var unwrapped = QueryReturnTypes.Unwrap(matched.Method.ReturnType, ref isCollection);
+        if (isCollection)
+        {
+            reason = "the query returns many read models, and the generated query scenario shape holds exactly one";
+            return false;
+        }
+
+        if (unwrapped is not INamedTypeSymbol applicationReadModel ||
+            !SymbolEqualityComparer.Default.Equals(applicationReadModel, matched.ReadModel) ||
+            applicationReadModel.NullableAnnotation != NullableAnnotation.Annotated)
+        {
+            reason = "the application query does not return exactly one optional read model";
+            return false;
+        }
+
+        if (TypeOf(resultSymbol) is not INamedTypeSymbol capturedReadModel ||
+            !SymbolEqualityComparer.Default.Equals(capturedReadModel, calledMethod.ContainingType))
+        {
+            reason = "the captured result is not the exact read model a generated query scenario declares";
+            return false;
+        }
+
+        if (resultSymbol.NullableAnnotation != NullableAnnotation.Annotated)
+        {
+            reason = "the captured result is not nullable as a generated query scenario declares";
+            return false;
+        }
+
+        var resultProperties = matched.ReadModel.DeclaredProperties().ToArray();
+        if (resultProperties.Any(property => !IsSupportedResultProperty(property)))
+        {
+            reason = "the expected read model declares a nullable, collection, or unsupported result property";
+            return false;
+        }
+
+        var keyProperties = resultProperties.Where(property =>
+            string.Equals(_naming.ToPropertyName(property.Name), _naming.ToPropertyName(input.Name), StringComparison.Ordinal) &&
+            SymbolEqualityComparer.IncludeNullability.Equals(property.Type, input.Type) &&
+            IsNonNullableScalar(property.Type)).ToArray();
+        if (keyProperties.Length != 1)
+        {
+            reason = "the sole required query input does not match exactly one non-nullable scalar read-model property by normalized name and exact type";
+            return false;
+        }
+
+        if (!TryReadReadModels(invocation, calledMethod, becauseModel, type, out var readModelsSymbol, out reason) ||
+            !TryReadArguments(invocation, calledMethod, matched.Method, becauseModel, out var arguments, out var argumentEvidence, out reason))
+        {
+            return false;
+        }
+
+        if (!TryReadAssertion(type, resultSymbol, calledMethod.ContainingType, out var expectedSymbol, out var construction, out reason))
+        {
+            return false;
+        }
+
+        if (construction.SemanticModel.GetTypeInfo(construction.Creation).Type is not INamedTypeSymbol expectedType ||
+            !SymbolEqualityComparer.Default.Equals(expectedType, calledMethod.ContainingType))
+        {
+            reason = "the expected construction is not the exact read model the query returns";
+            return false;
+        }
+
+        if (!IsExactPrimaryReadModelConstruction(construction, expectedType, matched.ReadModel, resultProperties, out var constructionReason))
+        {
+            reason = constructionReason;
+            return false;
+        }
+
+        var draft = new SpecificationDraft();
+        var values = new SpecificationValues(new ScreenplayDiagnostics(), new GeneratedIdentities(models));
+        var result = values.ReadQuery(construction.Creation, construction.SemanticModel, expectedType, matched.ReadModel, type.Name, type.ToDisplayString(), draft).ToArray();
+        if (!HasEveryExpectedValue(expectedType, result))
+        {
+            reason = "the expected read model omits, repeats, reorders, or computes a value the generated construction states directly";
+            return false;
+        }
+
+        var applicationProperties = resultProperties;
+        if (applicationProperties.Length != result.Length ||
+            applicationProperties.Zip(result).Any(pair => !string.Equals(pair.First.Name, pair.Second.Property, StringComparison.Ordinal)))
+        {
+            reason = "the expected read model values do not match the application read model in declaration order";
+            return false;
+        }
+
+        if (!TryReadEstablish(
+                steps,
+                calledMethod.ContainingType,
+                readModelsSymbol,
+                expectedSymbol,
+                arguments.Single(),
+                calledMethod.Parameters[input.Ordinal].Type,
+                input.Type,
+                out reason))
+        {
+            return false;
+        }
+
+        var valueEvidence = new Dictionary<PropertyMappingModel, Location>(ReferenceEqualityComparer.Instance);
+        foreach (var (value, source) in argumentEvidence)
+        {
+            valueEvidence.Add(value, source);
+        }
+
+        foreach (var (value, source) in draft.GetValueEvidence())
+        {
+            valueEvidence.TryAdd(value, source);
+        }
+
+        evidence = new(
+            type,
+            StableSourceOf(type),
+            matched.Method,
+            invocation.GetLocation(),
+            matched.ReadModel,
+            construction.Creation.GetLocation(),
+            true,
+            arguments,
+            [.. result],
+            valueEvidence);
+        return true;
+    }
+
+    static Location StableSourceOf(INamedTypeSymbol type) =>
+        type.DeclaringSyntaxReferences
+            .Select(_ => _.GetSyntax().GetLocation())
+            .Where(_ => _.IsInSource)
+            .OrderBy(_ => NormalizedPath(_.SourceTree?.FilePath), StringComparer.Ordinal)
+            .ThenBy(_ => _.SourceSpan.Start)
+            .First();
+
+    static string NormalizedPath(string? path) =>
+        (path ?? string.Empty).Replace('\\', '/').Normalize();
+
+    static bool IsNonNullableScalar(ITypeSymbol type) =>
+        type.NullableAnnotation != NullableAnnotation.Annotated &&
+        type is not INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } &&
+        CollectionElements.ElementOf(type) is null;
+
+    static bool IsExactStagePrimitive(INamedTypeSymbol type)
+    {
+        var name = type.FullMetadataName();
+        return string.Equals(name, "System.Guid", StringComparison.Ordinal) ||
+            string.Equals(name, "System.String", StringComparison.Ordinal) ||
+            string.Equals(name, "System.Int32", StringComparison.Ordinal) ||
+            string.Equals(name, "System.Decimal", StringComparison.Ordinal) ||
+            string.Equals(name, "System.Boolean", StringComparison.Ordinal) ||
+            string.Equals(name, "System.DateOnly", StringComparison.Ordinal) ||
+            string.Equals(name, "System.DateTimeOffset", StringComparison.Ordinal);
+    }
+
+    static bool IsExactPrimaryReadModelConstruction(
+        HeldConstruction construction,
+        INamedTypeSymbol expectedType,
+        INamedTypeSymbol sourceType,
+        IPropertySymbol[] sourceProperties,
+        out string reason)
+    {
+        reason = "the expected read model is not constructed through its exact positional-record primary constructor";
+        var localProperties = expectedType.DeclaredProperties().ToArray();
+        if (!expectedType.IsRecord || !sourceType.IsRecord)
+        {
+            return false;
+        }
+
+        if (construction.Creation.Initializer is not null ||
+            construction.Creation.ArgumentList?.Arguments is not { } arguments ||
+            arguments.Count != sourceProperties.Length ||
+            arguments.Any(_ => _.NameColon is not null))
+        {
+            return false;
+        }
+
+        if (construction.SemanticModel.GetSymbolInfo(construction.Creation).Symbol is not IMethodSymbol selectedConstructor ||
+            !SymbolEqualityComparer.Default.Equals(selectedConstructor.ContainingType, expectedType))
+        {
+            return false;
+        }
+
+        if (sourceType.InstanceConstructors.SingleOrDefault(IsPrimaryRecordConstructor) is not { } sourceConstructor)
+        {
+            return false;
+        }
+
+        if (selectedConstructor.Parameters.Length != sourceConstructor.Parameters.Length ||
+            localProperties.Length != selectedConstructor.Parameters.Length ||
+            sourceProperties.Length != sourceConstructor.Parameters.Length ||
+            !ParametersMatchProperties(selectedConstructor.Parameters, localProperties) ||
+            !ParametersMatchProperties(sourceConstructor.Parameters, sourceProperties))
+        {
+            return false;
+        }
+
+        return selectedConstructor.Parameters.Zip(sourceConstructor.Parameters).All(pair =>
+            string.Equals(pair.First.Name, pair.Second.Name, StringComparison.Ordinal) &&
+            TypesHaveSameIdentity(pair.First.Type, pair.Second.Type));
+    }
+
+    static bool IsPrimaryRecordConstructor(IMethodSymbol constructor) =>
+        constructor.DeclaringSyntaxReferences.Any(_ => _.GetSyntax() is RecordDeclarationSyntax { ParameterList: not null });
+
+    static bool ParametersMatchProperties(
+        IReadOnlyList<IParameterSymbol> parameters,
+        IReadOnlyList<IPropertySymbol> properties) =>
+        parameters.Zip(properties).All(pair =>
+            string.Equals(pair.First.Name, pair.Second.Name, StringComparison.Ordinal) &&
+            SymbolEqualityComparer.IncludeNullability.Equals(pair.First.Type, pair.Second.Type));
+
+    static bool TypesHaveSameIdentity(ITypeSymbol first, ITypeSymbol second) =>
+        first.NullableAnnotation == second.NullableAnnotation &&
+        string.Equals(
+            first.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            second.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            StringComparison.Ordinal);
+
+    /// <summary>
+    /// Finds the single awaited call a generated query scenario captures, from every <c>Because</c> in the chain.
+    /// </summary>
+    /// <param name="becauseMethods">Every authored <c>Because</c> method in the specification chain.</param>
+    /// <param name="assignment">The exact result assignment.</param>
+    /// <param name="invocation">The exact query invocation.</param>
+    /// <param name="method">The exactly bound called method.</param>
+    /// <param name="matched">The authoritative application query match, when one exists.</param>
+    /// <param name="semanticModel">The semantic model owning the call.</param>
+    /// <param name="body">The exact <c>Because</c> body.</param>
+    /// <param name="reason">The blocking reason when the attempted shape is not exact.</param>
+    /// <returns><see langword="true"/> when exactly one awaited assignment is found.</returns>
+    /// <remarks>
+    /// Every awaited call to a declared query's own read model is gathered first, whether or not it is captured by
+    /// an assignment - so that a second call, or one nobody captures, is what makes the scenario ambiguous rather
+    /// than something silently ignored. A type with no such call at all is not attempting this shape, and is left
+    /// for whatever else reads it.
+    /// </remarks>
+    bool TryFindQueryCall(
+        IReadOnlyList<IMethodSymbol> becauseMethods,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out AssignmentExpressionSyntax? assignment,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out InvocationExpressionSyntax? invocation,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IMethodSymbol? method,
+        out SpecificationQueryCatalog.Entry? matched,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out SemanticModel? semanticModel,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out SyntaxNode? body,
+        out string? reason)
+    {
+        assignment = null;
+        invocation = null;
+        method = null;
+        matched = null;
+        semanticModel = null;
+        body = null;
+        reason = null;
+
+        var found = new List<QueryAttempt>();
+        foreach (var because in becauseMethods)
+        {
+            foreach (var candidateBody in HandlerBodies.Of(because))
+            {
+                if (models.For(candidateBody.SyntaxTree) is not { } candidateModel)
+                {
+                    continue;
+                }
+
+                foreach (var awaited in candidateBody.DescendantNodesAndSelf().OfType<AwaitExpressionSyntax>())
+                {
+                    if (MappingSourceReader.Unwrap(awaited.Expression) is not InvocationExpressionSyntax candidateInvocation ||
+                        DotNetInvocations.MethodFor(candidateInvocation, candidateModel) is not { IsStatic: true } candidateMethod)
+                    {
+                        continue;
+                    }
+
+                    var matches = catalog.Where(entry => DotNetMethodSignatures.Matches(candidateMethod, entry.Signature)).ToArray();
+                    found.Add(new(awaited, candidateInvocation, candidateMethod, candidateModel, candidateBody, matches));
+                }
+            }
+        }
+
+        var exact = found.Where(_ => _.Matches.Count > 0).ToArray();
+        var attempts = exact.Length > 0 ? exact : found.Where(_ => LooksLikeStageQueryCall(_.Method)).ToArray();
+        if (attempts.Length == 0)
+        {
+            return false;
+        }
+
+        if (attempts.Length > 1)
+        {
+            reason = "it captures more than one query call, and a generated query scenario captures exactly one";
+            return false;
+        }
+
+        var attempt = attempts[0];
+        if (attempt.Matches.Count > 1)
+        {
+            reason = "the query it calls matches more than one query the application declares";
+            return false;
+        }
+
+        if (becauseMethods is not [var singleBecause] ||
+            singleBecause.IsStatic ||
+            !singleBecause.IsAsync ||
+            singleBecause.Parameters.Length != 0 ||
+            !singleBecause.ReturnType.Is("System.Threading.Tasks.Task") ||
+            singleBecause.DeclaringSyntaxReferences.Select(_ => _.GetSyntax()).OfType<MethodDeclarationSyntax>().SingleOrDefault() is not
+            {
+                Body: null,
+                ExpressionBody.Expression: AssignmentExpressionSyntax
+                {
+                    RawKind: (int)SyntaxKind.SimpleAssignmentExpression,
+                    Right: AwaitExpressionSyntax
+                    {
+                        Expression: InvocationExpressionSyntax exactInvocation
+                    } exactAwait
+                } exactAssignment
+            } exactBecause ||
+            attempt.Await != exactAwait ||
+            attempt.Invocation != exactInvocation ||
+            attempt.Body != exactAssignment ||
+            exactBecause.ExpressionBody?.Expression != exactAssignment)
+        {
+            reason = "Because is not exactly one parameterless expression-bodied awaited query assignment";
+            return false;
+        }
+
+        assignment = exactAssignment;
+        invocation = attempt.Invocation;
+        method = attempt.Method;
+        matched = attempt.Matches.SingleOrDefault();
+        semanticModel = attempt.SemanticModel;
+        body = exactAssignment;
+        return true;
+    }
+
+    /// <summary>
+    /// Reads the exact substituted <c>IReadModels</c> field handed to the query.
+    /// </summary>
+    /// <param name="invocation">The exact query invocation.</param>
+    /// <param name="method">The method bound in the specification compilation.</param>
+    /// <param name="semanticModel">The semantic model owning the invocation.</param>
+    /// <param name="specification">The exact scenario type declaring the field.</param>
+    /// <param name="readModels">The exact substituted field.</param>
+    /// <param name="reason">The blocking reason when the collaborator is not exact.</param>
+    /// <returns><see langword="true"/> when the exact field is read.</returns>
+    bool TryReadReadModels(
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method,
+        SemanticModel semanticModel,
+        INamedTypeSymbol specification,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IFieldSymbol? readModels,
+        out string? reason)
+    {
+        readModels = null;
+        reason = null;
+        var parameters = method.Parameters.Where(parameter => parameter.Type.Is(WellKnownTypeNames.ReadModels)).ToArray();
+        if (parameters is not [var parameter] ||
+            DotNetInvocations.ArgumentForParameter(invocation, method, parameter.Name, semanticModel)?.Expression is not { } argument ||
+            semanticModel.GetSymbolInfo(MappingSourceReader.Unwrap(argument)).Symbol is not IFieldSymbol
+            {
+                IsReadOnly: true,
+                Type.TypeKind: TypeKind.Interface
+            } field ||
+            field.Name != "_readModels" ||
+            field.IsStatic ||
+            !field.Type.Is(WellKnownTypeNames.ReadModels) ||
+            field.Type.NullableAnnotation == NullableAnnotation.Annotated ||
+            !SymbolEqualityComparer.Default.Equals(field.ContainingType, specification) ||
+            field.DeclaringSyntaxReferences.Select(_ => _.GetSyntax()).OfType<VariableDeclaratorSyntax>().SingleOrDefault() is not
+            {
+                Initializer.Value: InvocationExpressionSyntax initializer
+            } ||
+            models.For(initializer.SyntaxTree) is not { } initializerModel ||
+            DotNetInvocations.MethodFor(initializer, initializerModel) is not { } substitute ||
+            DotNetInvocations.DefinitionOf(substitute) is not
+            {
+                IsStatic: true,
+                Name: SubstituteForMethod,
+                TypeParameters.Length: 1
+            } substituteDefinition ||
+            substituteDefinition.ContainingType.ToDisplayString() != SubstituteType ||
+            substitute.TypeArguments is not [var substitutedType] ||
+            !SymbolEqualityComparer.Default.Equals(substitutedType, field.Type) ||
+            initializer.ArgumentList.Arguments.Count != 0 ||
+            AssignmentsTo(specification, field).Any())
+        {
+            reason = "the query is not handed the exact readonly directly initialized NSubstitute IReadModels field a generated query scenario declares";
+            return false;
+        }
+
+        readModels = field;
+        return true;
+    }
+
+    /// <summary>
+    /// Gets every authored assignment to one field in the exact specification type.
+    /// </summary>
+    /// <param name="type">The authored specification type.</param>
+    /// <param name="field">The field to inspect.</param>
+    /// <returns>The exact assignments.</returns>
+    IEnumerable<AssignmentExpressionSyntax> AssignmentsTo(INamedTypeSymbol type, IFieldSymbol field) =>
+        type.DeclaringSyntaxReferences
+            .Select(_ => _.GetSyntax())
+            .SelectMany(_ => _.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+            .Where(assignment => models.For(assignment.SyntaxTree) is { } model &&
+                SymbolEqualityComparer.Default.Equals(model.GetSymbolInfo(assignment.Left).Symbol, field));
+
+    /// <summary>
+    /// Determines whether a computed call still returns a model-bound read model and therefore attempted this shape.
+    /// </summary>
+    /// <param name="method">The computed method call.</param>
+    /// <returns><see langword="true"/> when its answer is a model-bound read model.</returns>
+    bool ReturnsReadModel(IMethodSymbol method)
+    {
+        var collection = false;
+        return QueryReturnTypes.Unwrap(method.ReturnType, ref collection) is { } returned && QueryReader.IsReadModel(returned);
+    }
+
+    /// <summary>
+    /// Reads the exact input arguments a query call gives, in the query's own formal parameter order.
+    /// </summary>
+    /// <param name="invocation">The exact query invocation.</param>
+    /// <param name="calledMethod">The method bound in the specification compilation.</param>
+    /// <param name="applicationMethod">The exact matched application method.</param>
+    /// <param name="semanticModel">The semantic model owning the invocation.</param>
+    /// <param name="arguments">The exact values in application formal parameter order.</param>
+    /// <param name="evidence">The exact authored argument locations.</param>
+    /// <param name="reason">The blocking reason when an argument is not exact.</param>
+    /// <returns><see langword="true"/> when every input argument is exact.</returns>
+    bool TryReadArguments(
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol calledMethod,
+        IMethodSymbol applicationMethod,
+        SemanticModel semanticModel,
+        out IReadOnlyList<PropertyMappingModel> arguments,
+        out IReadOnlyList<(PropertyMappingModel Value, Location Source)> evidence,
+        out string? reason)
+    {
+        arguments = [];
+        evidence = [];
+        reason = null;
+
+        var values = new List<PropertyMappingModel>();
+        var located = new List<(PropertyMappingModel, Location)>();
+        var sources = new MappingSourceReader(new ScreenplayDiagnostics());
+        foreach (var (parameter, index) in applicationMethod.Parameters.Select((parameter, index) => (parameter, index)).Where(_ => QueryReader.IsInput(_.parameter)))
+        {
+            var calledParameter = calledMethod.Parameters[index];
+            if (DotNetInvocations.ArgumentForParameter(invocation, calledMethod, calledParameter.Name, semanticModel)?.Expression is not { } argument)
+            {
+                reason = $"the query argument '{parameter.Name}' is not given by exactly one exact authored argument";
+                return false;
+            }
+
+            if (sources.ReadQueryLiteral(argument, semanticModel, calledParameter.Type, parameter.Type) is not { } literal)
+            {
+                reason = $"the query argument '{parameter.Name}' is not an exact Stage-authored scalar or concept value";
+                return false;
+            }
+
+            var value = new PropertyMappingModel(parameter.Name, literal);
+            values.Add(value);
+            located.Add((value, argument.GetLocation()));
+        }
+
+        arguments = values;
+        evidence = located;
+        return true;
+    }
+
+    /// <summary>
+    /// Reads the single exact whole-result equality assertion a generated query scenario declares.
+    /// </summary>
+    /// <param name="type">The authored specification type.</param>
+    /// <param name="resultSymbol">The exact field receiving the query result.</param>
+    /// <param name="readModel">The exact read model the called query is declared on.</param>
+    /// <param name="expectedSymbol">The exact expected field.</param>
+    /// <param name="construction">The direct expected read-model construction.</param>
+    /// <param name="reason">The blocking reason when the assertion is not exact.</param>
+    /// <returns><see langword="true"/> when the exact whole-result assertion is read.</returns>
+    /// <remarks>
+    /// The assertion has to name the exact result symbol as its receiver, or it is not this assertion - a property
+    /// of the result, or the expected read model written the other way around, both fail that the same way a
+    /// lookalike helper of the same name does.
+    /// </remarks>
+    bool TryReadAssertion(
+        INamedTypeSymbol type,
+        ISymbol resultSymbol,
+        INamedTypeSymbol readModel,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out ISymbol? expectedSymbol,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out HeldConstruction? construction,
+        out string? reason)
+    {
+        expectedSymbol = null;
+        construction = null;
+        reason = null;
+
+        var facts = SpecificationMembers.AssertionsIn(type).ToArray();
+        if (facts.Length != 1)
+        {
+            reason = "it does not declare exactly one assertion, and a generated query scenario declares exactly one";
+            return false;
+        }
+
+        var fact = facts[0];
+        if (fact.IsStatic ||
+            !fact.ReturnsVoid ||
+            fact.Parameters.Length != 0 ||
+            fact.DeclaringSyntaxReferences.Select(_ => _.GetSyntax()).OfType<MethodDeclarationSyntax>().SingleOrDefault() is not
+            {
+                Body: null,
+                ExpressionBody.Expression: InvocationExpressionSyntax assertion
+            } ||
+            models.For(assertion.SyntaxTree) is not { } assertionModel ||
+            DotNetInvocations.MethodFor(assertion, assertionModel) is not { } assertionMethod ||
+            !IsExactEquality(assertionMethod))
+        {
+            reason = "the single assertion is not exactly one expression-bodied whole-result ShouldEqual call";
+            return false;
+        }
+
+        var receiver = DotNetInvocations.ReceiverFor(assertion, assertionMethod, assertionModel);
+        if (receiver is null ||
+            assertionModel.GetSymbolInfo(Unwrap(receiver)).Symbol is not { } receiverSymbol ||
+            !SymbolEqualityComparer.Default.Equals(receiverSymbol, resultSymbol))
+        {
+            reason = "the exact query result field is not the receiver of the whole-result equality";
+            return false;
+        }
+
+        if (DotNetInvocations.ArgumentForParameter(assertion, assertionMethod, ExpectedParameter, assertionModel)?.Expression is not { } expectedExpression)
+        {
+            reason = "the expected read model is not given by an exact authored argument";
+            return false;
+        }
+
+        if (assertionModel.GetSymbolInfo(Unwrap(expectedExpression)).Symbol is not IFieldSymbol { IsReadOnly: true } foundExpectedSymbol ||
+            foundExpectedSymbol.Name != "_expected" ||
+            foundExpectedSymbol.IsStatic ||
+            !SymbolEqualityComparer.Default.Equals(foundExpectedSymbol.ContainingType, type) ||
+            !SymbolEqualityComparer.Default.Equals(foundExpectedSymbol.Type, readModel) ||
+            foundExpectedSymbol.Type.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            reason = "the expected read model is not the exact readonly non-nullable field a generated query scenario declares";
+            return false;
+        }
+
+        if (_held.ConstructionOf(expectedExpression, assertionModel) is not { } foundConstruction ||
+            foundConstruction.Creation.Initializer is not null ||
+            foundExpectedSymbol.DeclaringSyntaxReferences.Select(_ => _.GetSyntax()).OfType<VariableDeclaratorSyntax>().SingleOrDefault()?.Initializer?.Value is not { } declaredExpected ||
+            MappingSourceReader.Unwrap(declaredExpected) != foundConstruction.Creation ||
+            AssignmentsTo(type, foundExpectedSymbol).Any())
+        {
+            reason = "the expected read model is not constructed directly in its field declaration";
+            return false;
+        }
+
+        expectedSymbol = foundExpectedSymbol;
+        construction = foundConstruction;
+        return true;
+    }
+
+    /// <summary>
+    /// Confirms an optional substitute setup, when present, exactly corroborates the query call and the expected
+    /// read model - never states a fact of its own.
+    /// </summary>
+    /// <param name="steps">The specification chain carrying setup.</param>
+    /// <param name="readModel">The exact returned read model.</param>
+    /// <param name="readModelsSymbol">The exact substitute handed to the query.</param>
+    /// <param name="expectedSymbol">The expected field corroborated by setup.</param>
+    /// <param name="key">The exact first query argument.</param>
+    /// <param name="expectedKeyType">The exact key type in the specification compilation.</param>
+    /// <param name="sourceExpectedKeyType">The corresponding exact application-declared key type.</param>
+    /// <param name="reason">The blocking reason when setup conflicts.</param>
+    /// <returns><see langword="true"/> when setup is absent or corroborates exactly.</returns>
+    bool TryReadEstablish(
+        INamedTypeSymbol steps,
+        INamedTypeSymbol readModel,
+        IFieldSymbol readModelsSymbol,
+        ISymbol expectedSymbol,
+        PropertyMappingModel key,
+        ITypeSymbol expectedKeyType,
+        ITypeSymbol sourceExpectedKeyType,
+        out string? reason)
+    {
+        reason = null;
+        var establishMethods = SpecificationMembers.MethodsIn(steps, SpecificationMembers.EstablishMethod).ToArray();
+        if (establishMethods.Length == 0)
+        {
+            return true;
+        }
+
+        if (establishMethods is not [var establish] ||
+            establish.IsStatic ||
+            !establish.ReturnsVoid ||
+            establish.Parameters.Length != 0 ||
+            establish.DeclaringSyntaxReferences.Select(_ => _.GetSyntax()).OfType<MethodDeclarationSyntax>().SingleOrDefault() is not
+            {
+                Body: null,
+                ExpressionBody.Expression: InvocationExpressionSyntax returnsInvocation
+            } ||
+            models.For(returnsInvocation.SyntaxTree) is not { } establishModel ||
+            returnsInvocation.ArgumentList.Arguments is not [_] ||
+            DotNetInvocations.MethodFor(returnsInvocation, establishModel) is not { Name: ReturnsMethod } returnsMethod ||
+            DotNetInvocations.DefinitionOf(returnsMethod).ContainingType.ToDisplayString() != SubstituteExtensionsType ||
+            DotNetInvocations.ReceiverFor(returnsInvocation, returnsMethod, establishModel) is not InvocationExpressionSyntax getInstanceInvocation ||
+            DotNetInvocations.MethodFor(getInstanceInvocation, establishModel) is not { Name: GetInstanceByIdMethod } getInstanceMethod ||
+            !getInstanceMethod.ContainingType.Is(WellKnownTypeNames.ReadModels))
+        {
+            reason = "Establish is not exactly one parameterless expression-bodied GetInstanceById<T>(key).Returns(expected) setup";
+            return false;
+        }
+        if (getInstanceMethod.TypeArguments is not [INamedTypeSymbol configuredReadModel] ||
+            !SymbolEqualityComparer.Default.Equals(configuredReadModel, readModel) ||
+            getInstanceInvocation.ArgumentList.Arguments.Count != 1)
+        {
+            reason = "the substitute setup configures a different read model than the query returns";
+            return false;
+        }
+
+        if (DotNetInvocations.ReceiverFor(getInstanceInvocation, getInstanceMethod, establishModel) is not { } readModelsExpression ||
+            establishModel.GetSymbolInfo(MappingSourceReader.Unwrap(readModelsExpression)).Symbol is not { } establishedReadModels ||
+            !SymbolEqualityComparer.Default.Equals(establishedReadModels, readModelsSymbol))
+        {
+            reason = "the substitute setup configures a different IReadModels field than the query is handed";
+            return false;
+        }
+
+        if (DotNetInvocations.ArgumentForParameter(returnsInvocation, returnsMethod, ReturnThisParameter, establishModel)?.Expression is not { } returnsExpression ||
+            establishModel.GetSymbolInfo(Unwrap(returnsExpression)).Symbol is not { } returnsSymbol ||
+            !SymbolEqualityComparer.Default.Equals(returnsSymbol, expectedSymbol))
+        {
+            reason = "the substitute setup returns a different expected read model than the assertion compares against";
+            return false;
+        }
+
+        if (key.Source is not LiteralSource literalKey ||
+            getInstanceMethod.Parameters.Length == 0 ||
+            DotNetInvocations.ArgumentForParameter(getInstanceInvocation, getInstanceMethod, getInstanceMethod.Parameters[0].Name, establishModel)?.Expression is not CastExpressionSyntax
+            {
+                Type: var castType,
+                Expression: var keyExpression
+            } ||
+            !establishModel.GetTypeInfo(castType).Type.Is(WellKnownTypeNames.EventSourceId) ||
+            new MappingSourceReader(new ScreenplayDiagnostics()).ReadQueryLiteral(keyExpression, establishModel, expectedKeyType, sourceExpectedKeyType) is not { } establishKey ||
+            !Equals(establishKey.Value, literalKey.Value))
+        {
+            reason = "the substitute setup keys the read model by a different value than the query is called with";
+            return false;
+        }
+
+        return true;
+    }
+
+    bool IsExactEquality(IMethodSymbol method)
+    {
+        var definition = DotNetInvocations.DefinitionOf(method);
+        return definition.ContainingType.ToDisplayString() == ShouldEqualityExtensionsType &&
+            definition.Name == ShouldEqualMethod &&
+            definition.IsExtensionMethod &&
+            definition.TypeParameters.Length == 1 &&
+            definition.Parameters is [var actual, var expected] &&
+            SymbolEqualityComparer.Default.Equals(actual.Type, definition.TypeParameters[0]) &&
+            SymbolEqualityComparer.Default.Equals(expected.Type, definition.TypeParameters[0]);
+    }
+
+    bool LooksLikeStageQueryCall(IMethodSymbol method) =>
+        method.Parameters.Count(_ => _.Type.Is(WellKnownTypeNames.ReadModels)) == 1 &&
+        method.Parameters.Count(QueryReader.IsInput) == 1 &&
+        (QueryReader.IsReadModel(method.ContainingType) || ReturnsReadModel(method));
+
+    bool IsSupportedResultProperty(IPropertySymbol property)
+    {
+        if (!IsNonNullableScalar(property.Type))
+        {
+            return false;
+        }
+
+        if (property.Type.TypeKind == TypeKind.Enum)
+        {
+            return true;
+        }
+
+        if (property.Type is not INamedTypeSymbol named)
+        {
+            return false;
+        }
+
+        if (IsExactStagePrimitive(named))
+        {
+            return true;
+        }
+
+        return named.FindBase(WellKnownTypeNames.ConceptAs) is { TypeArguments: [var backing] } &&
+            IsNonNullableScalar(backing) &&
+            (backing.TypeKind == TypeKind.Enum ||
+             (backing is INamedTypeSymbol namedBacking && IsExactStagePrimitive(namedBacking)));
+    }
+
+    ITypeSymbol TypeOf(IFieldSymbol symbol) => symbol.Type;
+
+    bool HasEveryExpectedValue(INamedTypeSymbol type, PropertyMappingModel[] values)
+    {
+        var properties = type.DeclaredProperties().ToArray();
+        return properties.Length == values.Length &&
+            properties.Zip(values).All(pair => string.Equals(pair.First.Name, pair.Second.Property, StringComparison.Ordinal));
+    }
+
+    bool ContainsTransport(ITypeSymbol type)
+    {
+        var current = type;
+        while (true)
+        {
+            if (QueryReturnTypes.IsTransport(current))
+            {
+                return true;
+            }
+
+            if (current is not INamedTypeSymbol { TypeArguments: [var wrapped] })
+            {
+                return false;
+            }
+
+            current = wrapped;
+        }
+    }
+
+    ExpressionSyntax Unwrap(ExpressionSyntax expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    expression = parenthesized.Expression;
+                    break;
+                case PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression } suppressed:
+                    expression = suppressed.Operand;
+                    break;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    sealed record QueryAttempt(
+        AwaitExpressionSyntax Await,
+        InvocationExpressionSyntax Invocation,
+        IMethodSymbol Method,
+        SemanticModel SemanticModel,
+        SyntaxNode Body,
+        IReadOnlyList<SpecificationQueryCatalog.Entry> Matches);
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReadModelOutcomeValues.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReadModelOutcomeValues.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Screenplay.Analysis.Specifications;
+
+/// <summary>
+/// Reads exact values asserted against a generated read-model scenario instance.
+/// </summary>
+static class SpecificationReadModelOutcomeValues
+{
+    const string ScenarioType = "Cratis.Chronicle.Testing.ReadModels.ReadModelScenario`1";
+    const string AssertionType = "Cratis.Specifications.ShouldEqualityExtensions";
+
+    /// <summary>
+    /// Reads the exact generated read-model outcome and its source evidence.
+    /// </summary>
+    /// <param name="type">The authored scenario type.</param>
+    /// <param name="steps">The type carrying the scenario fields and methods.</param>
+    /// <param name="readModel">The exact read model type.</param>
+    /// <param name="models">The semantic models owning the scenario bodies.</param>
+    /// <param name="draft">The scenario collecting exact value evidence.</param>
+    /// <param name="values">The values in read-model declaration order.</param>
+    /// <param name="source">The exact read-model type-argument source.</param>
+    /// <param name="reason">The blocking reason when the outcome is not exact.</param>
+    /// <returns><see langword="true"/> when every public read-model property is asserted exactly once.</returns>
+    public static bool TryRead(
+        INamedTypeSymbol type,
+        INamedTypeSymbol steps,
+        INamedTypeSymbol readModel,
+        SemanticModels models,
+        SpecificationDraft draft,
+        out IReadOnlyList<PropertyMappingModel> values,
+        out Location? source,
+        out string? reason)
+    {
+        values = [];
+        source = null;
+        reason = null;
+        var scenarioFields = steps.GetMembers()
+            .OfType<IFieldSymbol>()
+            .Where(field => IsScenario(field.Type, readModel))
+            .ToArray();
+        if (scenarioFields.Length != 1 || TypeArgumentSource(scenarioFields[0]) is not { } scenarioSource)
+        {
+            reason = "the read-model scenario field or its exact type argument is missing or ambiguous";
+            return false;
+        }
+
+        var expectedProperties = readModel.DeclaredProperties().ToArray();
+        var recovered = new Dictionary<string, (PropertyMappingModel Value, Location Source)>(StringComparer.Ordinal);
+        foreach (var assertion in SpecificationMembers.AssertionsIn(type))
+        {
+            foreach (var body in HandlerBodies.Of(assertion))
+            {
+                if (models.For(body.SyntaxTree) is not { } semanticModel)
+                {
+                    reason = "an assertion has no exact semantic model";
+                    return false;
+                }
+
+                foreach (var invocation in body.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>())
+                {
+                    var method = DotNetInvocations.MethodFor(invocation, semanticModel);
+                    var receiver = method is null ? null : DotNetInvocations.ReceiverFor(invocation, method, semanticModel);
+                    if (!TryReadProperty(receiver, semanticModel, scenarioFields[0], expectedProperties, out var property))
+                    {
+                        continue;
+                    }
+
+                    if (!StepsTaken.Always(invocation, body))
+                    {
+                        reason = $"the read-model property '{property!.Name}' is asserted conditionally";
+                        return false;
+                    }
+
+                    if (!IsExactEquality(method!))
+                    {
+                        reason = $"the read-model property '{property!.Name}' does not use the exact allowlisted equality assertion";
+                        return false;
+                    }
+
+                    if (DotNetInvocations.ArgumentForParameter(invocation, method!, "expected", semanticModel)?.Expression is not { } expected ||
+                        semanticModel.GetConstantValue(expected) is not { HasValue: true } constant)
+                    {
+                        reason = $"the read-model property '{property!.Name}' is not asserted with an exact constant";
+                        return false;
+                    }
+
+                    var value = constant.Value;
+                    if (EnumConstants.IsEnumeration(property!.Type))
+                    {
+                        if (!EnumConstants.TryResolve(property.Type, constant.Value, out var enumeration))
+                        {
+                            reason = $"the read-model property '{property.Name}' names no exact enumeration member";
+                            return false;
+                        }
+
+                        value = enumeration;
+                    }
+
+                    if (!recovered.TryAdd(property.Name, (new(property.Name, new LiteralSource(value)), expected.GetLocation())))
+                    {
+                        reason = $"the read-model property '{property.Name}' is asserted repeatedly";
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if (expectedProperties.Length == 0 ||
+            recovered.Count != expectedProperties.Length ||
+            expectedProperties.Any(property => !recovered.ContainsKey(property.Name)))
+        {
+            reason = "the generated scenario does not assert every public read-model property exactly once";
+            return false;
+        }
+
+        var ordered = expectedProperties.Select(property => recovered[property.Name]).ToArray();
+        foreach (var item in ordered)
+        {
+            draft.AddValue(item.Value, item.Source);
+        }
+
+        values = [.. ordered.Select(_ => _.Value)];
+        source = scenarioSource;
+        return true;
+    }
+
+    static bool IsScenario(ITypeSymbol type, INamedTypeSymbol readModel) =>
+        type is INamedTypeSymbol { TypeArguments: [var argument] } named &&
+        $"{named.OriginalDefinition.ContainingNamespace.ToDisplayString()}.{named.OriginalDefinition.MetadataName}" == ScenarioType &&
+        SymbolEqualityComparer.Default.Equals(argument, readModel);
+
+    static Location? TypeArgumentSource(IFieldSymbol field) =>
+        field.DeclaringSyntaxReferences
+            .Select(reference => reference.GetSyntax())
+            .OfType<VariableDeclaratorSyntax>()
+            .Select(variable => variable.Parent as VariableDeclarationSyntax)
+            .SelectMany(declaration => declaration?.Type.DescendantNodesAndSelf().OfType<GenericNameSyntax>() ?? [])
+            .Where(generic => generic.Identifier.ValueText == "ReadModelScenario" && generic.TypeArgumentList.Arguments.Count == 1)
+            .Select(generic => generic.TypeArgumentList.Arguments[0].GetLocation())
+            .SingleOrDefault();
+
+    static bool TryReadProperty(
+        ExpressionSyntax? expression,
+        SemanticModel semanticModel,
+        IFieldSymbol scenarioField,
+        IReadOnlyList<IPropertySymbol> expectedProperties,
+        out IPropertySymbol? property)
+    {
+        property = null;
+        expression = expression is null ? null : Unwrap(expression);
+        if (expression is not MemberAccessExpressionSyntax member ||
+            semanticModel.GetSymbolInfo(member).Symbol is not IPropertySymbol candidate ||
+            !expectedProperties.Any(property => SymbolEqualityComparer.Default.Equals(property, candidate)))
+        {
+            return false;
+        }
+
+        if (Unwrap(member.Expression) is not MemberAccessExpressionSyntax instance ||
+            semanticModel.GetSymbolInfo(instance).Symbol is not IPropertySymbol { Name: "Instance" } ||
+            !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(Unwrap(instance.Expression)).Symbol, scenarioField))
+        {
+            return false;
+        }
+
+        property = candidate;
+        return true;
+    }
+
+    static bool IsExactEquality(IMethodSymbol method)
+    {
+        var definition = DotNetInvocations.DefinitionOf(method);
+        return definition.ContainingType.ToDisplayString() == AssertionType &&
+            definition.Name == "ShouldEqual" &&
+            definition.IsExtensionMethod &&
+            definition.TypeParameters.Length == 1 &&
+            definition.Parameters is [var actual, var expected] &&
+            SymbolEqualityComparer.Default.Equals(actual.Type, definition.TypeParameters[0]) &&
+            SymbolEqualityComparer.Default.Equals(expected.Type, definition.TypeParameters[0]);
+    }
+
+    static ExpressionSyntax Unwrap(ExpressionSyntax expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    expression = parenthesized.Expression;
+                    break;
+                case PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression } suppressed:
+                    expression = suppressed.Operand;
+                    break;
+                default:
+                    return expression;
+            }
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
@@ -89,9 +89,24 @@ public class SpecificationReader(SemanticModels models, ScreenplayDiagnostics di
         reader.ReadWhen(steps, draft, name, location);
         new SpecificationOutcomeReader(models, stated).Read(type, draft, name, location);
 
-        if (readModel is not null && draft.When is null)
+        if (readModel is INamedTypeSymbol namedReadModel && draft.When is null)
         {
-            ReadStateOfTheReadModel(readModel, draft);
+            if (SpecificationReadModelOutcomeValues.TryRead(
+                    type,
+                    steps,
+                    namedReadModel,
+                    models,
+                    draft,
+                    out var values,
+                    out var source,
+                    out var reason))
+            {
+                ReadStateOfTheReadModel(namedReadModel, values, source!, draft);
+            }
+            else
+            {
+                draft.CannotRead(reason!);
+            }
         }
         else if (draft.When is null)
         {
@@ -132,27 +147,42 @@ public class SpecificationReader(SemanticModels models, ScreenplayDiagnostics di
     /// </summary>
     /// <param name="type">The type to check.</param>
     /// <returns>True when the type is shaped like a specification.</returns>
-    static bool IsWrittenAsOne(INamedTypeSymbol type) =>
-        type is { TypeKind: TypeKind.Class, IsAbstract: false, ContainingType: null } &&
-        SpecificationMembers.MethodsIn(SpecificationMembers.StepsOf(type), SpecificationMembers.BecauseMethod).Any();
+    static bool IsWrittenAsOne(INamedTypeSymbol type)
+    {
+        if (type is not { TypeKind: TypeKind.Class, IsAbstract: false, ContainingType: null })
+        {
+            return false;
+        }
+
+        var steps = SpecificationMembers.StepsOf(type);
+        return SpecificationMembers.MethodsIn(steps, SpecificationMembers.BecauseMethod).Any() ||
+               (SpecificationMembers.ReadModelOf(steps) is not null &&
+                SpecificationMembers.MethodsIn(steps, SpecificationMembers.EstablishMethod).Any());
+    }
 
     /// <summary>
     /// States the read model a scenario is about as what followed the events it started from.
     /// </summary>
     /// <param name="readModel">The read model the scenario is of.</param>
+    /// <param name="values">Every exact read-model value asserted by the generated scenario.</param>
+    /// <param name="source">The exact read-model scenario type-argument source.</param>
     /// <param name="draft">The scenario collected so far.</param>
     /// <remarks>
     /// A scenario of a read model has no command to issue - the events are what happened and the model is what they
     /// built - so what it says is the two halves the language already holds: <c>given</c> the events, and then the
-    /// <c>readmodel</c> they left behind. Which values the model ended up with is asserted in the host language
-    /// against the instance the scenario holds, and stays unsaid for the same reason the values of an event do.
+    /// <c>readmodel</c> they left behind. Generated assertions against the scenario instance state every resulting
+    /// value exactly; an incomplete, repeated, conditional, or computed assertion blocks the whole scenario.
     /// <para>
     /// A scenario stating nothing that had happened is left out rather than written, because a read model with no
     /// events behind it is the empty one every read model starts as, and saying so describes nothing the application
     /// does.
     /// </para>
     /// </remarks>
-    static void ReadStateOfTheReadModel(ITypeSymbol readModel, SpecificationDraft draft)
+    static void ReadStateOfTheReadModel(
+        ITypeSymbol readModel,
+        IReadOnlyList<PropertyMappingModel> values,
+        Location source,
+        SpecificationDraft draft)
     {
         if (draft.Given.Count == 0)
         {
@@ -160,11 +190,8 @@ public class SpecificationReader(SemanticModels models, ScreenplayDiagnostics di
             return;
         }
 
-        var state = new SpecificationStateModel(readModel.Name, SpecificationStateKind.ReadModel, []);
-        draft.AddThen(
-            state,
-            readModel,
-            readModel.Locations.First(location => location.IsInSource));
+        var state = new SpecificationStateModel(readModel.Name, SpecificationStateKind.ReadModel, values);
+        draft.AddThen(state, readModel, source);
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationValues.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationValues.cs
@@ -38,18 +38,34 @@ public class SpecificationValues(ScreenplayDiagnostics diagnostics, GeneratedIde
         ITypeSymbol type,
         string specification,
         string location,
-        SpecificationDraft draft)
-    {
-        var values = new List<PropertyMappingModel>();
-        var constructor = semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol;
+        SpecificationDraft draft) =>
+        Read(creation, semanticModel, type, type, specification, location, draft, queryValues: false);
 
-        foreach (var (name, expression) in Stated(creation, constructor))
-        {
-            Add(values, PropertyOf(type, name), expression, semanticModel, type, specification, location, draft);
-        }
-
-        return values;
-    }
+    /// <summary>
+    /// Reads the values one exact Stage-generated query result construction states.
+    /// </summary>
+    /// <param name="creation">The construction to read.</param>
+    /// <param name="semanticModel">The semantic model of the tree the construction lives in.</param>
+    /// <param name="type">The type being constructed in the specification compilation.</param>
+    /// <param name="sourceType">The corresponding exact type declared by the application.</param>
+    /// <param name="specification">The name of the specification, for use in diagnostics.</param>
+    /// <param name="location">Where the specification lives, for use in diagnostics.</param>
+    /// <param name="draft">The scenario collecting exact value evidence.</param>
+    /// <returns>The values, in the order the source declares them.</returns>
+    /// <remarks>
+    /// Query specifications additionally admit the direct concept and framework parse syntax Stage emits. Existing
+    /// command, event, and read-model readers continue through the legacy path and retain their original source
+    /// contract.
+    /// </remarks>
+    public IEnumerable<PropertyMappingModel> ReadQuery(
+        BaseObjectCreationExpressionSyntax creation,
+        SemanticModel semanticModel,
+        ITypeSymbol type,
+        ITypeSymbol sourceType,
+        string specification,
+        string location,
+        SpecificationDraft draft) =>
+        Read(creation, semanticModel, type, sourceType, specification, location, draft, queryValues: true);
 
     /// <summary>
     /// Gets every value a construction states, from its arguments and from its initializer.
@@ -101,9 +117,34 @@ public class SpecificationValues(ScreenplayDiagnostics diagnostics, GeneratedIde
     /// </summary>
     /// <param name="type">The type being constructed.</param>
     /// <param name="name">The name to resolve.</param>
+    /// <param name="exact">Whether only exact Stage-authored casing is admitted.</param>
     /// <returns>The property name.</returns>
-    static string PropertyOf(ITypeSymbol type, string name) =>
-        type.DeclaredProperties().FirstOrDefault(_ => string.Equals(_.Name, name, StringComparison.OrdinalIgnoreCase))?.Name ?? name;
+    static string PropertyOf(ITypeSymbol type, string name, bool exact) =>
+        type.DeclaredProperties().FirstOrDefault(_ => string.Equals(
+            _.Name,
+            name,
+            exact ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))?.Name ?? name;
+
+    List<PropertyMappingModel> Read(
+        BaseObjectCreationExpressionSyntax creation,
+        SemanticModel semanticModel,
+        ITypeSymbol type,
+        ITypeSymbol sourceType,
+        string specification,
+        string location,
+        SpecificationDraft draft,
+        bool queryValues)
+    {
+        var values = new List<PropertyMappingModel>();
+        var constructor = semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol;
+
+        foreach (var (name, expression) in Stated(creation, constructor))
+        {
+            Add(values, PropertyOf(type, name, queryValues), expression, semanticModel, type, sourceType, specification, location, draft, queryValues);
+        }
+
+        return values;
+    }
 
     /// <summary>
     /// Adds a value, reporting one that is code rather than stating it as something it is not.
@@ -112,10 +153,12 @@ public class SpecificationValues(ScreenplayDiagnostics diagnostics, GeneratedIde
     /// <param name="property">The property being filled in.</param>
     /// <param name="expression">The expression filling it in.</param>
     /// <param name="semanticModel">The semantic model of the tree the expression lives in.</param>
-    /// <param name="type">The type being constructed.</param>
+    /// <param name="type">The type being constructed in the specification compilation.</param>
+    /// <param name="sourceType">The corresponding exact type declared by the application.</param>
     /// <param name="specification">The name of the specification.</param>
     /// <param name="location">Where the specification lives.</param>
     /// <param name="draft">The scenario collecting exact value evidence.</param>
+    /// <param name="queryValues">Whether the additive Stage query literal syntax is admitted.</param>
     /// <remarks>
     /// An identity made on the spot is left out without a word, because there is no value for the document to have
     /// missed - see <see cref="GeneratedIdentities"/>. Every other value that cannot be read is one the source states
@@ -127,11 +170,26 @@ public class SpecificationValues(ScreenplayDiagnostics diagnostics, GeneratedIde
         ExpressionSyntax expression,
         SemanticModel semanticModel,
         ITypeSymbol type,
+        ITypeSymbol sourceType,
         string specification,
         string location,
-        SpecificationDraft draft)
+        SpecificationDraft draft,
+        bool queryValues)
     {
-        if (_sources.Read(expression, semanticModel, type, location) is LiteralSource literal)
+        var localProperty = type.DeclaredProperties().SingleOrDefault(_ => string.Equals(_.Name, property, StringComparison.Ordinal));
+        var sourceProperty = sourceType.DeclaredProperties().SingleOrDefault(_ => string.Equals(_.Name, property, StringComparison.Ordinal));
+        LiteralSource? literal;
+        if (queryValues)
+        {
+            literal = localProperty is not null && sourceProperty is not null
+                ? _sources.ReadQueryLiteral(expression, semanticModel, localProperty.Type, sourceProperty.Type)
+                : null;
+        }
+        else
+        {
+            literal = _sources.Read(expression, semanticModel, type, location) as LiteralSource;
+        }
+        if (literal is not null)
         {
             var value = new PropertyMappingModel(property, literal);
             values.Add(value);

--- a/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
+++ b/Source/DotNET/Screenplay/Analysis/WellKnownTypeNames.cs
@@ -42,6 +42,12 @@ public static class WellKnownTypeNames
     /// <summary>The base type every strongly typed domain value derives from.</summary>
     public const string ConceptAs = "Cratis.Concepts.ConceptAs`1";
 
+    /// <summary>The generic base type every strongly typed event-source identifier derives from.</summary>
+    public const string EventSourceIdOfT = "Cratis.Chronicle.Events.EventSourceId`1";
+
+    /// <summary>The untyped event-source identifier a generated read-model substitute call casts its key to.</summary>
+    public const string EventSourceId = "Cratis.Chronicle.Events.EventSourceId";
+
     /// <summary>The attribute marking an event type.</summary>
     public const string EventTypeAttribute = "Cratis.Chronicle.Events.EventTypeAttribute";
 
@@ -161,4 +167,7 @@ public static class WellKnownTypeNames
 
     /// <summary>The attribute giving a read model or a query a route of its own rather than the conventional one.</summary>
     public const string PathAttribute = "Cratis.Arc.Queries.ModelBound.PathAttribute";
+
+    /// <summary>The interface a query reads a read model through, and the collaborator a generated query specification substitutes.</summary>
+    public const string ReadModels = "Cratis.Chronicle.ReadModels.IReadModels";
 }

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
@@ -39,7 +39,7 @@ internal sealed class ArcSpecificationArtifactFacts(
             Adapter = adapter,
             Strength = EvidenceStrength.Exact,
             Source = placement.Structure.Source,
-            Explanation = "The shared source-placement derivation places the exact scenario target"
+            Explanation = "The shared source-placement derivation places the exact scenario artifact"
         },
         Artifact = placement.Artifact,
         Placement = placement.Placement
@@ -95,9 +95,9 @@ internal sealed class ArcSpecificationArtifactFacts(
     }
 
     /// <summary>
-    /// Creates a shared placement request for the exact scenario target.
+    /// Creates a shared placement request for one exact scenario artifact.
     /// </summary>
-    /// <param name="target">The exact target artifact.</param>
+    /// <param name="target">The exact scenario artifact.</param>
     /// <param name="sliceKind">The independently established semantic slice kind.</param>
     /// <param name="policy">The host-owned source-structure policy.</param>
     /// <returns>The placement request, or <see langword="null"/> when no exact source structure exists.</returns>

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Queries;
 using Cratis.Screenplay.Generation;
 using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
@@ -52,8 +53,15 @@ internal sealed class ArcSpecificationArtifactFacts(
     /// <param name="type">The exact source type.</param>
     /// <param name="kind">The neutral artifact kind.</param>
     /// <param name="source">The referencing step source.</param>
+    /// <param name="propertyName">The optional semantic property naming conversion.</param>
+    /// <param name="typeReference">The optional slice-specific type conversion.</param>
     /// <returns>The artifact key, or <see langword="null"/> when source identity is ambiguous.</returns>
-    public ArtifactKey? Artifact(INamedTypeSymbol type, ArtifactKind kind, Location source)
+    public ArtifactKey? Artifact(
+        INamedTypeSymbol type,
+        ArtifactKind kind,
+        Location source,
+        Func<string, string>? propertyName = null,
+        Func<ITypeSymbol, TypeReferenceDefinition>? typeReference = null)
     {
         var sourceProjects = context.Projects
             .Where(project => type.DeclaringSyntaxReferences.Any(_ => project.AuthoredSyntaxTrees.Contains(_.SyntaxTree)))
@@ -83,9 +91,60 @@ internal sealed class ArcSpecificationArtifactFacts(
                     Properties = [.. type.DeclaredProperties()
                         .Select(property => new PropertyDefinition
                         {
-                            Name = property.Name,
-                            Type = TypeReference(property.Type, context)
+                            Name = propertyName?.Invoke(property.Name) ?? property.Name,
+                            Type = typeReference?.Invoke(property.Type) ?? TypeReference(property.Type, context)
                         })]
+                }
+            });
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Adds or resolves one exact method-backed query artifact.
+    /// </summary>
+    /// <param name="method">The exact application-declared query method.</param>
+    /// <param name="propertyName">The optional semantic parameter naming conversion.</param>
+    /// <returns>The query artifact key, or <see langword="null"/> when source identity is ambiguous.</returns>
+    public ArtifactKey? Query(IMethodSymbol method, Func<string, string>? propertyName = null)
+    {
+        var sourceProjects = context.Projects
+            .Where(project => project.Role == DotNetProjectRole.Application &&
+                method.DeclaringSyntaxReferences.Any(_ => project.AuthoredSyntaxTrees.Contains(_.SyntaxTree)))
+            .ToArray();
+        var source = method.Locations
+            .Where(_ => _.IsInSource)
+            .OrderBy(_ => _.SourceTree?.FilePath, StringComparer.Ordinal)
+            .ThenBy(_ => _.SourceSpan.Start)
+            .FirstOrDefault();
+        if (sourceProjects.Length != 1 || source is null)
+        {
+            return null;
+        }
+
+        var subject = sourceProjects[0].SubjectForMethod(method);
+        var key = new ArtifactKey { Subject = subject, Kind = ArtifactKind.Query };
+        if (!facts.OfType<ArtifactFact>().Any(fact => fact.Definition.Key == key))
+        {
+            var inputs = method.Parameters.Where(QueryReader.IsInput).ToArray();
+            var identifier = inputs.FirstOrDefault(_ => !_.HasExplicitDefaultValue);
+            var evidence = Evidence(source, "The exact application method declares this query");
+            facts.Add(new ArtifactFact
+            {
+                Id = FactId("artifact", subject, nameof(ArtifactKind.Query)),
+                Subject = subject,
+                Evidence = evidence,
+                Definition = new ArtifactDefinition
+                {
+                    Key = key,
+                    Name = method.Name,
+                    Properties = [.. inputs.Select(parameter => new PropertyDefinition
+                    {
+                        Name = propertyName?.Invoke(parameter.Name) ?? parameter.Name,
+                        Type = QueryTypeReference(parameter.Type, context),
+                        IsIdentifier = SymbolEqualityComparer.Default.Equals(parameter, identifier)
+                    })]
                 }
             });
         }
@@ -99,19 +158,23 @@ internal sealed class ArcSpecificationArtifactFacts(
     /// <param name="target">The exact scenario artifact.</param>
     /// <param name="sliceKind">The independently established semantic slice kind.</param>
     /// <param name="policy">The host-owned source-structure policy.</param>
+    /// <param name="sourceOwner">The exact type owning a method-backed artifact's source placement, when the artifact does not own it.</param>
     /// <returns>The placement request, or <see langword="null"/> when no exact source structure exists.</returns>
     public DotNetSourcePlacementRequest? PlacementRequest(
         ArtifactKey target,
         GenerationSliceKind sliceKind,
-        DotNetSourceStructurePolicy policy)
+        DotNetSourceStructurePolicy policy,
+        SubjectId? sourceOwner = null)
     {
-        var structure = sourceStructures.Structures.SingleOrDefault(_ => _.Subject == target.Subject);
+        var structureSubject = sourceOwner ?? target.Subject;
+        var structure = sourceStructures.Structures.SingleOrDefault(_ => _.Subject == structureSubject);
         return structure is null
             ? null
             : new()
             {
                 Artifact = target,
                 Structure = structure,
+                SourceOwner = sourceOwner,
                 SliceKind = sliceKind,
                 Policy = policy
             };

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationArtifactFacts.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Screenplay.Analysis;
 using Cratis.Screenplay.Generation;
 using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
@@ -79,9 +80,7 @@ internal sealed class ArcSpecificationArtifactFacts(
                     Key = key,
                     Name = type.Name,
                     File = evidence.Source?.Path,
-                    Properties = [.. type.GetMembers().OfType<IPropertySymbol>()
-                        .Where(property => !property.IsStatic)
-                        .OrderBy(property => property.Name, StringComparer.Ordinal)
+                    Properties = [.. type.DeclaredProperties()
                         .Select(property => new PropertyDefinition
                         {
                             Name = property.Name,

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationEventPlacement.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationEventPlacement.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Commands;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Proves whether an event is produced by an exact model-bound command handler.
+/// </summary>
+static class ArcSpecificationEventPlacement
+{
+    /// <summary>
+    /// Determines whether a command handler signature proves the event belongs to a StateChange slice.
+    /// </summary>
+    /// <param name="context">The analyzed source context.</param>
+    /// <param name="eventType">The exact event type.</param>
+    /// <returns><see langword="true"/> when one authored command handler returns the event.</returns>
+    public static bool IsStateChangeEvent(DotNetAnalysisContext context, INamedTypeSymbol eventType) =>
+        context.Projects
+            .Where(project => project.Role == DotNetProjectRole.Application)
+            .SelectMany(project => ArtifactCatalog.From(project.Compilation).Types)
+            .Where(CommandReader.IsCommand)
+            .SelectMany(command => command.GetMembers(CommandReader.HandleMethod)
+                .OfType<IMethodSymbol>()
+                .Where(method => method is { MethodKind: MethodKind.Ordinary, IsStatic: false }))
+            .SelectMany(method => HandlerBodies.EventTypesIn(method.ReturnType))
+            .Any(produced => SymbolEqualityComparer.Default.Equals(produced, eventType));
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationEvidence.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationEvidence.cs
@@ -47,13 +47,25 @@ internal sealed class ArcSpecificationEvidence(
     /// <param name="evidence">The exact scenario evidence.</param>
     /// <param name="reason">The blocking reason.</param>
     public void Block(SpecificationModel specification, SpecificationScenarioEvidence evidence, string reason) =>
+        Block(specification.Name, evidence.SourceType, evidence.Source, reason);
+
+    /// <summary>
+    /// Reports one exact query scenario that contributes no partial neutral facts.
+    /// </summary>
+    /// <param name="name">The recovered scenario name.</param>
+    /// <param name="evidence">The exact query scenario evidence.</param>
+    /// <param name="reason">The blocking reason.</param>
+    public void Block(string name, SpecificationQueryEvidence evidence, string reason) =>
+        Block(name, evidence.SourceType, evidence.Source, reason);
+
+    void Block(string name, INamedTypeSymbol sourceType, Location source, string reason) =>
         diagnostics.Add(new GenerationDiagnostic
         {
             Code = "ARCSP0001",
             Severity = GenerationDiagnosticSeverity.Warning,
             Outcome = GenerationDiagnosticOutcome.Unsupported,
-            Message = $"Specification '{specification.Name}' contributed no neutral scenario because {reason}",
-            Source = For(evidence.Source).Source,
-            Subject = scenarioProject.SubjectForType(evidence.SourceType)
+            Message = $"Specification '{name}' contributed no neutral scenario because {reason}",
+            Source = For(source).Source,
+            Subject = scenarioProject.SubjectForType(sourceType)
         });
 }

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
@@ -74,12 +74,14 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
             }
         }
 
-        var placements = DotNetSourcePlacementDerivation.Derive(candidates.Select(_ => _.PlacementRequest));
+        var placements = DotNetSourcePlacementDerivation.Derive(candidates.SelectMany(_ => _.PlacementRequests));
         diagnostics.AddRange(placements.Diagnostics);
         foreach (var candidate in candidates)
         {
-            var placement = placements.Placements.SingleOrDefault(_ => _.Artifact == candidate.PlacementRequest.Artifact);
-            if (placement is null)
+            var candidatePlacements = candidate.PlacementRequests
+                .Select(request => placements.Placements.SingleOrDefault(_ => _.Artifact == request.Artifact))
+                .ToArray();
+            if (candidatePlacements.Any(_ => _ is null))
             {
                 continue;
             }
@@ -92,10 +94,13 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
                 }
             }
 
-            var placementFact = ArcSpecificationArtifactFacts.Placement(Identity, placement);
-            if (!facts.Exists(_ => _.Id == placementFact.Id))
+            foreach (var placement in candidatePlacements.OfType<DotNetSourcePlacement>())
             {
-                facts.Add(placementFact);
+                var placementFact = ArcSpecificationArtifactFacts.Placement(Identity, placement);
+                if (!facts.Exists(_ => _.Id == placementFact.Id))
+                {
+                    facts.Add(placementFact);
+                }
             }
         }
 

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactAdapter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Queries;
 using Cratis.Arc.Screenplay.Analysis.Specifications;
 using Cratis.Screenplay.Generation;
 using Cratis.Screenplay.Generation.DotNet;
@@ -21,10 +22,15 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
     public AdapterIdentity Identity { get; } = new() { Id = AdapterId, Version = AdapterVersion };
 
     /// <inheritdoc/>
-    public bool CanAnalyze(DotNetAnalysisContext context) =>
-        context.Projects.SelectMany(project => ArtifactCatalog.From(project.Compilation).Types)
-            .Any(type => SpecificationMembers.CommandOf(SpecificationMembers.StepsOf(type)) is not null ||
-                         SpecificationMembers.ReadModelOf(SpecificationMembers.StepsOf(type)) is not null);
+    public bool CanAnalyze(DotNetAnalysisContext context)
+    {
+        var types = context.Projects.SelectMany(project => ArtifactCatalog.From(project.Compilation).Types).ToArray();
+        var hasLegacySpecification = types.Any(type =>
+            SpecificationMembers.CommandOf(SpecificationMembers.StepsOf(type)) is not null ||
+            SpecificationMembers.ReadModelOf(SpecificationMembers.StepsOf(type)) is not null);
+        var hasQuerySpecification = SpecificationQueryCatalog.From(context).Count > 0 && types.Any(IsQuerySpecificationShape);
+        return hasLegacySpecification || hasQuerySpecification;
+    }
 
     /// <inheritdoc/>
     public AdapterContribution Analyze(DotNetAnalysisContext context, DotNetAdapterOptions options)
@@ -37,39 +43,63 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
         var models = new SemanticModels([.. context.Projects.Select(project => project.Compilation)]);
         var readerDiagnostics = new ScreenplayDiagnostics();
         var reader = new SpecificationReader(models, readerDiagnostics);
+        var queryReader = new SpecificationQueryReader(models, SpecificationQueryCatalog.From(context));
 
         foreach (var project in context.Projects)
         {
-            foreach (var type in ArtifactCatalog.From(project.Compilation).Types.Where(reader.IsSpecification))
+            foreach (var type in ArtifactCatalog.From(project.Compilation).Types)
             {
-                var steps = SpecificationMembers.StepsOf(type);
-                var target = SpecificationMembers.CommandOf(steps) ?? SpecificationMembers.ReadModelOf(steps);
-                if (target is not INamedTypeSymbol namedTarget)
+                if (reader.IsSpecification(type))
                 {
+                    var steps = SpecificationMembers.StepsOf(type);
+                    var target = SpecificationMembers.CommandOf(steps) ?? SpecificationMembers.ReadModelOf(steps);
+                    if (target is not INamedTypeSymbol namedTarget)
+                    {
+                        continue;
+                    }
+
+                    var slice = namedTarget.ContainingNamespace.ToDisplayString();
+                    var name = SpecificationPlacement.NameOf(type, slice);
+                    var diagnosticCount = readerDiagnostics.All.Count;
+                    if (reader.Read(type, name) is not { } specification)
+                    {
+                        var reason = string.Join("; ", readerDiagnostics.All.Skip(diagnosticCount).Select(item => item.Message));
+                        diagnostics.Add(Unreadable(project, type, reason));
+                        continue;
+                    }
+
+                    if (SpecificationEvidence.For(specification) is not { } evidence)
+                    {
+                        diagnostics.Add(Unreadable(project, type, "source evidence was not retained"));
+                        continue;
+                    }
+
+                    var candidate = new ArcSpecificationFactBuilder(context, project, Identity, options, sourceStructures, diagnostics)
+                        .Build(specification, evidence, namedTarget);
+                    if (candidate is not null)
+                    {
+                        candidates.Add(candidate);
+                    }
+
                     continue;
                 }
 
-                var slice = namedTarget.ContainingNamespace.ToDisplayString();
-                var name = SpecificationPlacement.NameOf(type, slice);
-                var diagnosticCount = readerDiagnostics.All.Count;
-                if (reader.Read(type, name) is not { } specification)
+                if (queryReader.TryRead(type, out var queryEvidence, out var queryReason))
                 {
-                    var reason = string.Join("; ", readerDiagnostics.All.Skip(diagnosticCount).Select(item => item.Message));
-                    diagnostics.Add(Unreadable(project, type, reason));
+                    var queryName = SpecificationPlacement.NameOf(type, queryEvidence!.ReadModel.ContainingNamespace.ToDisplayString());
+                    var queryCandidate = new ArcSpecificationQueryFactBuilder(context, project, Identity, options, sourceStructures, diagnostics)
+                        .Build(queryName, queryEvidence);
+                    if (queryCandidate is not null)
+                    {
+                        candidates.Add(queryCandidate);
+                    }
+
                     continue;
                 }
 
-                if (SpecificationEvidence.For(specification) is not { } evidence)
+                if (queryReason is not null)
                 {
-                    diagnostics.Add(Unreadable(project, type, "source evidence was not retained"));
-                    continue;
-                }
-
-                var candidate = new ArcSpecificationFactBuilder(context, project, Identity, options, sourceStructures, diagnostics)
-                    .Build(specification, evidence, namedTarget);
-                if (candidate is not null)
-                {
-                    candidates.Add(candidate);
+                    diagnostics.Add(Unreadable(project, type, queryReason));
                 }
             }
         }
@@ -111,6 +141,11 @@ public sealed class ArcSpecificationFactAdapter : IDotNetScreenplayAdapter
             Diagnostics = diagnostics
         };
     }
+
+    static bool IsQuerySpecificationShape(INamedTypeSymbol type) =>
+        type is { TypeKind: TypeKind.Class, IsAbstract: false, ContainingType: null } &&
+        SpecificationMembers.MethodsIn(SpecificationMembers.StepsOf(type), SpecificationMembers.BecauseMethod).Any() &&
+        SpecificationMembers.AssertionsIn(type).Any();
 
     GenerationDiagnostic Unreadable(DotNetProjectCompilation project, INamedTypeSymbol type, string reason) => new()
     {

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
@@ -30,6 +30,7 @@ internal sealed class ArcSpecificationFactBuilder(
     List<GenerationDiagnostic> diagnostics)
 {
     readonly List<GenerationFact> _facts = [];
+    readonly Dictionary<ArtifactKey, INamedTypeSymbol> _artifactTypes = [];
     readonly ArcSpecificationEvidence _sourceEvidence = new(context, scenarioProject, adapter, diagnostics);
 
     ArcSpecificationArtifactFacts ArtifactFacts => new(context, scenarioProject, adapter, sourceStructures, _facts);
@@ -128,15 +129,20 @@ internal sealed class ArcSpecificationFactBuilder(
         {
             [targetKey] = sliceKind
         };
-        if (!targetsStateView)
+        var eventsToPlace = targetsStateView
+            ? stepFacts.Where(_ => _.Definition.Phase == SpecificationStepPhase.Given && _.Definition.Kind == SpecificationStepKind.Event)
+            : stepFacts.Where(_ => _.Definition.Phase == SpecificationStepPhase.Then && _.Definition.Kind == SpecificationStepKind.Event);
+        foreach (var artifact in eventsToPlace.Select(_ => _.Definition.Artifact).OfType<ArtifactKey>())
         {
-            foreach (var artifact in stepFacts
-                         .Where(_ => _.Definition.Phase == SpecificationStepPhase.Then && _.Definition.Kind == SpecificationStepKind.Event)
-                         .Select(_ => _.Definition.Artifact)
-                         .OfType<ArtifactKey>())
+            if (targetsStateView &&
+                (!_artifactTypes.TryGetValue(artifact, out var eventType) ||
+                 !ArcSpecificationEventPlacement.IsStateChangeEvent(context, eventType)))
             {
-                artifactPlacements[artifact] = GenerationSliceKind.StateChange;
+                _sourceEvidence.Block(specification, evidence, $"event '{artifact.Subject.Value}' has no exact command production proving its StateChange placement");
+                return null;
             }
+
+            artifactPlacements[artifact] = GenerationSliceKind.StateChange;
         }
 
         var placementRequests = new List<DotNetSourcePlacementRequest>();
@@ -185,6 +191,14 @@ internal sealed class ArcSpecificationFactBuilder(
             return false;
         }
 
+        if (_artifactTypes.TryGetValue(artifactKey, out var existingArtifact) &&
+            !SymbolEqualityComparer.Default.Equals(existingArtifact, artifact))
+        {
+            _sourceEvidence.Block(specification, evidence, $"step {index} resolves one artifact identity to several source types");
+            return false;
+        }
+
+        _artifactTypes[artifactKey] = artifact;
         if (kind != SpecificationStepKind.ReadModel && !HasEveryRequiredConstructionValue(artifact, state.Values.Count()))
         {
             _sourceEvidence.Block(specification, evidence, $"step {index} omits a required computed or unreadable construction value");

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactBuilder.cs
@@ -46,7 +46,7 @@ internal sealed class ArcSpecificationFactBuilder(
         SpecificationScenarioEvidence evidence,
         INamedTypeSymbol target)
     {
-        if (evidence.Blockers.Count > 0 || HasUnrepresentedEventPredicate(specification, evidence))
+        if (evidence.Blockers.Count > 0)
         {
             _sourceEvidence.Block(specification, evidence, "the existing Arc analyzer cannot prove every authored step and value exactly");
             return null;
@@ -124,18 +124,41 @@ internal sealed class ArcSpecificationFactBuilder(
         _facts.AddRange(stepFacts);
         _facts.AddRange(valueFacts);
 
-        var placement = ArtifactFacts.PlacementRequest(targetKey, sliceKind, options.SourceStructurePolicy);
-        if (placement is null)
+        var artifactPlacements = new Dictionary<ArtifactKey, GenerationSliceKind>
         {
-            if (sourceStructures.Diagnostics.Count == 0)
+            [targetKey] = sliceKind
+        };
+        if (!targetsStateView)
+        {
+            foreach (var artifact in stepFacts
+                         .Where(_ => _.Definition.Phase == SpecificationStepPhase.Then && _.Definition.Kind == SpecificationStepKind.Event)
+                         .Select(_ => _.Definition.Artifact)
+                         .OfType<ArtifactKey>())
             {
-                _sourceEvidence.Block(specification, evidence, "the target artifact has no exact shared source structure");
+                artifactPlacements[artifact] = GenerationSliceKind.StateChange;
             }
-
-            return null;
         }
 
-        return new(placement, _facts);
+        var placementRequests = new List<DotNetSourcePlacementRequest>();
+        foreach (var (artifact, artifactSliceKind) in artifactPlacements
+                     .OrderBy(_ => _.Key.Subject.Value, StringComparer.Ordinal)
+                     .ThenBy(_ => _.Key.Kind))
+        {
+            var placement = ArtifactFacts.PlacementRequest(artifact, artifactSliceKind, options.SourceStructurePolicy);
+            if (placement is null)
+            {
+                if (sourceStructures.Diagnostics.Count == 0)
+                {
+                    _sourceEvidence.Block(specification, evidence, $"artifact '{artifact.Subject.Value}' has no exact shared source structure");
+                }
+
+                return null;
+            }
+
+            placementRequests.Add(placement);
+        }
+
+        return new(placementRequests, _facts);
     }
 
     bool TryAddState(

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFactCandidate.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFactCandidate.cs
@@ -9,8 +9,8 @@ namespace Cratis.Arc.Screenplay.Generation;
 /// <summary>
 /// Represents one complete scenario contribution awaiting exact shared placement.
 /// </summary>
-/// <param name="PlacementRequest">The exact target placement request.</param>
+/// <param name="PlacementRequests">The exact artifact placement requests.</param>
 /// <param name="Facts">The scenario facts staged atomically.</param>
 internal sealed record ArcSpecificationFactCandidate(
-    DotNetSourcePlacementRequest PlacementRequest,
+    IReadOnlyList<DotNetSourcePlacementRequest> PlacementRequests,
     IReadOnlyList<GenerationFact> Facts);

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFacts.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
-using Cratis.Arc.Screenplay.Analysis.Specifications;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Generation;
 using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Cratis.Arc.Screenplay.Generation;
 
@@ -136,23 +134,6 @@ internal static class ArcSpecificationFacts
             .Max();
         return valueCount >= required;
     }
-
-    /// <summary>
-    /// Determines whether an expected event assertion contains predicate values the legacy analyzer did not retain.
-    /// </summary>
-    /// <param name="specification">The recovered specification.</param>
-    /// <param name="evidence">The exact scenario evidence.</param>
-    /// <returns><see langword="true"/> when predicate values would be lost.</returns>
-    public static bool HasUnrepresentedEventPredicate(
-        SpecificationModel specification,
-        SpecificationScenarioEvidence evidence) =>
-        specification.Then
-            .Where(state => state.Kind == SpecificationStateKind.Event)
-            .Select(state => evidence.States[state].Source)
-            .Any(location => location.SourceTree!.GetRoot().FindNode(location.SourceSpan)
-                .DescendantNodesAndSelf()
-                .OfType<LambdaExpressionSyntax>()
-                .Any());
 
     static string AdapterId(string kind) => $"cratis.arc.specifications:{kind}";
 }

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationFacts.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission.Types;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Generation;
 using Cratis.Screenplay.Generation.DotNet;
@@ -104,6 +106,24 @@ internal static class ArcSpecificationFacts
         },
         Subject = type is INamedTypeSymbol named ? context.SubjectForType(named) : null
     };
+
+    /// <summary>
+    /// Creates the exact neutral type reference admitted by Stage query specifications.
+    /// </summary>
+    /// <param name="type">The exact query parameter or result-property type.</param>
+    /// <param name="context">The analyzed application context.</param>
+    /// <returns>The neutral type reference.</returns>
+    public static TypeReferenceDefinition QueryTypeReference(ITypeSymbol type, DotNetAnalysisContext context)
+    {
+        if (type is INamedTypeSymbol named &&
+            named.TypeKind != TypeKind.Enum &&
+            ScreenplayPrimitiveTypes.TryResolve(named.FullMetadataName(), out var primitive))
+        {
+            return new() { Name = ScreenplayPrimitiveTypes.GetName(primitive) };
+        }
+
+        return TypeReference(type, context);
+    }
 
     /// <summary>
     /// Creates a stable adapter-qualified fact identity.

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationQueryFactBuilder.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationQueryFactBuilder.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Queries;
+using Cratis.Arc.Screenplay.Analysis.Specifications;
+using Cratis.Arc.Screenplay.Analysis.Types;
+using Cratis.Arc.Screenplay.Emission.Naming;
+using Cratis.Arc.Screenplay.Model;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+using static Cratis.Arc.Screenplay.Generation.ArcSpecificationFacts;
+
+namespace Cratis.Arc.Screenplay.Generation;
+
+/// <summary>
+/// Converts one exact generated query specification into an atomic neutral fact contribution.
+/// </summary>
+/// <param name="context">The analyzed application projects.</param>
+/// <param name="scenarioProject">The project declaring the scenario.</param>
+/// <param name="adapter">The adapter identity.</param>
+/// <param name="options">The host placement options.</param>
+/// <param name="sourceStructures">The fixed source-structure snapshot.</param>
+/// <param name="diagnostics">The diagnostics to append.</param>
+internal sealed class ArcSpecificationQueryFactBuilder(
+    DotNetAnalysisContext context,
+    DotNetProjectCompilation scenarioProject,
+    AdapterIdentity adapter,
+    DotNetAdapterOptions options,
+    DotNetSourceStructureSnapshot sourceStructures,
+    List<GenerationDiagnostic> diagnostics)
+{
+    readonly List<GenerationFact> _facts = [];
+    readonly ArcSpecificationEvidence _sourceEvidence = new(context, scenarioProject, adapter, diagnostics);
+    readonly ScreenplayNaming _naming = new();
+
+    ArcSpecificationArtifactFacts ArtifactFacts => new(context, scenarioProject, adapter, sourceStructures, _facts);
+
+    /// <summary>
+    /// Adds one query scenario only when every artifact, relationship, ordered value, placement, and source is exact.
+    /// </summary>
+    /// <param name="name">The recovered scenario name.</param>
+    /// <param name="evidence">The exact query scenario evidence.</param>
+    /// <returns>The complete candidate, or <see langword="null"/> when the scenario cannot be proven exactly.</returns>
+    public ArcSpecificationFactCandidate? Build(string name, SpecificationQueryEvidence evidence)
+    {
+        var scenarioSubject = scenarioProject.SubjectForType(evidence.SourceType);
+        var inputParameters = evidence.Query.Parameters.Where(QueryReader.IsInput).ToArray();
+        var resultProperties = evidence.ReadModel.DeclaredProperties().ToArray();
+        if (inputParameters.Length != evidence.Arguments.Count ||
+            inputParameters.Zip(evidence.Arguments).Any(pair => !string.Equals(pair.First.Name, pair.Second.Property, StringComparison.Ordinal)) ||
+            resultProperties.Length != evidence.Result.Count ||
+            resultProperties.Zip(evidence.Result).Any(pair => !string.Equals(pair.First.Name, pair.Second.Property, StringComparison.Ordinal)))
+        {
+            _sourceEvidence.Block(name, evidence, "the query arguments or result values lost their exact formal declaration order");
+            return null;
+        }
+
+        if (!NamesAreUnique(inputParameters.Select(_ => _.Name)) ||
+            !NamesAreUnique(resultProperties.Select(_ => _.Name)))
+        {
+            _sourceEvidence.Block(name, evidence, "two query argument or result paths normalize to the same semantic property name");
+            return null;
+        }
+
+        if (inputParameters is not [var input] ||
+            !IsNonNullableScalar(input.Type) ||
+            resultProperties.Count(property =>
+                string.Equals(_naming.ToPropertyName(property.Name), _naming.ToPropertyName(input.Name), StringComparison.Ordinal) &&
+                SymbolEqualityComparer.IncludeNullability.Equals(property.Type, input.Type) &&
+                IsNonNullableScalar(property.Type)) != 1)
+        {
+            _sourceEvidence.Block(name, evidence, "the required query input has no unique non-nullable scalar read-model key with the same normalized name and exact type");
+            return null;
+        }
+
+        var queryKey = ArtifactFacts.Query(evidence.Query, _naming.ToPropertyName);
+        var readModelKey = ArtifactFacts.Artifact(
+            evidence.ReadModel,
+            ArtifactKind.ReadModel,
+            evidence.ExpectedSource,
+            _naming.ToPropertyName,
+            type => QueryTypeReference(type, context));
+        if (queryKey is null || readModelKey is null)
+        {
+            _sourceEvidence.Block(name, evidence, "the query or read model has no unique analyzed source identity");
+            return null;
+        }
+
+        var stepKey = StepKey(scenarioSubject, 0);
+        var valueFacts = new List<SpecificationValueFact>();
+        var valueKeys = new List<SpecificationValueKey>();
+        foreach (var (parameter, value) in inputParameters.Zip(evidence.Arguments))
+        {
+            if (!TryAddValue(name, evidence, stepKey, ["arguments", _naming.ToPropertyName(parameter.Name)], parameter.Type, value, valueFacts, valueKeys))
+            {
+                return null;
+            }
+        }
+
+        foreach (var (property, value) in resultProperties.Zip(evidence.Result))
+        {
+            if (!TryAddValue(name, evidence, stepKey, ["result", "0", _naming.ToPropertyName(property.Name)], property.Type, value, valueFacts, valueKeys))
+            {
+                return null;
+            }
+        }
+
+        var querySource = evidence.Query.Locations
+            .Where(_ => _.IsInSource)
+            .OrderBy(_ => _.SourceTree?.FilePath, StringComparer.Ordinal)
+            .ThenBy(_ => _.SourceSpan.Start)
+            .FirstOrDefault();
+        if (querySource is null)
+        {
+            _sourceEvidence.Block(name, evidence, "the matched application query has no exact authored declaration");
+            return null;
+        }
+
+        _facts.Add(new RelationshipFact
+        {
+            Id = FactId("relationship", queryKey.Subject, $"Returns:{readModelKey.Subject.Value}"),
+            Subject = queryKey.Subject,
+            Evidence = _sourceEvidence.For(querySource, "The exact application query return type declares this relationship"),
+            Definition = new RelationshipDefinition
+            {
+                Key = new RelationshipKey
+                {
+                    Kind = RelationshipKind.Returns,
+                    Source = queryKey.Subject,
+                    Target = readModelKey.Subject
+                },
+                IsCollection = false,
+                IsOptional = evidence.IsOptional
+            }
+        });
+
+        var step = new SpecificationStepFact
+        {
+            Id = FactId("step", scenarioSubject, "0"),
+            Subject = StepSubject(scenarioSubject, 0),
+            Evidence = _sourceEvidence.For(evidence.QueryInvocationSource, "The exact awaited assignment performs this read"),
+            Definition = new SpecificationStepDefinition
+            {
+                Key = stepKey,
+                Phase = SpecificationStepPhase.Then,
+                Kind = SpecificationStepKind.Read,
+                Artifact = queryKey,
+                Values = valueKeys
+            }
+        };
+        _facts.Add(new SpecificationScenarioFact
+        {
+            Id = FactId("scenario", scenarioSubject),
+            Subject = scenarioSubject,
+            Evidence = _sourceEvidence.For(evidence.Source, "The authored type is an exact generated query specification"),
+            Definition = new SpecificationScenarioDefinition
+            {
+                Key = new() { Scenario = scenarioSubject },
+                Name = name,
+                TargetArtifact = queryKey,
+                Steps = [stepKey]
+            }
+        });
+        _facts.Add(step);
+        _facts.AddRange(valueFacts);
+
+        var readModelPlacement = ArtifactFacts.PlacementRequest(readModelKey, GenerationSliceKind.StateView, options.SourceStructurePolicy);
+        var queryPlacement = ArtifactFacts.PlacementRequest(queryKey, GenerationSliceKind.StateView, options.SourceStructurePolicy, readModelKey.Subject);
+        if (readModelPlacement is null || queryPlacement is null)
+        {
+            _sourceEvidence.Block(name, evidence, "the query or read model has no exact shared source structure");
+            return null;
+        }
+
+        return new([queryPlacement, readModelPlacement], _facts);
+    }
+
+    bool TryAddValue(
+        string name,
+        SpecificationQueryEvidence evidence,
+        SpecificationStepKey step,
+        IReadOnlyList<string> path,
+        ITypeSymbol type,
+        PropertyMappingModel value,
+        List<SpecificationValueFact> facts,
+        List<SpecificationValueKey> keys)
+    {
+        if (!ArcSpecificationValueFacts.TryAddQueryAt(
+                context,
+                _sourceEvidence.For,
+                evidence.ValueEvidence,
+                step,
+                path,
+                type,
+                value,
+                facts,
+                out var key,
+                out var reason))
+        {
+            _sourceEvidence.Block(name, evidence, reason!);
+            return false;
+        }
+
+        keys.Add(key!);
+        return true;
+    }
+
+    bool NamesAreUnique(IEnumerable<string> names)
+    {
+        var normalized = names.Select(_naming.ToPropertyName).ToArray();
+        return normalized.Distinct(StringComparer.Ordinal).Count() == normalized.Length;
+    }
+
+    bool IsNonNullableScalar(ITypeSymbol type) =>
+        type.NullableAnnotation != NullableAnnotation.Annotated &&
+        type is not INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } &&
+        CollectionElements.ElementOf(type) is null;
+}

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationValueFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationValueFacts.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Analysis.Types;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Generation;
 using Cratis.Screenplay.Generation.DotNet;
@@ -42,34 +43,192 @@ internal static class ArcSpecificationValueFacts
         out string? reason)
     {
         key = null;
+        var property = artifact.DeclaredProperties().SingleOrDefault(_ => string.Equals(_.Name, value.Property, StringComparison.Ordinal));
+        if (property is null)
+        {
+            reason = $"value '{artifact.Name}.{value.Property}' has no exact declared property";
+            return false;
+        }
+
+        return TryAddAt(
+            context,
+            evidenceFor,
+            valueEvidence,
+            step,
+            [value.Property],
+            property.Type,
+            value,
+            values,
+            out key,
+            out reason);
+    }
+
+    /// <summary>
+    /// Adds one exact value at its semantic path using the legacy Arc specification type conversion.
+    /// </summary>
+    /// <param name="context">The analyzed application projects.</param>
+    /// <param name="evidenceFor">The exact evidence factory.</param>
+    /// <param name="valueEvidence">Value-expression evidence by legacy model reference.</param>
+    /// <param name="step">The owning neutral step.</param>
+    /// <param name="path">The exact semantic value path.</param>
+    /// <param name="type">The exact formal type.</param>
+    /// <param name="value">The recovered exact value.</param>
+    /// <param name="values">The atomic value fact buffer.</param>
+    /// <param name="key">The value key when successful.</param>
+    /// <param name="reason">The blocking reason when unsuccessful.</param>
+    /// <returns><see langword="true"/> when the value fact was added.</returns>
+    public static bool TryAddAt(
+        DotNetAnalysisContext context,
+        Func<Location, string?, Evidence> evidenceFor,
+        IReadOnlyDictionary<PropertyMappingModel, Location> valueEvidence,
+        SpecificationStepKey step,
+        IReadOnlyList<string> path,
+        ITypeSymbol type,
+        PropertyMappingModel value,
+        List<SpecificationValueFact> values,
+        out SpecificationValueKey? key,
+        out string? reason) =>
+        TryAddAt(
+            context,
+            evidenceFor,
+            valueEvidence,
+            step,
+            path,
+            type,
+            value,
+            values,
+            TypeReference,
+            out key,
+            out reason);
+
+    /// <summary>
+    /// Adds one exact Stage query argument or result value at its semantic query path.
+    /// </summary>
+    /// <param name="context">The analyzed application projects.</param>
+    /// <param name="evidenceFor">The exact evidence factory.</param>
+    /// <param name="valueEvidence">Value-expression evidence by legacy model reference.</param>
+    /// <param name="step">The owning neutral step.</param>
+    /// <param name="path">The exact semantic query value path.</param>
+    /// <param name="type">The exact formal parameter or read-model property type.</param>
+    /// <param name="value">The recovered exact value.</param>
+    /// <param name="values">The atomic value fact buffer.</param>
+    /// <param name="key">The value key when successful.</param>
+    /// <param name="reason">The blocking reason when unsuccessful.</param>
+    /// <returns><see langword="true"/> when the value fact was added.</returns>
+    public static bool TryAddQueryAt(
+        DotNetAnalysisContext context,
+        Func<Location, string?, Evidence> evidenceFor,
+        IReadOnlyDictionary<PropertyMappingModel, Location> valueEvidence,
+        SpecificationStepKey step,
+        IReadOnlyList<string> path,
+        ITypeSymbol type,
+        PropertyMappingModel value,
+        List<SpecificationValueFact> values,
+        out SpecificationValueKey? key,
+        out string? reason)
+    {
+        if (value.Source is not LiteralSource literal || !QueryValueMatches(literal.Value, type))
+        {
+            key = null;
+            reason = $"value '{string.Join('/', path)}' does not exactly match its non-nullable scalar query type";
+            return false;
+        }
+
+        return TryAddAt(
+            context,
+            evidenceFor,
+            valueEvidence,
+            step,
+            path,
+            type,
+            value,
+            values,
+            QueryTypeReference,
+            out key,
+            out reason);
+    }
+
+    static bool TryAddAt(
+        DotNetAnalysisContext context,
+        Func<Location, string?, Evidence> evidenceFor,
+        IReadOnlyDictionary<PropertyMappingModel, Location> valueEvidence,
+        SpecificationStepKey step,
+        IReadOnlyList<string> path,
+        ITypeSymbol type,
+        PropertyMappingModel value,
+        List<SpecificationValueFact> values,
+        Func<ITypeSymbol, DotNetAnalysisContext, TypeReferenceDefinition> typeReference,
+        out SpecificationValueKey? key,
+        out string? reason)
+    {
+        key = null;
         reason = null;
         if (value.Source is not LiteralSource literal || !valueEvidence.TryGetValue(value, out var source))
         {
-            reason = $"value '{value.Property}' is not an exact authored literal";
+            reason = $"value '{string.Join('/', path)}' is not an exact authored literal";
             return false;
         }
 
-        var property = artifact.DeclaredProperties().SingleOrDefault(_ => string.Equals(_.Name, value.Property, StringComparison.Ordinal));
-        if (property is null || !TryValue(literal.Value, out var kind, out var scalar))
+        if (!TryValue(literal.Value, out var kind, out var scalar))
         {
-            reason = $"value '{artifact.Name}.{value.Property}' has an unsupported type or shape";
+            reason = $"value '{string.Join('/', path)}' has an unsupported type or shape";
             return false;
         }
 
-        key = new() { Step = step, Path = [value.Property] };
+        key = new() { Step = step, Path = [.. path] };
+        var pathText = string.Join('/', path);
         values.Add(new()
         {
-            Id = FactId("value", step.Scenario.Scenario, $"{step.Index.ToString(CultureInfo.InvariantCulture)}:{value.Property}"),
-            Subject = new SubjectId { Value = $"{step.Scenario.Scenario.Value}/step/{step.Index.ToString(CultureInfo.InvariantCulture)}/value/{value.Property}" },
-            Evidence = evidenceFor(source, "The authored construction states this exact literal value"),
+            Id = FactId("value", step.Scenario.Scenario, $"{step.Index.ToString(CultureInfo.InvariantCulture)}:{string.Join(':', path)}"),
+            Subject = new SubjectId { Value = $"{step.Scenario.Scenario.Value}/step/{step.Index.ToString(CultureInfo.InvariantCulture)}/value/{pathText}" },
+            Evidence = evidenceFor(source, "The authored expression states this exact literal value"),
             Definition = new SpecificationValueDefinition
             {
                 Key = key,
                 Kind = kind,
-                Type = TypeReference(property.Type, context),
+                Type = typeReference(type, context),
                 Scalar = scalar
             }
         });
         return true;
+    }
+
+    static bool QueryValueMatches(object? value, ITypeSymbol type)
+    {
+        if (value is null ||
+            type.NullableAnnotation == NullableAnnotation.Annotated ||
+            type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } ||
+            CollectionElements.ElementOf(type) is not null)
+        {
+            return false;
+        }
+
+        if (type.TypeKind == TypeKind.Enum)
+        {
+            return value is EnumValue enumeration &&
+                type.GetMembers(enumeration.Member).OfType<IFieldSymbol>().Any(_ => _.HasConstantValue);
+        }
+
+        if (type is not INamedTypeSymbol named)
+        {
+            return false;
+        }
+
+        if (named.FindBase(WellKnownTypeNames.ConceptAs) is { TypeArguments: [var backing] })
+        {
+            return QueryValueMatches(value, backing);
+        }
+
+        return named.FullMetadataName() switch
+        {
+            "System.Guid" => value is string text && Guid.TryParse(text, out _),
+            "System.String" => value is string,
+            "System.Int32" => value is int,
+            "System.Decimal" => value is decimal,
+            "System.Boolean" => value is bool,
+            "System.DateOnly" => value is string text && DateOnly.TryParse(text, CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out _),
+            "System.DateTimeOffset" => value is string text && DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out _),
+            _ => false
+        };
     }
 }

--- a/Source/DotNET/Screenplay/Generation/ArcSpecificationValueFacts.cs
+++ b/Source/DotNET/Screenplay/Generation/ArcSpecificationValueFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using Cratis.Arc.Screenplay.Analysis;
 using Cratis.Arc.Screenplay.Model;
 using Cratis.Screenplay.Generation;
 using Cratis.Screenplay.Generation.DotNet;
@@ -48,7 +49,7 @@ internal static class ArcSpecificationValueFacts
             return false;
         }
 
-        var property = artifact.GetMembers(value.Property).OfType<IPropertySymbol>().SingleOrDefault();
+        var property = artifact.DeclaredProperties().SingleOrDefault(_ => string.Equals(_.Name, value.Property, StringComparison.Ordinal));
         if (property is null || !TryValue(literal.Value, out var kind, out var scalar))
         {
             reason = $"value '{artifact.Name}.{value.Property}' has an unsupported type or shape";


### PR DESCRIPTION
# Summary

Completes generated Screenplay specification recovery across rejection, command/event, read-model, and query scenarios with exact source evidence and atomic fail-closed behavior.

## Added

- Recover generated command success and appended-event expectations with exact predicate values. (Cratis/Screenplay.Generation#25)
- Recover generated read-model scenarios, inherited properties, and application-proven event placement. (Cratis/Screenplay.Generation#25)
- Recover Stage-generated query specifications as query/read-model artifacts, `Returns`, StateView placement, and ordered argument/result values. (Cratis/Screenplay.Generation#25)

## Changed

- Adopt the verified Generation `0.15.0` bounded-source evidence release. (Cratis/Screenplay.Generation#25)
- Reject computed, conditional, repeated, ambiguous, incomplete, lookalike, or unsupported scenario shapes atomically with no partial facts. (Cratis/Screenplay.Generation#25)
