### PR TITLE
Link release announcements to the Cratis blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,5 @@ Arc is part of [Cratis](https://www.cratis.io) — free, MIT-licensed tools for 
 - **[Samples](https://github.com/Cratis/Samples)** — runnable event sourcing and CQRS samples for the whole stack
 
 Everything Cratis publishes today is MIT licensed and free to use.
+
+Release notes and announcements: the [Cratis blog](https://blog.cratis.io).


### PR DESCRIPTION
One-line README addition pointing at the Cratis blog. Labeled `patch` so merging cuts a patch release that publishes the updated package metadata (descriptions/tags from the discoverability wave) to the registries.