### PR TITLE
Remove documents from an observable when they leave the filter

### DIFF
--- a/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_checking_containment/and_the_document_is_in_the_set.cs
+++ b/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_checking_containment/and_the_document_is_in_the_set.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_QueryContextAwareSet.when_checking_containment;
+
+public class and_the_document_is_in_the_set : Specification
+{
+    QueryContextAwareSet<SomeClassWithSomeId> _set;
+    SomeClassWithSomeId _item;
+    bool _result;
+
+    void Establish()
+    {
+        _set = new(QueryContextBuilder.New().Build());
+        _item = new(Guid.NewGuid(), 42);
+        _set.Add(_item);
+    }
+
+    void Because() => _result = _set.Contains(_item.Id);
+
+    [Fact] void should_find_it() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_checking_containment/and_the_document_is_not_in_the_set.cs
+++ b/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_checking_containment/and_the_document_is_not_in_the_set.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_QueryContextAwareSet.when_checking_containment;
+
+public class and_the_document_is_not_in_the_set : Specification
+{
+    QueryContextAwareSet<SomeClassWithSomeId> _set;
+    SomeId _absent;
+    bool _result;
+
+    void Establish()
+    {
+        _set = new(QueryContextBuilder.New().Build());
+        _set.Add(new(Guid.NewGuid(), 42));
+        _absent = Guid.NewGuid();
+    }
+
+    void Because() => _result = _set.Contains(_absent);
+
+    [Fact] void should_not_find_it() => _result.ShouldBeFalse();
+}

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -173,12 +173,24 @@ public static class MongoCollectionExtensions
         var filterRendered = filter.Render(new(collection.DocumentSerializer, collection.Settings.SerializerRegistry));
         PrefixKeys(filterRendered);
 
+        // An insert is narrowed by the observed filter server-side: a document that never matched is
+        // of no interest to this observer and there is no reason to carry it over the wire.
+        //
+        // An update or a replace is deliberately NOT narrowed, and that is the whole point. The
+        // filter is rendered against fullDocument - the document as it is *after* the change - so
+        // narrowing update events by it discards precisely the events that say a document has left
+        // the result set. An observer watching "work that is still running" would be told when work
+        // started and never when it finished, so the finished item stayed in the observed set until
+        // the client reconnected. Membership is decided per event in HandleChange instead.
         var fullFilter = Builders<ChangeStreamDocument<TDocument>>.Filter.Or(
             Builders<ChangeStreamDocument<TDocument>>.Filter.And(
                    filterRendered,
-                   Builders<ChangeStreamDocument<TDocument>>.Filter.In(
+                   Builders<ChangeStreamDocument<TDocument>>.Filter.Eq(
                        new StringFieldDefinition<ChangeStreamDocument<TDocument>, string>("operationType"),
-                       ["insert", "replace", "update", "delete"])),
+                       "insert")),
+            Builders<ChangeStreamDocument<TDocument>>.Filter.In(
+                new StringFieldDefinition<ChangeStreamDocument<TDocument>, string>("operationType"),
+                ["replace", "update", "delete"]),
             Builders<ChangeStreamDocument<TDocument>>.Filter.Eq("fullDocument", BsonNull.Value));
 
         var pipeline = new EmptyPipelineDefinition<ChangeStreamDocument<TDocument>>().Match(fullFilter);
@@ -224,13 +236,16 @@ public static class MongoCollectionExtensions
                         try
                         {
                             await HandleChange(
+                                collection,
+                                filter,
                                 queryContext,
                                 onNext,
                                 changeDocument,
                                 query,
                                 documents,
                                 subject,
-                                idProperty);
+                                idProperty,
+                                cancellationToken);
                         }
                         catch (Exception e)
                         {
@@ -274,13 +289,16 @@ public static class MongoCollectionExtensions
     }
 
     static async Task HandleChange<TDocument, TResult>(
+        IMongoCollection<TDocument> collection,
+        FilterDefinition<TDocument> filter,
         QueryContext queryContext,
         Action<IEnumerable<TDocument>, ISubject<TResult>> onNext,
         ChangeStreamDocument<TDocument> changeDocument,
         IFindFluent<TDocument, TDocument> query,
         QueryContextAwareSet<TDocument> documents,
         ISubject<TResult> subject,
-        PropertyInfo idProperty)
+        PropertyInfo idProperty,
+        CancellationToken cancellationToken)
     {
         var hasChanges = false;
         if (changeDocument.DocumentKey is not null && changeDocument.DocumentKey.TryGetValue("_id", out var idValue))
@@ -290,14 +308,7 @@ public static class MongoCollectionExtensions
             if (changeDocument.OperationType == ChangeStreamOperationType.Delete)
             {
                 queryContext.TotalItems--;
-                if (queryContext.Paging.IsPaged)
-                {
-                    hasChanges = await documents.RemoveAndAddLastInQuery(id, query);
-                }
-                else
-                {
-                   hasChanges = documents.Remove(id);
-                }
+                hasChanges = await RemoveFromSet(queryContext, query, documents, id);
             }
             else if (changeDocument.OperationType == ChangeStreamOperationType.Insert)
             {
@@ -306,7 +317,28 @@ public static class MongoCollectionExtensions
             }
             else if (fullDocument is not null)
             {
-                hasChanges = documents.Add(fullDocument);
+                // An update or a replace. It arrives whether or not the new document still satisfies
+                // the observed filter, because an event saying a document has left the result set
+                // looks exactly like one saying it never belonged. Ask the collection which it is:
+                // one indexed lookup on the document's own key.
+                var belongs = await collection
+                    .Find(Builders<TDocument>.Filter.And(filter, Builders<TDocument>.Filter.Eq("_id", idValue)))
+                    .AnyAsync(cancellationToken);
+
+                var wasPresent = documents.Contains(id);
+                if (belongs)
+                {
+                    if (!wasPresent)
+                    {
+                        queryContext.TotalItems++;
+                    }
+                    hasChanges = documents.Add(fullDocument);
+                }
+                else if (wasPresent)
+                {
+                    queryContext.TotalItems--;
+                    hasChanges = await RemoveFromSet(queryContext, query, documents, id);
+                }
             }
         }
         if (hasChanges)
@@ -314,6 +346,24 @@ public static class MongoCollectionExtensions
             onNext(documents, subject);
         }
     }
+
+    /// <summary>
+    /// Takes a document out of the observed set, refilling the page behind it when the query is paged.
+    /// </summary>
+    /// <param name="queryContext">The <see cref="QueryContext"/> carrying the paging state.</param>
+    /// <param name="query">The sorted and paged query the refill reads from.</param>
+    /// <param name="documents">The observed set to remove from.</param>
+    /// <param name="id">The identifier of the document to remove.</param>
+    /// <typeparam name="TDocument">Type of document in the collection.</typeparam>
+    /// <returns>True when a document was removed.</returns>
+    static Task<bool> RemoveFromSet<TDocument>(
+        QueryContext queryContext,
+        IFindFluent<TDocument, TDocument> query,
+        QueryContextAwareSet<TDocument> documents,
+        object id) =>
+        queryContext.Paging.IsPaged
+            ? documents.RemoveAndAddLastInQuery(id, query)
+            : Task.FromResult(documents.Remove(id));
 
     static object GetId(PropertyInfo idProperty, BsonValue idValue)
     {

--- a/Source/DotNET/MongoDB/QueryContextAwareSet.cs
+++ b/Source/DotNET/MongoDB/QueryContextAwareSet.cs
@@ -86,6 +86,18 @@ internal sealed class QueryContextAwareSet<TDocument> : IEnumerable<TDocument>
         query.ForEachAsync(document => _items.AddLast((_getId(document), document)));
 
     /// <summary>
+    /// Whether the set currently holds a document with the given id.
+    /// </summary>
+    /// <param name="id">The id.</param>
+    /// <returns>True when the document is in the set.</returns>
+    /// <remarks>
+    /// Tells an item entering the observed result set apart from one that was already in it, which
+    /// is what keeps <see cref="QueryContext.TotalItems"/> honest when a document changes in a way
+    /// that moves it across the observed filter.
+    /// </remarks>
+    public bool Contains(object id) => _items.Any(node => _idEqualityComparer.Equals(node.Id, id));
+
+    /// <summary>
     /// Removes the document with the given id.
     /// </summary>
     /// <param name="id">The id.</param>


### PR DESCRIPTION
### Fixed

- An observable query now removes documents that stop matching its filter. The change-stream `$match` narrowed every operation type by the observed filter, but that filter is rendered against `fullDocument` — the document *after* the change — so an update that moved a document out of the result set produced an event the pipeline discarded. `HandleChange` compounded it by only ever calling `Add` on an update. The result was an observable that could only grow: an observer watching "orders still open" was told when each order opened and never when it closed, and the stale rows survived until the client reconnected. (#2617)
- `QueryContext.TotalItems` stays correct when a document moves across the observed filter, rather than counting only inserts and deletes.
