### PR TITLE
Keep useIdentity's promise to hand back details

### DIFF
--- a/Source/JavaScript/Arc.React/identity/for_useIdentity/when_the_identity_carries_details.ts
+++ b/Source/JavaScript/Arc.React/identity/for_useIdentity/when_the_identity_carries_details.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import sinon from 'sinon';
+import { useIdentity } from '../useIdentity';
+
+interface UserDetails {
+    login: string;
+}
+
+describe('when the identity carries details', () => {
+    let useContextStub: sinon.SinonStub;
+    let details: UserDetails;
+
+    beforeEach(() => {
+        useContextStub = sinon.stub(React, 'useContext').returns({
+            identity: { id: 'user', name: 'user', isSet: true, details: { login: 'ada' }, refresh: () => Promise.resolve() },
+            isLoading: false,
+            clearIdentity: () => { },
+        });
+
+        details = useIdentity<UserDetails>({ login: '' }).details;
+    });
+
+    afterEach(() => useContextStub.restore());
+
+    // The default stands in for missing details; it must never displace real ones.
+    it('should keep what the identity resolved to', () => details.login.should.equal('ada'));
+});

--- a/Source/JavaScript/Arc.React/identity/for_useIdentity/when_the_identity_resolved_without_details.ts
+++ b/Source/JavaScript/Arc.React/identity/for_useIdentity/when_the_identity_resolved_without_details.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import sinon from 'sinon';
+import { useIdentity } from '../useIdentity';
+
+interface UserDetails {
+    login: string;
+}
+
+describe('when the identity resolved without details', () => {
+    let useContextStub: sinon.SinonStub;
+    let details: UserDetails;
+
+    beforeEach(() => {
+        // An identity that came back from the endpoint - isSet is true - but carried nothing in
+        // details. Callers dereference details unguarded because the return type promises it is
+        // there, so a null here took a whole page down after the backend restarted.
+        useContextStub = sinon.stub(React, 'useContext').returns({
+            identity: { id: 'user', name: 'user', isSet: true, details: null, refresh: () => Promise.resolve() },
+            isLoading: false,
+            clearIdentity: () => { },
+        });
+
+        details = useIdentity<UserDetails>({ login: '' }).details;
+    });
+
+    afterEach(() => useContextStub.restore());
+
+    it('should stand in with the supplied default', () => details.should.deep.equal({ login: '' }));
+
+    it('should never hand back nothing', () => (details === null || details === undefined).should.be.false);
+});

--- a/Source/JavaScript/Arc.React/identity/useIdentity.ts
+++ b/Source/JavaScript/Arc.React/identity/useIdentity.ts
@@ -38,9 +38,18 @@ export function useIdentity<TDetails = object>(
     if (identity.isSet === false && actualDefaultDetails !== undefined) {
         identity.details = actualDefaultDetails!;
     }
-    
+
+    // The return type promises a TDetails, and callers dereference it without guarding precisely
+    // because of that promise. Substituting the default only when the identity is explicitly unset
+    // did not keep it: an identity that resolved while carrying no details has isSet true, so
+    // nothing stood in for the missing details and the first property access on them threw. One null
+    // reaching one call site takes the whole page down - which is how a signed-in user got a blank
+    // screen after the backend restarted. Stand in whenever there are no details to give.
+    const details = (identity.details ?? actualDefaultDetails ?? identity.details) as TDetails;
+
     return {
         ...identity,
+        details,
         // Absent means nobody is fetching - a hand-built context rather than the provider - so the
         // identity on it is as resolved as it is ever going to get.
         isLoading: contextValue.isLoading ?? false,


### PR DESCRIPTION
### Fixed

- `useIdentity` now hands back the details it promises. The default details were substituted only when the identity was explicitly unset, so an identity that resolved while carrying no details — `isSet` is true — passed `null` through to callers, even though the declared return type says `details` is a `TDetails`. That is exactly why call sites dereference it unguarded, and one `null` reaching one of them takes the whole page down: a signed-in user got a blank screen with a `TypeError` on the first property read after their backend restarted. The default now stands in whenever there are no details to give, without displacing real ones.
