### PR TITLE
Record a command's values on the causation chain

### DIFF
--- a/Documentation/backend/chronicle/code-analysis/ARCCHR0009.md
+++ b/Documentation/backend/chronicle/code-analysis/ARCCHR0009.md
@@ -1,0 +1,75 @@
+---
+title: "ARCCHR0009: Command property reads as a secret and should be marked [NotAudited]"
+description: A command carries a property whose name reads like a secret, and its value will be written to the causation of every event the command appends.
+---
+
+## Rule
+
+A command's property values are recorded on the [causation chain](../commands/causation.md) of every event it appends. This rule fires when a `[Command]` type has a public property whose name contains a word that reads as a secret — `Password`, `Token`, `ApiKey`, `Credential`, `Pin`, `Cvv` and the like — and neither the property, its positional parameter, nor the command is marked `[NotAudited]` or `[PII]`.
+
+It matches whole words, not fragments: `PasswordPolicyId` is reported, `Passenger` and `Subtotal` are not. It stays silent on anything that is not a command, and in a project without Chronicle, where nothing is written to a causation chain at all.
+
+## Severity
+
+Warning
+
+## Example
+
+### Violation
+
+```csharp
+using Cratis.Arc.Commands.ModelBound;
+
+[Command]
+public record ChangePassword(Guid UserId, string Password)
+{
+    // ARCCHR0009: 'Password' is written to the causation of every event this command appends
+    public PasswordChanged Handle(IPasswordHasher hasher) => new(hasher.Hash(Password));
+}
+```
+
+### Fix
+
+```csharp
+using Cratis.Arc.Chronicle.Commands;
+using Cratis.Arc.Commands.ModelBound;
+
+[Command]
+public record ChangePassword(Guid UserId, [property: NotAudited] string Password)
+{
+    public PasswordChanged Handle(IPasswordHasher hasher) => new(hasher.Hash(Password));
+}
+```
+
+Marking the positional parameter — `[NotAudited] string Password` — works the same way. A command that exists only to carry secrets is marked once, on the type:
+
+```csharp
+[Command]
+[NotAudited]
+public record ResetCredentials(Guid UserId, string Password, string RecoveryCode);
+```
+
+If the value is personal data rather than a secret, mark it `[PII]` instead — Chronicle withholds that from the causation too, and encrypts it in the event.
+
+## Quick Fix
+
+None. The right marking depends on what the value is: `[NotAudited]` for a secret, `[PII]` for personal data, and the two are not interchangeable — `[PII]` also encrypts the value and enrolls it in erasure, which is wrong for a password, and `[NotAudited]` does nothing for a GDPR request, which is wrong for a name.
+
+## Why This Rule Exists
+
+A name-based guess is normally a poor basis for a diagnostic. It earns its place here because of what is at the other end of it: the causation is written into the event log, the event log is immutable, and a secret recorded there cannot be taken back out by changing code. Fixing it after the fact means redacting events. The cost of a false positive is one attribute; the cost of a miss is permanent.
+
+The mistake is also easy to make silently. Adding a property to a command is an ordinary edit, nothing about it says "this is now in the audit trail forever", and the value only appears somewhere a person would notice — the Workbench, a replay, an export — long after the commit that introduced it.
+
+## What It Does Not Catch
+
+The rule reads names, so it only sees secrets whose names say so. A property called `Value` or `Payload` holding an API key is invisible to it. Treat a clean build as "nothing obvious was missed", not as "no secrets are recorded" — the decision about what belongs in a permanent audit record is still yours to make when you add the property.
+
+## Related Rules
+
+- [ARCCHR0008](ARCCHR0008.md) — Command key marked with the data annotations Key attribute
+
+## See also
+
+- [Causation](../commands/causation.md) — what a command records, and how to keep a value out of it
+- [Compliance](../compliance/pii.md) — marking personal data

--- a/Documentation/backend/chronicle/code-analysis/index.md
+++ b/Documentation/backend/chronicle/code-analysis/index.md
@@ -17,6 +17,7 @@ All rules follow the identifier format `ARCCHR####` where the numbers are sequen
 | [ARCCHR0003](ARCCHR0003.md) | Reactor must not reach the default event log | Warning | A reactor appends to the default event log directly instead of returning the events. |
 | [ARCCHR0005](ARCCHR0005.md) | Chronicle is used but not wired up | Warning | A project uses Chronicle features but sets up Arc without `WithChronicle()` or `AddCratis()`. |
 | [ARCCHR0008](ARCCHR0008.md) | Command key marked with the data annotations Key attribute | Warning | A command marks its key with an attribute Chronicle does not resolve keys from. |
+| [ARCCHR0009](ARCCHR0009.md) | Command property reads as a secret and should be marked `[NotAudited]` | Warning | A command carries a property whose name reads like a secret, whose value is written to the causation of every event it appends. |
 
 ## Quick Fixes
 

--- a/Documentation/backend/chronicle/code-analysis/toc.yml
+++ b/Documentation/backend/chronicle/code-analysis/toc.yml
@@ -8,3 +8,5 @@
   href: ARCCHR0005.md
 - name: ARCCHR0008 - Command key marked with the data annotations Key attribute
   href: ARCCHR0008.md
+- name: ARCCHR0009 - Command property reads as a secret and should be marked [NotAudited]
+  href: ARCCHR0009.md

--- a/Documentation/backend/chronicle/commands/causation.md
+++ b/Documentation/backend/chronicle/commands/causation.md
@@ -1,0 +1,108 @@
+---
+title: Causation
+description: A command's values are recorded on the causation of every event it appends, permanently — and how to keep a value out of that record.
+---
+
+Every event a command appends carries a causation chain saying how the work arrived: an HTTP request came in, a command ran, an aggregate root committed. Arc adds a link naming the command, and records **the values that command was asked to act on** alongside the name.
+
+Naming the command alone answers "which command produced this event". Recording the values answers "which invocation" — two purchase orders raised by the same command are otherwise indistinguishable on the chain.
+
+> [!IMPORTANT]
+> The causation is written into the event log, and the event log is immutable. A value recorded there stays there for as long as the events do, is read by everything that ever replays them, and **cannot be taken back out by changing code**. Before adding a property to a command, decide whether its value belongs in a permanent audit record — and mark it [`[NotAudited]`](#keeping-a-value-out-of-the-record) if it does not.
+
+## What gets recorded
+
+For a command like this:
+
+```csharp
+[Command]
+public record RaisePurchaseOrder(PurchaseOrderId OrderId, SupplierId Supplier, decimal Amount)
+{
+    public PurchaseOrderRaised Handle() => new(Supplier, Amount);
+}
+```
+
+the causation link carries:
+
+| Property | Value |
+|---|---|
+| `commandType` | `RaisePurchaseOrder` |
+| `commandTypeFullName` | `Acme.Purchasing.RaisePurchaseOrder` |
+| `eventSequenceId` | `event-log` |
+| `orderId` | `00000026-0000-0000-0000-0000000000b2` |
+| `supplier` | `ACME` |
+| `amount` | `1234.56` |
+
+Every readable public instance property is recorded, keyed by its camel-cased name. The values render as you would expect them to read:
+
+- A [concept](/fundamentals/csharp/concepts/) records the value it wraps, not the wrapper — `orderId` above is the id, not `{"Value":"…"}`.
+- Numbers and dates are written invariantly, dates round-trippably (`2026-02-26T11:03:00.0000000+00:00`), so a chain written in one locale reads the same in another.
+- A nested object or a collection is written as compact JSON.
+- A property that is not set is left out entirely, rather than recorded as empty.
+
+## Keeping a value out of the record
+
+Two markings keep a value off the chain.
+
+### Personal data — `[PII]`
+
+Anything Chronicle already treats as personal data is withheld automatically. Nothing extra is needed: mark it as you would anywhere else and it stays out of the causation as well as out of the event.
+
+The marking is honored wherever it is written — on the property, on the command, on the positional parameter, and **on the concept**, so a concept marked once carries the marking to every command that uses it:
+
+```csharp
+[PII("The name of a person")]
+public record ClaimantName(string Value) : ConceptAs<string>(Value);
+
+[Command]
+public record SubmitClaim(ClaimId ClaimId, ClaimantName Claimant);  // claimant is never recorded
+```
+
+See [Compliance](../compliance/pii.md) for the full picture.
+
+### Secrets — `[NotAudited]`
+
+A password, a token, an API key or a card number is not personal data, so `[PII]` does not describe it and would not keep it out. `[NotAudited]` does:
+
+```csharp
+[Command]
+public record ChangePassword(
+    UserId User,
+    [property: NotAudited] string OldPassword,
+    [property: NotAudited] string NewPassword)
+{
+    public PasswordChanged Handle(IPasswordHasher hasher) => new(hasher.Hash(NewPassword));
+}
+```
+
+Written on a positional parameter — `[NotAudited] string OldPassword` — it works the same way.
+
+Applied to the command itself it excludes every property at once, which is the right answer when a command exists only to carry secrets, and stays right as properties are added to it later:
+
+```csharp
+[Command]
+[NotAudited]
+public record ResetCredentials(UserId User, string Password, string RecoveryCode);
+```
+
+The command is still **named** on the chain either way. What is withheld is the values, never the fact that the command ran — an audit trail that hides which commands executed would not be an audit trail.
+
+## The analyzer
+
+[ARCCHR0009](../code-analysis/ARCCHR0009.md) reports a command property whose name reads like a secret and which is not marked. It is a name-based guess, which is normally a poor basis for a diagnostic — it earns its place here because the cost of a false positive is one attribute and the cost of a miss is a password in the event log forever.
+
+It will not catch a secret whose name does not say so. A property called `Value` holding an API key is invisible to it, and to any reviewer reading the model. The analyzer narrows the problem; it does not remove your judgment from it.
+
+## Size
+
+A recorded value is cut short at 1024 characters, marked with `…` where it was cut. The causation travels on **every** event the command appends, so an unbounded value is written once per event — a value long enough to be truncated has stopped being an audit note and become a payload.
+
+## Reading the chain
+
+In the [Chronicle Workbench](/chronicle/workbench/), an event's **Context** tab shows its causation. Open `causation`, then an entry's `properties`, to see what the command was asked to do.
+
+## See also
+
+- [ARCCHR0009](../code-analysis/ARCCHR0009.md) — the analyzer for unmarked secrets
+- [Compliance](../compliance/pii.md) — marking personal data
+- [Events](events.md) — what a command returns

--- a/Documentation/backend/chronicle/commands/toc.yml
+++ b/Documentation/backend/chronicle/commands/toc.yml
@@ -6,5 +6,7 @@
   href: subject.md
 - name: Returning EventSourceId
   href: returning-event-source-id.md
+- name: Causation
+  href: causation.md
 - name: Concurrency
   href: concurrency.md

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_a_name_merely_contains_a_sensitive_fragment.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_a_name_merely_contains_a_sensitive_fragment.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+/// <summary>
+/// The guess is on words, not fragments. An analyzer that reports "Passenger" because it starts with "Pass" gets
+/// suppressed wholesale, and the real findings go with it.
+/// </summary>
+public class and_a_name_merely_contains_a_sensitive_fragment : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record BookingRegistered(Guid BookingId);
+
+    [Command]
+    public record RegisterBooking(Guid BookingId, string PassengerName, decimal Subtotal, string Pinboard)
+    {
+        public BookingRegistered Handle() => new(BookingId);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_it_carries_an_unmarked_secret.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_it_carries_an_unmarked_secret.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+public class and_it_carries_an_unmarked_secret : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record PasswordChanged(Guid UserId);
+
+    [Command]
+    public record ChangePassword(Guid UserId, string {|#0:Password|})
+    {
+        public PasswordChanged Handle() => new(UserId);
+    }
+}",
+                VerifyCS.Diagnostic("ARCCHR0009")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("ChangePassword", "Password")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_it_marks_the_positional_parameter_as_not_audited.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_it_marks_the_positional_parameter_as_not_audited.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+/// <summary>
+/// An attribute written on a positional parameter lands on the parameter rather than on the property it generates,
+/// and that is what someone writing it means.
+/// </summary>
+public class and_it_marks_the_positional_parameter_as_not_audited : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Chronicle.Commands;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record PasswordChanged(Guid UserId);
+
+    [Command]
+    public record ChangePassword(Guid UserId, [NotAudited] string Password)
+    {
+        public PasswordChanged Handle() => new(UserId);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_it_marks_the_secret_as_not_audited.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_it_marks_the_secret_as_not_audited.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+public class and_it_marks_the_secret_as_not_audited : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Chronicle.Commands;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record PasswordChanged(Guid UserId);
+
+    [Command]
+    public record ChangePassword(Guid UserId, [property: NotAudited] string Password)
+    {
+        public PasswordChanged Handle() => new(UserId);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_command_itself_is_not_audited.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_command_itself_is_not_audited.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+public class and_the_command_itself_is_not_audited : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Chronicle.Commands;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record CredentialsReset(Guid UserId);
+
+    [Command]
+    [NotAudited]
+    public record ResetCredentials(Guid UserId, string Password, string RecoveryToken)
+    {
+        public CredentialsReset Handle() => new(UserId);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_secret_is_marked_as_personal_data.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_secret_is_marked_as_personal_data.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+/// <summary>
+/// Chronicle already withholds personal data from the causation, so a value marked that way is not going to be
+/// written and there is nothing left to warn about.
+/// </summary>
+public class and_the_secret_is_marked_as_personal_data : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace TestNamespace
+{
+    public record PinChanged(Guid UserId);
+
+    [Command]
+    public record ChangePin(Guid UserId, [property: PII(""The customer's chosen pin"")] string Pin)
+    {
+        public PinChanged Handle() => new(UserId);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_type_is_not_a_command.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_type_is_not_a_command.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+/// <summary>
+/// Only a command's values reach the causation chain, so a plain type carrying a secret is nothing to do with this
+/// rule.
+/// </summary>
+public class and_the_type_is_not_a_command : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+
+namespace TestNamespace
+{
+    public record Credentials(Guid UserId, string Password, string ApiKey);
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ ARCCHR0005|Arc.Chronicle|Warning|Chronicle artifacts are present but Chronicle i
 ARCCHR0006|Arc.Chronicle|Warning|Reactor handler invoking ICommandPipeline.Execute must be marked with [OnceOnly]
 ARCCHR0007|Arc.Chronicle|Warning|Command handler must not inject IEventLog
 ARCCHR0008|Arc.Chronicle|Warning|Command key marked with the data annotations Key attribute
+ARCCHR0009|Arc.Chronicle|Warning|Command property reads as a secret and should be marked [NotAudited]

--- a/Source/DotNET/Chronicle.CodeAnalysis/CommandSensitiveValueAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/CommandSensitiveValueAnalyzer.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that reports a command property whose name reads like a secret and which is not marked
+/// <c>[NotAudited]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A command's property values are recorded on the causation of every event it appends, and the causation is written
+/// into the event log and stays there for as long as the events do. A value that should never have been written
+/// cannot be taken back out by editing code, which makes this the rare case where a name-based guess earns its
+/// place: the cost of a false positive is one attribute, and the cost of a miss is a password in the log forever.
+/// </para>
+/// <para>
+/// The guess is deliberately narrow. It fires on whole words a reader would recognize as a secret, not on any
+/// substring, so <c>PasswordPolicyId</c> is reported - it does contain the word - while <c>Passenger</c> is not.
+/// Marking the property, the positional parameter, or the command itself silences it; so does marking the value as
+/// personal data, since Chronicle already withholds that.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CommandSensitiveValueAnalyzer : DiagnosticAnalyzer
+{
+    const string CommandAttributeName = "Cratis.Arc.Commands.ModelBound.CommandAttribute";
+    const string NotAuditedAttributeName = "Cratis.Arc.Chronicle.Commands.NotAuditedAttribute";
+    const string PiiAttributeName = "Cratis.Chronicle.Compliance.GDPR.PIIAttribute";
+
+    /// <summary>
+    /// The words that make a property name read as a secret.
+    /// </summary>
+    /// <remarks>
+    /// Words, not fragments. Matching a fragment turns <c>Passenger</c> and <c>Subtotal</c> into findings, and an
+    /// analyzer that cries wolf gets suppressed wholesale - taking the real findings with it.
+    /// </remarks>
+    static readonly ImmutableArray<string> _sensitiveWords =
+    [
+        "Password",
+        "Passphrase",
+        "Secret",
+        "Token",
+        "ApiKey",
+        "AccessKey",
+        "SecretKey",
+        "PrivateKey",
+        "Credential",
+        "Credentials",
+        "Pin",
+        "Otp",
+        "Cvv",
+        "Cvc",
+        "SecurityCode",
+        "AuthorizationHeader"
+    ];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARCCHR0009_CommandSensitiveValueShouldNotBeAudited];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    /// <summary>
+    /// Splits a member name into the words it is written from, so a word can be recognized without matching a
+    /// fragment of a longer one.
+    /// </summary>
+    /// <param name="name">The name to split.</param>
+    /// <returns>The words the name is composed of.</returns>
+    internal static IEnumerable<string> WordsIn(string name)
+    {
+        var start = 0;
+
+        for (var index = 1; index <= name.Length; index++)
+        {
+            var atEnd = index == name.Length;
+            var startsNewWord = !atEnd && char.IsUpper(name[index]) && !char.IsUpper(name[index - 1]);
+            var startsAcronymTail = !atEnd && index + 1 < name.Length && char.IsUpper(name[index]) && char.IsUpper(name[index - 1]) && char.IsLower(name[index + 1]);
+
+            if (!atEnd && !startsNewWord && !startsAcronymTail)
+            {
+                continue;
+            }
+
+            if (index > start)
+            {
+                yield return name.Substring(start, index - start);
+            }
+
+            start = index;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a member name reads as carrying a secret.
+    /// </summary>
+    /// <param name="name">The name to judge.</param>
+    /// <returns>True when the name contains a word that reads as a secret, false otherwise.</returns>
+    internal static bool ReadsAsSensitive(string name)
+    {
+        var words = WordsIn(name).ToArray();
+
+        // A single word ("ApiKey" splits into "Api" and "Key") is matched on its own, and adjacent pairs cover the
+        // compound words that only read as a secret together - "Api" + "Key", not every "Key".
+        for (var index = 0; index < words.Length; index++)
+        {
+            if (_sensitiveWords.Contains(words[index], StringComparer.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (index + 1 < words.Length && _sensitiveWords.Contains(words[index] + words[index + 1], StringComparer.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        // Without Chronicle there is no causation chain, so no command value is recorded anywhere and there is
+        // nothing to warn about.
+        if (context.Compilation.GetTypeByMetadataName(NotAuditedAttributeName) is null)
+        {
+            return;
+        }
+
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var command = (INamedTypeSymbol)context.Symbol;
+
+        if (!HasAttribute(command, CommandAttributeName) || IsExcluded(command))
+        {
+            return;
+        }
+
+        foreach (var property in command.GetMembers().OfType<IPropertySymbol>())
+        {
+            if (property.IsStatic || property.DeclaredAccessibility != Accessibility.Public)
+            {
+                continue;
+            }
+
+            if (!ReadsAsSensitive(property.Name) || IsExcluded(property) || IsExcludedThroughParameter(command, property))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ARCCHR0009_CommandSensitiveValueShouldNotBeAudited,
+                property.Locations[0],
+                command.Name,
+                property.Name));
+        }
+    }
+
+    static bool IsExcluded(ISymbol symbol) =>
+        HasAttribute(symbol, NotAuditedAttributeName) ||
+        HasAttribute(symbol, PiiAttributeName);
+
+    /// <summary>
+    /// Determines whether the positional record parameter a property came from carries a marking that silences the
+    /// diagnostic.
+    /// </summary>
+    /// <param name="command">The command the property belongs to.</param>
+    /// <param name="property">The property to check the originating parameter of.</param>
+    /// <returns>True when the parameter is marked, false otherwise.</returns>
+    /// <remarks>
+    /// An attribute written on a positional parameter lands on the parameter rather than on the property it
+    /// generates, unless it is spelled <c>[property: ...]</c>, and both are what someone means.
+    /// </remarks>
+    static bool IsExcludedThroughParameter(INamedTypeSymbol command, IPropertySymbol property)
+    {
+        var parameter = command.InstanceConstructors
+            .OrderByDescending(constructor => constructor.Parameters.Length)
+            .FirstOrDefault()?
+            .Parameters
+            .FirstOrDefault(_ => string.Equals(_.Name, property.Name, StringComparison.OrdinalIgnoreCase));
+
+        return parameter is not null && IsExcluded(parameter);
+    }
+
+    static bool HasAttribute(ISymbol symbol, string fullyQualifiedName) =>
+        symbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.ToDisplayString() == fullyQualifiedName);
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
@@ -107,5 +107,17 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Two attributes are spelled [Key]. Chronicle resolves a command's event source id from Cratis.Chronicle.Keys.KeyAttribute; Arc reads System.ComponentModel.DataAnnotations.KeyAttribute, but only in an application that has no Chronicle. Marking the data annotations one in an application that uses Chronicle compiles and reads correctly while doing nothing: Chronicle finds no key property, invents a fresh event source id, and every read model keyed by the command resolves to nothing.");
 
+    /// <summary>
+    /// ARCCHR0009: Command property reads as a secret and should be marked [NotAudited].
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARCCHR0009_CommandSensitiveValueShouldNotBeAudited = new(
+        id: "ARCCHR0009",
+        title: "Command property reads as a secret and should be marked [NotAudited]",
+        messageFormat: "Command '{0}' carries '{1}', whose name reads as a secret, and its value will be written to the causation of every event the command appends. Mark it [NotAudited], or [PII] if it is personal data.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A command's property values are recorded on the causation chain, which is written into the event log and stays there for as long as the events do - a secret written there cannot be taken back out by changing code. This rule reports a property whose name contains a word that reads as a secret (password, token, api key, credential, pin, cvv and the like) and which is not marked [NotAudited]. Marking the property, its positional parameter, or the command itself silences it, as does marking the value [PII], since Chronicle already withholds personal data. If the name only reads like a secret and the value is safe to record, mark it [NotAudited] anyway or rename the property - the value is written either way, so the reading is the only thing anyone reviewing the model has to go on.");
+
     const string Category = "Arc.Chronicle";
 }

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_carrying_values.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_carrying_values.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties;
+
+/// <summary>
+/// Naming the command tells a reader which command produced an event but not which invocation of it, so two orders
+/// raised by the same command are indistinguishable on the chain. Recording the values is what separates them.
+/// </summary>
+public class for_a_command_carrying_values : Specification
+{
+    record SubmitExpenseReport(
+        ExpenseReportId ReportId,
+        Amount Total,
+        ExpenseCategory Category,
+        string Description,
+        bool Reimbursable,
+        DateTimeOffset SubmittedAt);
+
+    static readonly Guid _reportId = Guid.NewGuid();
+    static readonly DateTimeOffset _submittedAt = new(2026, 2, 26, 11, 3, 0, TimeSpan.Zero);
+
+    IDictionary<string, string> _properties;
+
+    void Because() => _properties = CommandCausation.PropertiesFor(
+        typeof(SubmitExpenseReport),
+        new SubmitExpenseReport(
+            new(_reportId),
+            new(1234.56m),
+            ExpenseCategory.Travel,
+            "Flights to the customer",
+            true,
+            _submittedAt));
+
+    [Fact] void should_still_name_the_command() =>
+        _properties[CommandCausation.CommandTypeProperty].ShouldEqual(nameof(SubmitExpenseReport));
+
+    [Fact] void should_key_values_by_the_camel_cased_property_name() =>
+        _properties.ContainsKey("reportId").ShouldBeTrue();
+
+    [Fact] void should_record_the_value_a_concept_wraps_rather_than_the_wrapper() =>
+        _properties["reportId"].ShouldEqual(_reportId.ToString());
+
+    [Fact] void should_record_a_numeric_concept_invariantly() =>
+        _properties["total"].ShouldEqual(1234.56m.ToString(CultureInfo.InvariantCulture));
+
+    [Fact] void should_record_an_enum_by_name() =>
+        _properties["category"].ShouldEqual(nameof(ExpenseCategory.Travel));
+
+    [Fact] void should_record_a_string_as_written() =>
+        _properties["description"].ShouldEqual("Flights to the customer");
+
+    [Fact] void should_record_a_boolean() =>
+        _properties["reimbursable"].ShouldEqual("true");
+
+    [Fact] void should_record_a_date_round_trippably() =>
+        _properties["submittedAt"].ShouldEqual(_submittedAt.ToString("O", CultureInfo.InvariantCulture));
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_carrying_values_that_must_not_be_recorded.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_carrying_values_that_must_not_be_recorded.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties;
+
+/// <summary>
+/// The causation is written into the event log and stays there for as long as the events do, so a value withheld
+/// here is withheld permanently and a value recorded here is recorded permanently. Both markings are honoured: what
+/// GDPR describes, through Chronicle's own compliance metadata, and what it does not - a password is not personal
+/// data, and nothing about <c>[PII]</c> would keep it out.
+/// </summary>
+public class for_a_command_carrying_values_that_must_not_be_recorded : Specification
+{
+    record ChangeClaimantDetails(
+        ExpenseReportId ReportId,
+        [property: PII("The name of a person")] string DirectlyMarkedName,
+        ClaimantName NameThroughAPiiConcept,
+        [PII("Marked on the positional parameter")] string MarkedOnTheParameter,
+        [property: NotAudited] string Password,
+        [NotAudited] string ApiKey);
+
+    static readonly string[] _withheldValues = ["Jane Doe", "hunter2", "sk-live-0000"];
+
+    IDictionary<string, string> _properties;
+
+    void Because() => _properties = CommandCausation.PropertiesFor(
+        typeof(ChangeClaimantDetails),
+        new ChangeClaimantDetails(
+            new(Guid.NewGuid()),
+            "Jane Doe",
+            new("Jane Doe"),
+            "Jane Doe",
+            "hunter2",
+            "sk-live-0000"));
+
+    [Fact] void should_record_the_value_that_is_neither_personal_nor_secret() =>
+        _properties.ContainsKey("reportId").ShouldBeTrue();
+
+    [Fact] void should_withhold_a_property_marked_as_personal_data() =>
+        _properties.ContainsKey("directlyMarkedName").ShouldBeFalse();
+
+    [Fact] void should_withhold_a_value_whose_concept_is_marked_as_personal_data() =>
+        _properties.ContainsKey("nameThroughAPiiConcept").ShouldBeFalse();
+
+    [Fact] void should_withhold_a_positional_parameter_marked_as_personal_data() =>
+        _properties.ContainsKey("markedOnTheParameter").ShouldBeFalse();
+
+    [Fact] void should_withhold_a_property_marked_as_not_audited() =>
+        _properties.ContainsKey("password").ShouldBeFalse();
+
+    [Fact] void should_withhold_a_positional_parameter_marked_as_not_audited() =>
+        _properties.ContainsKey("apiKey").ShouldBeFalse();
+
+    [Fact] void should_never_leak_a_withheld_value_under_any_key() =>
+        _properties.Values.Any(value => _withheldValues.Contains(value, StringComparer.Ordinal)).ShouldBeFalse();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_marked_as_not_audited.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_marked_as_not_audited.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties;
+
+/// <summary>
+/// Marking the command rather than each of its properties is the right answer when a command exists only to carry
+/// secrets, and it stays right as properties are added to it later - which marking them one by one does not.
+/// </summary>
+public class for_a_command_marked_as_not_audited : Specification
+{
+    [NotAudited]
+    record ResetCredentials(Guid UserId, string Password, string RecoveryCode);
+
+    IDictionary<string, string> _properties;
+
+    void Because() => _properties = CommandCausation.PropertiesFor(
+        typeof(ResetCredentials),
+        new ResetCredentials(Guid.NewGuid(), "hunter2", "0000-1111"));
+
+    [Fact] void should_still_name_the_command() =>
+        _properties[CommandCausation.CommandTypeProperty].ShouldEqual(nameof(ResetCredentials));
+
+    [Fact] void should_still_qualify_the_command_name() =>
+        _properties[CommandCausation.CommandTypeFullNameProperty].ShouldEqual(typeof(ResetCredentials).FullName);
+
+    [Fact] void should_record_none_of_its_values() =>
+        _properties.Count.ShouldEqual(2);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_whose_values_need_special_handling.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/for_a_command_whose_values_need_special_handling.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties;
+
+/// <summary>
+/// Not every value renders as a word. A property named like the causation's own metadata would make an event
+/// misreport what produced it, an unset one has nothing to say, and an unbounded one is written again on every event
+/// the command appends - which is a payload, not an audit note.
+/// </summary>
+public class for_a_command_whose_values_need_special_handling : Specification
+{
+    record ArchiveExpenseReports(
+        string CommandType,
+        string EventSequenceId,
+        string? Note,
+        Approver ApprovedBy,
+        IEnumerable<string> ReportIds,
+        string Justification);
+
+    const int OversizedLength = 4000;
+
+    IDictionary<string, string> _properties;
+
+    void Because() => _properties = CommandCausation.PropertiesFor(
+        typeof(ArchiveExpenseReports),
+        new ArchiveExpenseReports(
+            "pretending to be the metadata",
+            "pretending to be the sequence",
+            null,
+            new("Jane", "Finance"),
+            ["first", "second"],
+            new string('x', OversizedLength)));
+
+    [Fact] void should_keep_the_causation_metadata_the_command_tried_to_occupy() =>
+        _properties[CommandCausation.CommandTypeProperty].ShouldEqual(nameof(ArchiveExpenseReports));
+
+    [Fact] void should_not_let_a_command_write_a_reserved_property() =>
+        _properties.Values.Contains("pretending to be the metadata").ShouldBeFalse();
+
+    [Fact] void should_not_let_a_command_write_the_reserved_sequence_property() =>
+        _properties.ContainsKey(CommandCausation.EventSequenceIdProperty).ShouldBeFalse();
+
+    [Fact] void should_leave_out_a_value_that_was_never_set() =>
+        _properties.ContainsKey("note").ShouldBeFalse();
+
+    [Fact] void should_render_a_nested_value_as_json() =>
+        _properties["approvedBy"].ShouldEqual("""{"Name":"Jane","Department":"Finance"}""");
+
+    [Fact] void should_render_a_collection_as_json() =>
+        _properties["reportIds"].ShouldEqual("""["first","second"]""");
+
+    [Fact] void should_cut_an_oversized_value_short() =>
+        _properties["justification"].Length.ShouldEqual(CommandCausationValues.MaximumValueLength + CommandCausationValues.TruncationMarker.Length);
+
+    [Fact] void should_mark_a_value_it_cut_short() =>
+        _properties["justification"].EndsWith(CommandCausationValues.TruncationMarker).ShouldBeTrue();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/Amount.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/Amount.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+
+public record Amount(decimal Value) : ConceptAs<decimal>(Value);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/Approver.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/Approver.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+
+public record Approver(string Name, string Department);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/ClaimantName.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/ClaimantName.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Concepts;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+
+/// <summary>
+/// A concept marked as personal data, so the marking travels with the value wherever it is used rather than having
+/// to be repeated on every command that carries one.
+/// </summary>
+/// <param name="Value">The name.</param>
+[PII("The name of a person")]
+public record ClaimantName(string Value) : ConceptAs<string>(Value);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/ExpenseCategory.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/ExpenseCategory.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+
+public enum ExpenseCategory
+{
+    Unknown = 0,
+    Travel = 1
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/ExpenseReportId.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausation/when_getting_properties/given/ExpenseReportId.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausation.when_getting_properties.given;
+
+public record ExpenseReportId(Guid Value) : ConceptAs<Guid>(Value);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausationScope/given/a_command_causation_scope.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausationScope/given/a_command_causation_scope.cs
@@ -21,8 +21,12 @@ public class a_command_causation_scope : Specification
         _scope = new();
     }
 
-    protected CommandContext ContextFor<TCommand>() =>
-        new(CorrelationId.New(), typeof(TCommand), new object(), [], new(), ServiceProvider: _serviceProvider);
+    protected CommandContext ContextFor<TCommand>()
+        where TCommand : new() =>
+        ContextFor(new TCommand());
+
+    protected CommandContext ContextFor<TCommand>(TCommand command) =>
+        new(CorrelationId.New(), typeof(TCommand), command!, [], new(), ServiceProvider: _serviceProvider);
 
     protected sealed record ApproveExpenseReport;
 

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausationScope/when_beginning/for_a_command_carrying_values.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandCausationScope/when_beginning/for_a_command_carrying_values.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Auditing;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandCausationScope.when_beginning;
+
+/// <summary>
+/// The scope is what puts the command on the chain for every append it makes, so the values have to travel with it
+/// there and not only on the events a handler returns.
+/// </summary>
+public class for_a_command_carrying_values : given.a_command_causation_scope
+{
+    sealed record RejectExpenseReport(string Reason);
+
+    IImmutableList<Causation> _chain;
+
+    void Because()
+    {
+        _scope.Begin(ContextFor(new RejectExpenseReport("Missing receipts")));
+        _chain = _causationManager.GetCurrentChain();
+    }
+
+    [Fact] void should_still_name_the_command() =>
+        _chain[^1].Properties[CommandCausation.CommandTypeProperty].ShouldEqual(nameof(RejectExpenseReport));
+
+    [Fact] void should_record_what_the_command_was_asked_to_do() =>
+        _chain[^1].Properties["reason"].ShouldEqual("Missing receipts");
+}

--- a/Source/DotNET/Chronicle/Commands/CommandCausation.cs
+++ b/Source/DotNET/Chronicle/Commands/CommandCausation.cs
@@ -36,6 +36,16 @@ public static class CommandCausation
     public static readonly CausationType Type = "Command";
 
     /// <summary>
+    /// The causation property names the causation's own metadata occupies, which a command's values never overwrite.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ReservedProperties = new HashSet<string>(StringComparer.Ordinal)
+    {
+        CommandTypeProperty,
+        CommandTypeFullNameProperty,
+        EventSequenceIdProperty
+    };
+
+    /// <summary>
     /// Gets the causation properties naming a command.
     /// </summary>
     /// <param name="commandType">The <see cref="System.Type"/> of the command.</param>
@@ -50,4 +60,30 @@ public static class CommandCausation
         { CommandTypeProperty, commandType.Name },
         { CommandTypeFullNameProperty, commandType.FullName ?? commandType.Name }
     };
+
+    /// <summary>
+    /// Gets the causation properties naming a command and carrying the values it was asked to act on.
+    /// </summary>
+    /// <param name="commandType">The <see cref="System.Type"/> of the command.</param>
+    /// <param name="command">The command instance, whose values are recorded alongside its name.</param>
+    /// <returns>The properties to record on the causation.</returns>
+    /// <remarks>
+    /// <para>
+    /// Naming the command says what was asked for only as far as its type goes - two invocations of the same command
+    /// are indistinguishable on the chain, so "which order did this event come from" is a question the name alone
+    /// cannot answer. Recording the values answers it.
+    /// </para>
+    /// <para>
+    /// Values that must not be written are left out: anything Chronicle treats as personal data, including a concept
+    /// marked <c>[PII]</c> wherever it is used, and anything marked
+    /// <see cref="NotAuditedAttribute"/>. See <see cref="NotAuditedAttribute"/> for what belongs in that second set -
+    /// the causation is written into the event log and stays there for as long as the events do.
+    /// </para>
+    /// </remarks>
+    public static IDictionary<string, string> PropertiesFor(Type commandType, object? command)
+    {
+        var properties = PropertiesFor(commandType);
+        CommandCausationValues.AddTo(properties, commandType, command);
+        return properties;
+    }
 }

--- a/Source/DotNET/Chronicle/Commands/CommandCausationScope.cs
+++ b/Source/DotNET/Chronicle/Commands/CommandCausationScope.cs
@@ -55,7 +55,7 @@ public class CommandCausationScope : ICommandExecutionScope
             return;
         }
 
-        _scope.Value = causationManager.BeginScope(CommandCausation.Type, CommandCausation.PropertiesFor(context.Type));
+        _scope.Value = causationManager.BeginScope(CommandCausation.Type, CommandCausation.PropertiesFor(context.Type, context.Command));
     }
 
     /// <inheritdoc/>

--- a/Source/DotNET/Chronicle/Commands/CommandCausationValues.cs
+++ b/Source/DotNET/Chronicle/Commands/CommandCausationValues.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Concepts;
+using Cratis.Strings;
+
+namespace Cratis.Arc.Chronicle.Commands;
+
+/// <summary>
+/// Renders the values a command carries into the properties recorded on its causation, so an event says not only
+/// which command produced it but what that command was asked to do.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every readable public instance property is recorded, keyed by its camel-cased name, except the ones that must not
+/// be: anything Chronicle already treats as personal data, anything marked <see cref="NotAuditedAttribute"/>, and
+/// anything whose name is already spoken for by the causation's own metadata. Exclusion is decided per property and
+/// the answer is cached per command type, because the same command runs over and over.
+/// </para>
+/// <para>
+/// The privacy decisions here fail closed. A property whose value cannot be read, or whose exclusion cannot be
+/// decided, is left out rather than written: the cost of omitting a value from an audit trail is that someone asks a
+/// question the chain cannot answer, and the cost of writing one that should have been withheld is a secret in the
+/// event log forever.
+/// </para>
+/// </remarks>
+static class CommandCausationValues
+{
+    /// <summary>
+    /// The greatest number of characters a single recorded value may occupy.
+    /// </summary>
+    /// <remarks>
+    /// The causation travels on every event the command appends, so an unbounded value is written once per event. A
+    /// value long enough to be truncated has stopped being an audit note and become a payload.
+    /// </remarks>
+    internal const int MaximumValueLength = 1024;
+
+    /// <summary>
+    /// Appended to a value that was cut short, so a truncated value is never mistaken for the whole one.
+    /// </summary>
+    internal const string TruncationMarker = "…";
+
+    static readonly PIIMetadataProvider _compliance = new();
+    static readonly ConcurrentDictionary<Type, PropertyInfo[]> _recordableProperties = new();
+    static readonly JsonSerializerOptions _serializerOptions = new();
+
+    /// <summary>
+    /// Adds the values a command carries to the properties recorded on its causation.
+    /// </summary>
+    /// <param name="properties">The causation properties to add to, already carrying the causation's own metadata.</param>
+    /// <param name="commandType">The <see cref="Type"/> of the command.</param>
+    /// <param name="command">The command instance to read the values from.</param>
+    internal static void AddTo(IDictionary<string, string> properties, Type commandType, object? command)
+    {
+        if (command is null || !commandType.IsInstanceOfType(command))
+        {
+            return;
+        }
+
+        foreach (var property in RecordablePropertiesOf(commandType))
+        {
+            var key = property.Name.ToCamelCase();
+
+            // The causation's own metadata names the command and the sequence, and a command free to overwrite
+            // those could make an event misreport what produced it.
+            if (CommandCausation.ReservedProperties.Contains(key))
+            {
+                continue;
+            }
+
+            if (Render(ValueOf(property, command)) is { } value)
+            {
+                properties[key] = value;
+            }
+        }
+    }
+
+    static PropertyInfo[] RecordablePropertiesOf(Type commandType) =>
+        _recordableProperties.GetOrAdd(commandType, static type =>
+            IsExcluded(type)
+                ? []
+                : [.. type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(property =>
+                        property.CanRead &&
+                        property.GetIndexParameters().Length == 0 &&
+                        !IsExcluded(property))]);
+
+    static bool IsExcluded(Type commandType) =>
+        Attribute.IsDefined(commandType, typeof(NotAuditedAttribute));
+
+    static bool IsExcluded(PropertyInfo property)
+    {
+        try
+        {
+            return Attribute.IsDefined(property, typeof(NotAuditedAttribute)) ||
+                   Attribute.IsDefined(property.PropertyType, typeof(NotAuditedAttribute)) ||
+                   HasNotAuditedOnConstructorParameter(property) ||
+
+                   // Chronicle already decides what counts as personal data, and it looks at the property, its
+                   // declaring type, its property type - so a concept marked [PII] carries the marking wherever it is
+                   // used - and the positional record parameter the property came from.
+                   _compliance.CanProvide(property);
+        }
+        catch
+        {
+            // A model this provider refuses to describe is one whose sensitivity is unknown, and an unknown is not a
+            // license to record the value.
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the positional record parameter a property came from is marked
+    /// <see cref="NotAuditedAttribute"/>.
+    /// </summary>
+    /// <param name="property">The <see cref="PropertyInfo"/> to check the originating parameter of.</param>
+    /// <returns>True when the parameter is marked, false otherwise.</returns>
+    /// <remarks>
+    /// An attribute written on a positional parameter lands on the parameter, not on the property it generates,
+    /// unless it is spelled <c>[property: NotAudited]</c>. Both readings are what someone means.
+    /// </remarks>
+    static bool HasNotAuditedOnConstructorParameter(PropertyInfo property)
+    {
+        if (property.DeclaringType is null)
+        {
+            return false;
+        }
+
+        var constructor = property.DeclaringType.GetConstructors().MaxBy(_ => _.GetParameters().Length);
+        var parameter = constructor?.GetParameters().FirstOrDefault(_ =>
+            string.Equals(_.Name, property.Name, StringComparison.OrdinalIgnoreCase));
+
+        return parameter is not null && Attribute.IsDefined(parameter, typeof(NotAuditedAttribute));
+    }
+
+    static object? ValueOf(PropertyInfo property, object command)
+    {
+        try
+        {
+            return property.GetValue(command);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string? Render(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        // A concept is a wrapper around the value someone actually wrote; recording the wrapper's shape instead of
+        // that value would make the chain say less than the command did.
+        if (value.IsConcept())
+        {
+            return Render(value.GetConceptValue());
+        }
+
+        return value switch
+        {
+            string text => Truncate(text),
+            DateTime date => date.ToString("O", CultureInfo.InvariantCulture),
+            DateTimeOffset offset => offset.ToString("O", CultureInfo.InvariantCulture),
+            IFormattable formattable => Truncate(formattable.ToString(null, CultureInfo.InvariantCulture)),
+            _ => Truncate(Serialize(value))
+        };
+    }
+
+    static string Serialize(object value)
+    {
+        try
+        {
+            return JsonSerializer.Serialize(value, _serializerOptions);
+        }
+        catch
+        {
+            return value.ToString() ?? string.Empty;
+        }
+    }
+
+    static string Truncate(string value) =>
+        value.Length <= MaximumValueLength
+            ? value
+            : string.Concat(value.AsSpan(0, MaximumValueLength), TruncationMarker);
+}

--- a/Source/DotNET/Chronicle/Commands/CommandTransactionAppender.cs
+++ b/Source/DotNET/Chronicle/Commands/CommandTransactionAppender.cs
@@ -39,7 +39,7 @@ internal static class CommandTransactionAppender
     /// </remarks>
     internal static Causation CreateCommandCausation(this IEventLog eventLog, CommandContext commandContext)
     {
-        var properties = CommandCausation.PropertiesFor(commandContext.Type);
+        var properties = CommandCausation.PropertiesFor(commandContext.Type, commandContext.Command);
         properties[CausationEventSequenceIdProperty] = eventLog.Id;
         return new(DateTimeOffset.Now, CausationType, properties);
     }

--- a/Source/DotNET/Chronicle/Commands/NotAuditedAttribute.cs
+++ b/Source/DotNET/Chronicle/Commands/NotAuditedAttribute.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.Commands;
+
+/// <summary>
+/// Marks a command, or a single property on one, as something whose value must never be written to the causation
+/// chain.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A command's property values are recorded on the causation of every event it appends, so that an event says not
+/// only which command produced it but what that command was asked to do. Some values must not travel that way. A
+/// password, a token, an API key or a card number would be written into the event log in plain text and stay there
+/// for as long as the events do - immutably, and read by everything that ever replays them.
+/// </para>
+/// <para>
+/// Personal data does not need this attribute: a property covered by Chronicle's
+/// <see cref="Cratis.Chronicle.Compliance.GDPR.PIIAttribute"/> is already left out. Use this one for the values that
+/// are sensitive without being personal, which is exactly the set GDPR does not describe.
+/// </para>
+/// <para>
+/// Applied to the command type it excludes every property at once, which is the right answer when a command exists
+/// only to carry secrets. The command is still named on the chain either way - what is withheld is the values, never
+/// the fact that the command ran.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [Command]
+/// public record ChangePassword(
+///     UserId User,
+///     [property: NotAudited] string OldPassword,
+///     [property: NotAudited] string NewPassword);
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
+public sealed class NotAuditedAttribute : Attribute;


### PR DESCRIPTION
# Summary

The causation chain named the command that produced an event but said nothing about what that command was asked to do, so two purchase orders raised by the same command were indistinguishable on it. A command's property values are now recorded alongside its name.

Because the causation is written into the event log and the event log is immutable, a value recorded there stays there for as long as the events do. Values that must not travel that way are withheld: personal data through Chronicle's existing `[PII]` marking, and secrets through a new `[NotAudited]`. A new analyzer reports a command property whose name reads like a secret and is not marked. (#2625)

## Added

- Command property values are recorded on the causation of every event the command appends, keyed by camel-cased property name, so an event says what the command was asked to do and not only which command it was (#2625)
- `[NotAudited]` keeps a value off the causation chain — on a property, on a positional parameter, or on the command itself to exclude every property at once (#2625)
- `ARCCHR0009` reports a command property whose name reads like a secret (`Password`, `Token`, `ApiKey`, `Credential`, `Pin`, `Cvv` and the like) and which is not marked `[NotAudited]` or `[PII]` (#2625)
- `CommandCausation.PropertiesFor(Type, object)` builds the causation properties for a command instance; the existing `PropertiesFor(Type)` is unchanged (#2625)

## Changed

- Values Chronicle treats as personal data are withheld from the causation chain, honoring `[PII]` on the property, the declaring type, the positional parameter, and the concept — so a concept marked once carries the marking to every command that uses it (#2625)
- A recorded value is truncated at 1024 characters and marked where it was cut, since the causation travels on every event the command appends (#2625)
