### PR TITLE
Judge the type as well as the name in ARCCHR0009

### DIFF
--- a/Documentation/backend/chronicle/code-analysis/ARCCHR0009.md
+++ b/Documentation/backend/chronicle/code-analysis/ARCCHR0009.md
@@ -7,7 +7,9 @@ description: A command carries a property whose name reads like a secret, and it
 
 A command's property values are recorded on the [causation chain](../commands/causation.md) of every event it appends. This rule fires when a `[Command]` type has a public property whose name contains a word that reads as a secret — `Password`, `Token`, `ApiKey`, `Credential`, `Pin`, `Cvv` and the like — and neither the property, its positional parameter, nor the command is marked `[NotAudited]` or `[PII]`.
 
-It matches whole words, not fragments: `PasswordPolicyId` is reported, `Passenger` and `Subtotal` are not. It stays silent on anything that is not a command, and in a project without Chronicle, where nothing is written to a causation chain at all.
+It matches whole words, not fragments: `PasswordPolicyId` is reported, `Passenger` and `Subtotal` are not. It also judges the type, because a name is weak evidence on its own — `AccessTokenExpiresAt` holds a `DateTimeOffset` and is a timestamp, not a secret, so a property whose type is a date, a duration, a number, a bool, a `Guid` or an enum is never reported however it is named. A concept is judged by the value it wraps, since that is what gets recorded.
+
+It stays silent on anything that is not a command, and in a project without Chronicle, where nothing is written to a causation chain at all.
 
 ## Severity
 
@@ -53,13 +55,24 @@ If the value is personal data rather than a secret, mark it `[PII]` instead — 
 
 ## Quick Fix
 
-None. The right marking depends on what the value is: `[NotAudited]` for a secret, `[PII]` for personal data, and the two are not interchangeable — `[PII]` also encrypts the value and enrolls it in erasure, which is wrong for a password, and `[NotAudited]` does nothing for a GDPR request, which is wrong for a name.
+None. The right response depends on what the value is: `[NotAudited]` for a secret, `[PII]` for personal data, [a suppression](#when-the-rule-is-wrong) for a false positive. The two attributes are not interchangeable — `[PII]` also encrypts the value and enrolls it in erasure, which is wrong for a password, and `[NotAudited]` does nothing for a GDPR request, which is wrong for a name.
 
 ## Why This Rule Exists
 
 A name-based guess is normally a poor basis for a diagnostic. It earns its place here because of what is at the other end of it: the causation is written into the event log, the event log is immutable, and a secret recorded there cannot be taken back out by changing code. Fixing it after the fact means redacting events. The cost of a false positive is one attribute; the cost of a miss is permanent.
 
 The mistake is also easy to make silently. Adding a property to a command is an ordinary edit, nothing about it says "this is now in the audit trail forever", and the value only appears somewhere a person would notice — the Workbench, a replay, an export — long after the commit that introduced it.
+
+## When the Rule Is Wrong
+
+A property can read as a secret and hold something you do want recorded. **Suppress the diagnostic — do not mark it `[NotAudited]`:**
+
+```csharp
+[SuppressMessage("Arc.Chronicle", "ARCCHR0009", Justification = "The token's scope names, not the token")]
+public string TokenScopes { get; init; }
+```
+
+`[NotAudited]` would silence the warning by withholding the value, which is a behavior change dressed up as a suppression — the audit trail quietly loses a value you wanted in it. A suppression says "recorded on purpose" and keeps it.
 
 ## What It Does Not Catch
 

--- a/Documentation/backend/chronicle/code-analysis/ARCCHR0009.md
+++ b/Documentation/backend/chronicle/code-analysis/ARCCHR0009.md
@@ -53,6 +53,13 @@ public record ResetCredentials(Guid UserId, string Password, string RecoveryCode
 
 If the value is personal data rather than a secret, mark it `[PII]` instead — Chronicle withholds that from the causation too, and encrypts it in the event.
 
+When the secret has its own concept, mark the concept once and every command that takes one is covered:
+
+```csharp
+[NotAudited]
+public record ProviderApiKey(string Value) : ConceptAs<string>(Value);
+```
+
 ## Quick Fix
 
 None. The right response depends on what the value is: `[NotAudited]` for a secret, `[PII]` for personal data, [a suppression](#when-the-rule-is-wrong) for a false positive. The two attributes are not interchangeable — `[PII]` also encrypts the value and enrolls it in erasure, which is wrong for a password, and `[NotAudited]` does nothing for a GDPR request, which is wrong for a name.

--- a/Documentation/backend/chronicle/commands/causation.md
+++ b/Documentation/backend/chronicle/commands/causation.md
@@ -91,6 +91,8 @@ The command is still **named** on the chain either way. What is withheld is the 
 
 [ARCCHR0009](../code-analysis/ARCCHR0009.md) reports a command property whose name reads like a secret and which is not marked. It is a name-based guess, which is normally a poor basis for a diagnostic — it earns its place here because the cost of a false positive is one attribute and the cost of a miss is a password in the event log forever.
 
+It judges the type as well as the name, so a `DateTimeOffset` called `AccessTokenExpiresAt` is left alone — it is a timestamp, not a secret. When it is wrong the other way and a value that reads as a secret should be recorded, [suppress the diagnostic](../code-analysis/ARCCHR0009.md#when-the-rule-is-wrong) rather than marking it `[NotAudited]`, which would silence the warning by withholding a value you wanted.
+
 It will not catch a secret whose name does not say so. A property called `Value` holding an API key is invisible to it, and to any reviewer reading the model. The analyzer narrows the problem; it does not remove your judgment from it.
 
 ## Size

--- a/Documentation/backend/chronicle/commands/causation.md
+++ b/Documentation/backend/chronicle/commands/causation.md
@@ -77,6 +77,13 @@ public record ChangePassword(
 
 Written on a positional parameter — `[NotAudited] string OldPassword` — it works the same way.
 
+Applied to a concept it travels with the value, the same way `[PII]` does — mark it once and every command that takes one is covered:
+
+```csharp
+[NotAudited]
+public record ProviderApiKey(string Value) : ConceptAs<string>(Value);
+```
+
 Applied to the command itself it excludes every property at once, which is the right answer when a command exists only to carry secrets, and stays right as properties are added to it later:
 
 ```csharp

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_a_sensitive_name_holds_a_string_backed_concept.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_a_sensitive_name_holds_a_string_backed_concept.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+/// <summary>
+/// Wrapping a secret in a concept does not stop it being recorded - the concept is unwrapped to the value it
+/// carries - so it must not stop it being reported either.
+/// </summary>
+public class and_a_sensitive_name_holds_a_string_backed_concept : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Concepts;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record AccessToken(string Value) : ConceptAs<string>(Value);
+
+    public record AccountConnected(Guid AccountId);
+
+    [Command]
+    public record ConnectAccount(Guid AccountId, AccessToken {|#0:Token|})
+    {
+        public AccountConnected Handle() => new(AccountId);
+    }
+}",
+                VerifyCS.Diagnostic("ARCCHR0009")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("ConnectAccount", "Token")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_a_sensitive_name_holds_a_value_no_secret_fits_in.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_a_sensitive_name_holds_a_value_no_secret_fits_in.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+/// <summary>
+/// A name is weak evidence on its own. "AccessTokenExpiresAt" contains the word "token" and holds a date - it is a
+/// timestamp, and reporting it would teach people that the rule guesses badly, which is how a rule ends up
+/// suppressed wholesale.
+/// </summary>
+public class and_a_sensitive_name_holds_a_value_no_secret_fits_in : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record AccountConnected(Guid AccountId);
+
+    [Command]
+    public record ConnectAccount(
+        Guid AccountId,
+        DateTimeOffset AccessTokenExpiresAt,
+        DateTime RefreshTokenIssuedAt,
+        TimeSpan TokenLifetime,
+        int PinLength,
+        bool SecretRotationEnabled)
+    {
+        public AccountConnected Handle() => new(AccountId);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_concept_holding_the_secret_is_marked.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandSensitiveValueAnalyzer/when_validating_a_command/and_the_concept_holding_the_secret_is_marked.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandSensitiveValueAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandSensitiveValueAnalyzer.when_validating_a_command;
+
+/// <summary>
+/// Marking the concept once is how an application covers every command that takes one, and the runtime honors a
+/// marking on the property's type. Reporting it here would be reporting code that is already correct - and would
+/// push people to repeat the marking on every use of the concept for no gain.
+/// </summary>
+public class and_the_concept_holding_the_secret_is_marked : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Concepts;
+using Cratis.Arc.Chronicle.Commands;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [NotAudited]
+    public record ProviderApiKey(string Value) : ConceptAs<string>(Value);
+
+    public record ProviderAdded(Guid ProviderId);
+
+    [Command]
+    public record AddProvider(Guid ProviderId, ProviderApiKey ApiKey)
+    {
+        public ProviderAdded Handle() => new(ProviderId);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/CommandSensitiveValueAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/CommandSensitiveValueAnalyzer.cs
@@ -190,7 +190,11 @@ public class CommandSensitiveValueAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (!ReadsAsSensitive(property.Name) || HoldsNoSecret(property.Type) || IsExcluded(property) || IsExcludedThroughParameter(command, property))
+            if (!ReadsAsSensitive(property.Name) ||
+                HoldsNoSecret(property.Type) ||
+                IsExcluded(property) ||
+                IsExcluded(property.Type) ||
+                IsExcludedThroughParameter(command, property))
             {
                 continue;
             }
@@ -240,6 +244,16 @@ public class CommandSensitiveValueAnalyzer : DiagnosticAnalyzer
         return type;
     }
 
+    /// <summary>
+    /// Determines whether a symbol carries a marking that keeps its value off the causation chain.
+    /// </summary>
+    /// <param name="symbol">The property, parameter, type, or command to check.</param>
+    /// <returns>True when the symbol is marked, false otherwise.</returns>
+    /// <remarks>
+    /// Applied to a type this is how a concept carries its own marking: mark <c>ApiKey</c> once and every command
+    /// that takes one is covered. The runtime withholds on exactly these markings - including the property's type -
+    /// so reporting one it already honors would be reporting correct code.
+    /// </remarks>
     static bool IsExcluded(ISymbol symbol) =>
         HasAttribute(symbol, NotAuditedAttributeName) ||
         HasAttribute(symbol, PiiAttributeName);

--- a/Source/DotNET/Chronicle.CodeAnalysis/CommandSensitiveValueAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/CommandSensitiveValueAnalyzer.cs
@@ -59,6 +59,41 @@ public class CommandSensitiveValueAnalyzer : DiagnosticAnalyzer
         "AuthorizationHeader"
     ];
 
+    /// <summary>
+    /// The types a secret is never held in, whatever the property is called.
+    /// </summary>
+    /// <remarks>
+    /// A name is weak evidence on its own. <c>AccessTokenExpiresAt</c> contains the word "token" and holds a
+    /// <see cref="DateTimeOffset"/> - it is a timestamp, and reporting it teaches people that the rule guesses badly.
+    /// This is an exclusion list rather than an "only strings" rule on purpose: skipping a date is provably safe,
+    /// while assuming only a string can hold a secret is not - a key can be a <c>byte[]</c>.
+    /// </remarks>
+    static readonly ImmutableHashSet<SpecialType> _typesThatHoldNoSecret =
+    [
+        SpecialType.System_Boolean,
+        SpecialType.System_Byte,
+        SpecialType.System_SByte,
+        SpecialType.System_Int16,
+        SpecialType.System_UInt16,
+        SpecialType.System_Int32,
+        SpecialType.System_UInt32,
+        SpecialType.System_Int64,
+        SpecialType.System_UInt64,
+        SpecialType.System_Single,
+        SpecialType.System_Double,
+        SpecialType.System_Decimal,
+        SpecialType.System_DateTime
+    ];
+
+    static readonly ImmutableArray<string> _typeNamesThatHoldNoSecret =
+    [
+        "System.DateTimeOffset",
+        "System.DateOnly",
+        "System.TimeOnly",
+        "System.TimeSpan",
+        "System.Guid"
+    ];
+
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARCCHR0009_CommandSensitiveValueShouldNotBeAudited];
 
@@ -155,7 +190,7 @@ public class CommandSensitiveValueAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (!ReadsAsSensitive(property.Name) || IsExcluded(property) || IsExcludedThroughParameter(command, property))
+            if (!ReadsAsSensitive(property.Name) || HoldsNoSecret(property.Type) || IsExcluded(property) || IsExcludedThroughParameter(command, property))
             {
                 continue;
             }
@@ -166,6 +201,43 @@ public class CommandSensitiveValueAnalyzer : DiagnosticAnalyzer
                 command.Name,
                 property.Name));
         }
+    }
+
+    /// <summary>
+    /// Determines whether a type is one a secret is never held in, so a name that reads as a secret can be
+    /// disregarded.
+    /// </summary>
+    /// <param name="type">The type of the property.</param>
+    /// <returns>True when the type cannot hold a secret, false otherwise.</returns>
+    /// <remarks>
+    /// A concept is judged by the value it wraps, since that is what would be recorded: a
+    /// <c>ConceptAs&lt;DateTimeOffset&gt;</c> called <c>TokenExpiry</c> is as much a timestamp as the bare type is.
+    /// </remarks>
+    static bool HoldsNoSecret(ITypeSymbol type)
+    {
+        var underlying = UnderlyingTypeOf(type);
+
+        return _typesThatHoldNoSecret.Contains(underlying.SpecialType) ||
+               underlying.TypeKind == TypeKind.Enum ||
+               _typeNamesThatHoldNoSecret.Contains(underlying.ToDisplayString());
+    }
+
+    static ITypeSymbol UnderlyingTypeOf(ITypeSymbol type)
+    {
+        if (type is INamedTypeSymbol { IsGenericType: true } nullable && nullable.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T)
+        {
+            type = nullable.TypeArguments[0];
+        }
+
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType && string.Equals(current.Name, "ConceptAs", StringComparison.Ordinal))
+            {
+                return current.TypeArguments[0];
+            }
+        }
+
+        return type;
     }
 
     static bool IsExcluded(ISymbol symbol) =>


### PR DESCRIPTION
# Summary

`ARCCHR0009` judged a command property by its name alone. Its first contact with real code found two kinds of false positive: properties like `AccessTokenExpiresAt`, which contain the word "token" and hold a `DateTimeOffset`, and properties whose secret is wrapped in a concept the application had already marked — which the runtime honors but the analyzer did not, so it reported correct code. Both are fixed, and the documentation now says what to do when the rule is still wrong.

## Changed

- `ARCCHR0009` no longer reports a property whose type cannot hold a secret — a date, a duration, a number, a bool, a `Guid` or an enum — however it is named, so `AccessTokenExpiresAt` is left alone while `AccessToken` is still reported (#2625)
- `ARCCHR0009` honors `[NotAudited]` and `[PII]` on the property's type, matching what the runtime already withholds, so marking a concept once covers every command that takes one (#2625)
- `ARCCHR0009` judges a concept by the value it wraps, so a `ConceptAs<string>` holding a token is reported and a `ConceptAs<DateTimeOffset>` is not (#2625)

## Fixed

- The `ARCCHR0009` documentation told you to mark a false positive `[NotAudited]`, which silences the warning by withholding the value rather than recording it; it now says to suppress the diagnostic and keep the value (#2625)