### PR TITLE
Stop HTML-escaping documentation in generated proxies

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithPunctuatedDocumentation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithPunctuatedDocumentation.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+/// <summary>
+/// Renames an issue's title, quoting "the old one" &amp; the new.
+/// </summary>
+[Command]
+public class CommandWithPunctuatedDocumentation
+{
+    /// <summary>
+    /// Gets or sets the provider's display name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Handles the command.
+    /// </summary>
+    public void Handle()
+    {
+        // Nothing to do - the documentation is what is under test.
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_generating_command_with_punctuation_in_documentation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_generating_command_with_punctuation_in_documentation.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.ProxyGenerator.ModelBound;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_XmlDocumentation;
+
+/// <summary>
+/// A generated proxy is TypeScript, and its documentation is a JSDoc comment rather than markup, so the text has to
+/// arrive as it was written. Rendering it through an escaping template turns every apostrophe into "&amp;#x27;",
+/// which is what a reader then sees in their editor's tooltip.
+/// </summary>
+public class when_generating_command_with_punctuation_in_documentation : Specification
+{
+    CommandDescriptor _descriptor = null!;
+    string _generatedCode = null!;
+
+    void Establish()
+    {
+        var commandType = typeof(Scenarios.for_ProxyGeneration.CommandWithPunctuatedDocumentation);
+        _descriptor = commandType.GetTypeInfo().ToCommandDescriptor(
+            "/output",
+            segmentsToSkip: 3,
+            skipCommandNameInRoute: false,
+            apiPrefix: "api",
+            [commandType.GetTypeInfo()]);
+    }
+
+    void Because() => _generatedCode = TemplateTypes.Command(_descriptor);
+
+    [Fact] void should_keep_an_apostrophe_in_the_type_documentation() => _generatedCode.ShouldContain("Renames an issue's title");
+    [Fact] void should_keep_an_apostrophe_in_the_property_documentation() => _generatedCode.ShouldContain("the provider's display name");
+    [Fact] void should_keep_quotes_as_written() => _generatedCode.ShouldContain("\"the old one\"");
+    [Fact] void should_keep_an_ampersand_as_written() => _generatedCode.ShouldContain("& the new");
+    [Fact] void should_not_html_escape_the_documentation() => _generatedCode.ShouldNotContain("&#x27;");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
@@ -14,7 +14,7 @@ import { {{{Type}}} } from '{{Module}}';
 
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 export interface I{{Name}} {
@@ -22,7 +22,7 @@ export interface I{{Name}} {
     {{#if Documentation}}
     
     /**
-     * {{Documentation}}
+     * {{{Documentation}}}
      */
     {{/if}}
     {{#if IsEnumerable}}
@@ -48,7 +48,7 @@ export class {{Name}}Validator extends CommandValidator<I{{Name}}> {
 
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 {{#if HasResponse }}
@@ -105,7 +105,7 @@ export class {{Name}} extends Command<I{{Name}}> implements I{{Name}} {
     {{#Properties}}
     {{#if Documentation}}
     /**
-     * {{Documentation}}
+     * {{{Documentation}}}
      */
     {{/if}}
     {{#if IsEnumerable}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Enum.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Enum.hbs
@@ -5,7 +5,7 @@
 // eslint-disable-next-line header/header
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 export enum {{Name}} {

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/FlagsEnum.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/FlagsEnum.hbs
@@ -5,7 +5,7 @@
 // eslint-disable-next-line header/header
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 export enum {{Name}} {

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -55,7 +55,7 @@ class {{Name}}SortByWithoutQuery {
 {{#if Parameters.[0]}}
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 export interface {{Name}}Parameters {
@@ -63,7 +63,7 @@ export interface {{Name}}Parameters {
     
     {{#if Documentation}}
     /**
-     * {{Documentation}}
+     * {{{Documentation}}}
      */
     {{/if}}
     {{#if IsOptional}}
@@ -89,7 +89,7 @@ export class {{Name}}Validator extends QueryValidator<{{Name}}Parameters> {
 
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 {{#if IsEnumerable}}
@@ -113,7 +113,7 @@ export class {{Name}}Validator extends QueryValidator<object> {
 
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 {{#if IsEnumerable}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
@@ -55,7 +55,7 @@ class {{Name}}SortByWithoutQuery {
 {{#if Parameters.[0]}}
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 export interface {{Name}}Parameters {
@@ -63,7 +63,7 @@ export interface {{Name}}Parameters {
     {{#if Documentation}}
     
     /**
-     * {{Documentation}}
+     * {{{Documentation}}}
     */
     {{/if}}
     {{#if IsOptional}}
@@ -89,7 +89,7 @@ export class {{Name}}Validator extends QueryValidator<{{Name}}Parameters> {
 
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 {{#if IsEnumerable}}
@@ -113,7 +113,7 @@ export class {{Name}}Validator extends QueryValidator<object> {
 
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 {{#if IsEnumerable}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Type.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Type.hbs
@@ -17,7 +17,7 @@ import { {{{Type}}} } from '{{Module}}';
 
 {{#if Documentation}}
 /**
- * {{Documentation}}
+ * {{{Documentation}}}
  */
 {{/if}}
 {{#if DerivedTypeId}}
@@ -28,7 +28,7 @@ export class {{Name}}{{#if BaseTypeName}} extends {{BaseTypeName}}{{/if}} {
     {{#if Documentation}}
 
     /**
-     * {{Documentation}}
+     * {{{Documentation}}}
      */
     {{/if}}
     {{#if IsEnumerable}}


### PR DESCRIPTION
# Summary

A generated proxy is TypeScript and its documentation is a JSDoc comment, not markup, but the templates rendered it through Handlebars' escaping expression. Every apostrophe in a summary reached the proxy as `&#x27;`, which is what a reader sees in their editor's tooltip; quotes and ampersands went the same way.

It surfaced on upgrading a downstream application: regenerating against the current generator rewrote 418 apostrophes across 163 proxy files that had none before.

## Fixed

- Documentation in generated TypeScript proxies keeps apostrophes, quotes and ampersands as written, instead of arriving HTML-escaped as `&#x27;`, `&quot;` and `&amp;`
