### PR TITLE
Make CommandScenario disposable and stop defaulting to console logging

### DIFF
--- a/Documentation/backend/testing/command-scenario.md
+++ b/Documentation/backend/testing/command-scenario.md
@@ -171,10 +171,35 @@ public class when_admin_command_executed_by_regular_user : Specification
 
 ## What the Scenario Provides
 
-`CommandScenario<TCommand>` adds console logging and calls `Services.AddCratisArcCore()` when first initialized, which wires:
+`CommandScenario<TCommand>` registers logging without a sink — `ILogger<T>` resolves as a no-op — and calls `Services.AddCratisArcCore()` when first initialized, which wires:
 
 - Type discovery for all handlers, validators, and filters
 - The real `ICommandPipeline`
 - All built-in validation and authorization filters
 
 Everything that runs in production runs in the spec — there is no hidden short-circuiting.
+
+No log output is produced by default, keeping scenarios lightweight — a console logger would otherwise spawn a background thread per scenario. To see log output while debugging a scenario, opt in before the first `Execute` or `Validate`:
+
+```csharp
+_scenario.Services.AddLogging(logging => logging.AddConsole());
+```
+
+## Disposal
+
+`CommandScenario<TCommand>` implements both `IDisposable` and `IAsyncDisposable`. Disposing it releases the service provider it built and disposes any disposable values extension packages placed in `Context` — the Chronicle extender's `EventScenario` is cleaned up this way. Disposal is idempotent, and calling `Execute` or `Validate` on a disposed scenario throws `ObjectDisposedException`.
+
+With Cratis Specifications, dispose the scenario in `Destroy()`:
+
+```csharp
+public class when_adding_item_to_cart : Specification
+{
+    readonly CommandScenario<AddItemToCart> _scenario = new();
+
+    void Destroy() => _scenario.Dispose();
+
+    // ...
+}
+```
+
+With plain xUnit, implement `IDisposable` (or `IAsyncDisposable`) on the test class and dispose the scenario there — xUnit disposes the test class after each test. Each scenario builds a full service provider on first use, so disposing it per test keeps long spec runs from accumulating providers.

--- a/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
+++ b/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
@@ -127,9 +127,7 @@ public static class HostBuilderExtensions
     /// <returns><see cref="IServiceCollection"/> for building continuation.</returns>
     public static IServiceCollection AddCratisArcMeter(this IServiceCollection services)
     {
-#pragma warning disable CA2000 // Dispose objects before losing scope
-        services.TryAddKeyedSingleton(Internals.MeterName, new Meter(Internals.MeterName));
-#pragma warning restore CA2000 // Dispose objects before losing scope
+        services.TryAddKeyedSingleton(Internals.MeterName, (_, _) => new Meter(Internals.MeterName));
         return services;
     }
 

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/AsyncTrackedResource.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/AsyncTrackedResource.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Testing.for_CommandScenario;
+
+/// <summary>
+/// A resource implementing both <see cref="IAsyncDisposable"/> and <see cref="IDisposable"/> that records
+/// which disposal path was taken and how many times.
+/// </summary>
+public sealed class AsyncTrackedResource : IAsyncDisposable, IDisposable
+{
+    /// <summary>
+    /// Gets the number of times <see cref="DisposeAsync"/> has been called.
+    /// </summary>
+    public int AsyncDisposeCount { get; private set; }
+
+    /// <summary>
+    /// Gets the number of times <see cref="Dispose"/> has been called.
+    /// </summary>
+    public int DisposeCount { get; private set; }
+
+    /// <inheritdoc/>
+    public ValueTask DisposeAsync()
+    {
+        AsyncDisposeCount++;
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => DisposeCount++;
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/PerformWork.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/PerformWork.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+
+namespace Cratis.Arc.Testing.for_CommandScenario;
+
+/// <summary>
+/// A command whose handler takes a <see cref="TrackedResource"/> dependency, forcing the scenario's
+/// service provider to materialize the registered singleton.
+/// </summary>
+[Command]
+public record PerformWork
+{
+    /// <summary>
+    /// Handles the command by touching the injected resource.
+    /// </summary>
+    /// <param name="resource">The <see cref="TrackedResource"/> resolved from the scenario's services.</param>
+    public void Handle(TrackedResource resource) => resource.Touch();
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/TrackedResource.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/TrackedResource.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Testing.for_CommandScenario;
+
+/// <summary>
+/// A disposable resource that records how many times it was disposed and whether it was used.
+/// </summary>
+public sealed class TrackedResource : IDisposable
+{
+    /// <summary>
+    /// Gets the number of times <see cref="Dispose"/> has been called.
+    /// </summary>
+    public int DisposeCount { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Touch"/> has been called.
+    /// </summary>
+    public bool Touched { get; private set; }
+
+    /// <summary>
+    /// Marks the resource as used.
+    /// </summary>
+    public void Touch() => Touched = true;
+
+    /// <inheritdoc/>
+    public void Dispose() => DisposeCount++;
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_constructing/with_default_services.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_constructing/with_default_services.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Testing.for_CommandScenario.when_constructing;
+
+/// <summary>
+/// The scenario must stay lightweight: logging resolves as a no-op, so no log sink — and no sink's
+/// background infrastructure — is registered unless a spec opts in.
+/// </summary>
+public class with_default_services : Specification
+{
+    CommandScenario<PerformWork> _scenario;
+
+    void Because() => _scenario = new CommandScenario<PerformWork>();
+
+    [Fact] void should_not_register_any_log_sink() => _scenario.Services.Any(_ => _.ServiceType == typeof(ILoggerProvider)).ShouldBeFalse();
+    [Fact] void should_register_logging() => _scenario.Services.Any(_ => _.ServiceType == typeof(ILoggerFactory)).ShouldBeTrue();
+
+    void Destroy() => _scenario.Dispose();
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing/and_disposing_again.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing/and_disposing_again.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Testing.for_CommandScenario.when_disposing;
+
+/// <summary>
+/// Disposal is idempotent: a second dispose neither throws nor disposes anything a second time.
+/// </summary>
+public class and_disposing_again : Specification
+{
+    CommandScenario<PerformWork> _scenario;
+    TrackedResource _resource;
+    Exception _error;
+
+    void Establish()
+    {
+        _scenario = new CommandScenario<PerformWork>();
+        _resource = new TrackedResource();
+        _scenario.Context["resource"] = _resource;
+    }
+
+    void Because()
+    {
+        _scenario.Dispose();
+        _error = Catch.Exception(_scenario.Dispose);
+    }
+
+    [Fact] void should_not_fail() => _error.ShouldBeNull();
+    [Fact] void should_only_dispose_once() => _resource.DisposeCount.ShouldEqual(1);
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing/and_the_context_holds_disposable_values.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing/and_the_context_holds_disposable_values.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Testing.for_CommandScenario.when_disposing;
+
+/// <summary>
+/// Extenders park resources in the context dictionary; disposing the scenario must dispose them —
+/// even when the scenario was never initialized — so extension packages need no coupling to be cleaned up.
+/// </summary>
+public class and_the_context_holds_disposable_values : Specification
+{
+    CommandScenario<PerformWork> _scenario;
+    TrackedResource _resource;
+
+    void Establish()
+    {
+        _scenario = new CommandScenario<PerformWork>();
+        _resource = new TrackedResource();
+        _scenario.Context["resource"] = _resource;
+    }
+
+    void Because() => _scenario.Dispose();
+
+    [Fact] void should_dispose_the_context_value() => _resource.DisposeCount.ShouldEqual(1);
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing/and_the_scenario_has_executed.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing/and_the_scenario_has_executed.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Testing.for_CommandScenario.when_disposing;
+
+/// <summary>
+/// Disposing an executed scenario must dispose the service provider it built, releasing every
+/// container-owned disposable the pipeline materialized.
+/// </summary>
+public class and_the_scenario_has_executed : Specification
+{
+    CommandScenario<PerformWork> _scenario;
+    TrackedResource _resource;
+    CommandResult _result;
+
+    async Task Establish()
+    {
+        _resource = new TrackedResource();
+        _scenario = new CommandScenario<PerformWork>();
+        _scenario.Services.AddSingleton(_ => _resource);
+        _result = await _scenario.Execute(new PerformWork());
+    }
+
+    void Because() => _scenario.Dispose();
+
+    [Fact] void should_execute_successfully() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_have_materialized_the_resource() => _resource.Touched.ShouldBeTrue();
+    [Fact] void should_dispose_the_service_provider_owned_resource() => _resource.DisposeCount.ShouldEqual(1);
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing_asynchronously/and_the_context_holds_async_disposable_values.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_disposing_asynchronously/and_the_context_holds_async_disposable_values.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Testing.for_CommandScenario.when_disposing_asynchronously;
+
+/// <summary>
+/// Asynchronous disposal prefers <see cref="IAsyncDisposable"/> on context values, only falling back
+/// to <see cref="IDisposable"/> when a value has no asynchronous path.
+/// </summary>
+public class and_the_context_holds_async_disposable_values : Specification
+{
+    CommandScenario<PerformWork> _scenario;
+    AsyncTrackedResource _asyncResource;
+    TrackedResource _syncOnlyResource;
+
+    void Establish()
+    {
+        _scenario = new CommandScenario<PerformWork>();
+        _asyncResource = new AsyncTrackedResource();
+        _syncOnlyResource = new TrackedResource();
+        _scenario.Context["async"] = _asyncResource;
+        _scenario.Context["sync"] = _syncOnlyResource;
+    }
+
+    async Task Because() => await _scenario.DisposeAsync();
+
+    [Fact] void should_dispose_through_the_async_path() => _asyncResource.AsyncDisposeCount.ShouldEqual(1);
+    [Fact] void should_not_dispose_through_the_sync_path() => _asyncResource.DisposeCount.ShouldEqual(0);
+    [Fact] void should_fall_back_to_sync_disposal_for_sync_only_values() => _syncOnlyResource.DisposeCount.ShouldEqual(1);
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_using_a_disposed_scenario/and_executing_a_command.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_using_a_disposed_scenario/and_executing_a_command.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Testing.for_CommandScenario.when_using_a_disposed_scenario;
+
+/// <summary>
+/// A disposed scenario must refuse to run: executing after disposal fails loudly instead of
+/// rebuilding a provider that would leak.
+/// </summary>
+public class and_executing_a_command : Specification
+{
+    CommandScenario<PerformWork> _scenario;
+    Exception _error;
+
+    void Establish()
+    {
+        _scenario = new CommandScenario<PerformWork>();
+        _scenario.Dispose();
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _scenario.Execute(new PerformWork()));
+
+    [Fact] void should_throw_object_disposed() => _error.ShouldBeOfExactType<ObjectDisposedException>();
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_using_a_disposed_scenario/and_validating_a_command.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandScenario/when_using_a_disposed_scenario/and_validating_a_command.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Testing.for_CommandScenario.when_using_a_disposed_scenario;
+
+/// <summary>
+/// Validation goes through the same guard as execution: a disposed scenario fails loudly.
+/// </summary>
+public class and_validating_a_command : Specification
+{
+    CommandScenario<PerformWork> _scenario;
+    Exception _error;
+
+    void Establish()
+    {
+        _scenario = new CommandScenario<PerformWork>();
+        _scenario.Dispose();
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _scenario.Validate(new PerformWork()));
+
+    [Fact] void should_throw_object_disposed() => _error.ShouldBeOfExactType<ObjectDisposedException>();
+}

--- a/Source/DotNET/Testing/Commands/CommandScenario.cs
+++ b/Source/DotNET/Testing/Commands/CommandScenario.cs
@@ -5,7 +5,6 @@ using Cratis.Arc.Commands;
 using Cratis.Arc.Validation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 
 namespace Cratis.Arc.Testing.Commands;
 
@@ -21,6 +20,14 @@ namespace Cratis.Arc.Testing.Commands;
 /// <para>
 /// The service provider and pipeline are built lazily on the first call to <see cref="Execute"/> or
 /// <see cref="Validate"/>. Register all services in the test constructor before any pipeline call.
+/// </para>
+/// <para>
+/// No log sink is registered by default — <c>ILogger&lt;T&gt;</c> resolves as a no-op logger, so scenarios
+/// stay lightweight and spawn no logging infrastructure threads. To see console output while debugging a
+/// scenario, opt in before the first call to <see cref="Execute"/> or <see cref="Validate"/>:
+/// <code>
+/// scenario.Services.AddLogging(logging => logging.AddConsole());
+/// </code>
 /// </para>
 /// <para>
 /// Extension packages can contribute services and context values by implementing
@@ -61,7 +68,7 @@ public class CommandScenario<TCommand>
     {
         Services = new ServiceCollection();
         Services.AddOptions();
-        Services.AddLogging(logging => logging.AddConsole());
+        Services.AddLogging();
         Services.Configure<ArcOptions>(_ => { });
 
         Context = new Dictionary<string, object>();

--- a/Source/DotNET/Testing/Commands/CommandScenario.cs
+++ b/Source/DotNET/Testing/Commands/CommandScenario.cs
@@ -35,6 +35,11 @@ namespace Cratis.Arc.Testing.Commands;
 /// time via the type discovery system and invoked before any command is executed.
 /// </para>
 /// <para>
+/// The scenario owns the service provider it builds and any disposable values extenders placed in
+/// <see cref="Context"/>. Dispose the scenario — or let the test framework do it — to release them;
+/// see <see cref="Dispose()"/> and <see cref="DisposeAsync()"/>.
+/// </para>
+/// <para>
 /// The typical pattern with xUnit:
 /// <code>
 /// public class when_adding_item_to_cart
@@ -52,10 +57,11 @@ namespace Cratis.Arc.Testing.Commands;
 /// </para>
 /// </remarks>
 /// <typeparam name="TCommand">The type of command under test.</typeparam>
-public class CommandScenario<TCommand>
+public class CommandScenario<TCommand> : IDisposable, IAsyncDisposable
 {
     IServiceProvider? _serviceProvider;
     ICommandPipeline? _pipeline;
+    bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CommandScenario{TCommand}"/> class.
@@ -109,8 +115,10 @@ public class CommandScenario<TCommand>
     /// </remarks>
     /// <param name="command">The command to execute.</param>
     /// <returns>A <see cref="Task{TResult}"/> that resolves to the <see cref="CommandResult"/>.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the scenario has been disposed.</exception>
     public Task<CommandResult> Execute(TCommand command)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureInitialized();
         return _pipeline!.Execute(command!, _serviceProvider!);
     }
@@ -123,10 +131,106 @@ public class CommandScenario<TCommand>
     /// </remarks>
     /// <param name="command">The command to validate.</param>
     /// <returns>A <see cref="Task{TResult}"/> that resolves to the <see cref="CommandResult"/>.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the scenario has been disposed.</exception>
     public Task<CommandResult> Validate(TCommand command)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureInitialized();
         return _pipeline!.Validate(command!, _serviceProvider!);
+    }
+
+    /// <summary>
+    /// Disposes the scenario, releasing the service provider built for it and any disposable values in <see cref="Context"/>.
+    /// </summary>
+    /// <remarks>
+    /// Safe to call multiple times; only the first call disposes. After disposal, calls to
+    /// <see cref="Execute"/> or <see cref="Validate"/> throw <see cref="ObjectDisposedException"/>.
+    /// </remarks>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the scenario, releasing the service provider built for it and any disposable values in <see cref="Context"/>.
+    /// </summary>
+    /// <remarks>
+    /// Prefers <see cref="IAsyncDisposable"/> on the service provider and context values when available,
+    /// falling back to <see cref="IDisposable"/>. Safe to call multiple times; only the first call disposes.
+    /// After disposal, calls to <see cref="Execute"/> or <see cref="Validate"/> throw <see cref="ObjectDisposedException"/>.
+    /// </remarks>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous dispose operation.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore().ConfigureAwait(false);
+        Dispose(disposing: false);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes the resources owned by the scenario.
+    /// </summary>
+    /// <param name="disposing">True when called from <see cref="Dispose()"/>, false when called from a finalizer path.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            (_serviceProvider as IDisposable)?.Dispose();
+
+            foreach (var value in Context.Values.Distinct().OfType<IDisposable>())
+            {
+                value.Dispose();
+            }
+        }
+
+        _serviceProvider = null;
+        _pipeline = null;
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the resources owned by the scenario.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous dispose operation.</returns>
+    protected virtual async ValueTask DisposeAsyncCore()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        switch (_serviceProvider)
+        {
+            case IAsyncDisposable asyncDisposableProvider:
+                await asyncDisposableProvider.DisposeAsync().ConfigureAwait(false);
+                break;
+            case IDisposable disposableProvider:
+                disposableProvider.Dispose();
+                break;
+        }
+
+        foreach (var value in Context.Values.Distinct())
+        {
+            switch (value)
+            {
+                case IAsyncDisposable asyncDisposableValue:
+                    await asyncDisposableValue.DisposeAsync().ConfigureAwait(false);
+                    break;
+                case IDisposable disposableValue:
+                    disposableValue.Dispose();
+                    break;
+            }
+        }
+
+        _serviceProvider = null;
+        _pipeline = null;
+        _disposed = true;
     }
 
     void EnsureInitialized()

--- a/Source/DotNET/Testing/Testing.csproj
+++ b/Source/DotNET/Testing/Testing.csproj
@@ -9,7 +9,4 @@
     <ItemGroup>
         <ProjectReference Include="../Arc.Core/Arc.Core.csproj" />
     </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" />
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Added

- `CommandScenario<TCommand>` implements `IDisposable` and `IAsyncDisposable`, disposing the service provider it builds and any disposable values extension packages place in `Context` (such as the Chronicle extender's `EventScenario`); disposal is idempotent and `Execute`/`Validate` throw `ObjectDisposedException` after disposal (#2629)

## Changed

- `CommandScenario<TCommand>` no longer registers a console logger by default — `ILogger<T>` resolves as a no-op, so no logging processor thread is spawned per scenario; opt in with `scenario.Services.AddLogging(l => l.AddConsole())` before the first `Execute`/`Validate` to see log output (#2629)

## Fixed

- `AddCratisArcMeter` no longer creates and abandons an undisposed `Meter` on every call after the first — the meter is created only when actually registered and is now owned and disposed by the service provider (#2629)
