### PR TITLE
Let a type whose file is named after it keep its own imports

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_two_types_share_a_short_name.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_two_types_share_a_short_name.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_DescriptorExtensions.when_writing_descriptors;
+
+/// <summary>
+/// Two different types share the short name `Shared`. One lives in a file named after itself, the other in
+/// a file named something else. The one that moves must not be allowed to rewrite imports of the one that
+/// does not - a short name claimed by two types is ambiguous, so neither gets a fixup.
+/// </summary>
+public class and_two_types_share_a_short_name : Specification, IDisposable
+{
+    string _tempDir = null!;
+    string _expectedFilePath = null!;
+    TypeDescriptor _descriptor = null!;
+    Dictionary<string, GeneratedFileMetadata> _generatedFiles = null!;
+    List<string> _directories = null!;
+    List<Type> _typesInvolved = null!;
+    Dictionary<string, string> _sourceFileMap = null!;
+    string _fileContent = null!;
+
+    void Establish()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+
+        _generatedFiles = [];
+        _directories = [];
+        _typesInvolved = [];
+
+        var descriptorType = typeof(ImporterOfShared);
+        var importedType = typeof(Shared);
+
+        var imports = new List<ImportStatement> { new(importedType, "Shared", "./Shared") };
+
+        _descriptor = new TypeDescriptor(
+            descriptorType,
+            "ImporterOfShared",
+            [new PropertyDescriptor(importedType, "myProp", "Shared", string.Empty, string.Empty, false, false, false, null)],
+            imports.OrderBy(_ => _.Module),
+            [importedType]);
+
+        _sourceFileMap = new Dictionary<string, string>
+        {
+            [descriptorType.FullName!] = "ImporterOfShared",
+
+            // This one's file is named after it, so it needs no rewrite - but it does claim the name.
+            [importedType.FullName!] = "Shared",
+
+            // A different type, same short name, in a file called something else entirely.
+            ["Some.Other.Namespace.Shared"] = "Grouped"
+        };
+
+        var path = descriptorType.ResolveTargetPath(0);
+        _expectedFilePath = Path.GetFullPath(Path.Join(_tempDir, path, "ImporterOfShared.ts"));
+    }
+
+    async Task Because()
+    {
+        await new[] { _descriptor }.Write(
+            _tempDir,
+            _typesInvolved,
+            TemplateTypes.Type,
+            _directories,
+            0,
+            "types",
+            _ => { },
+            _ => { },
+            _generatedFiles,
+            sourceFileMap: _sourceFileMap);
+
+        _fileContent = await File.ReadAllTextAsync(_expectedFilePath);
+    }
+
+    [Fact] void should_leave_the_import_pointing_at_its_own_file() => _fileContent.ShouldContain("from './Shared'");
+    [Fact] void should_not_redirect_it_to_the_other_types_file() => _fileContent.ShouldNotContain("from './Grouped'");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+}
+
+public class ImporterOfShared;
+public class Shared;

--- a/Source/DotNET/Tools/ProxyGenerator/DescriptorExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/DescriptorExtensions.cs
@@ -412,32 +412,40 @@ public static partial class DescriptorExtensions
     /// <returns>Dictionary mapping type short name to source file name.</returns>
     static Dictionary<string, string> BuildImportPathFixups(IReadOnlyDictionary<string, string> sourceFileMap)
     {
-        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        var claimed = new Dictionary<string, string>(StringComparer.Ordinal);
         var conflicts = new HashSet<string>(StringComparer.Ordinal);
 
+        // A type whose file is already named after it needs no rewrite, but it still has to be counted -
+        // it is the reason a short name is taken. Skipping it here would let another type with the same
+        // short name, declared in a differently named file, claim the name unopposed, and every import of
+        // the first type would then be rewritten to the second one's file.
         foreach (var (fullName, sourceFile) in sourceFileMap)
         {
             var shortName = fullName.Split('.')[^1];
-            if (shortName == sourceFile || conflicts.Contains(shortName))
+            if (conflicts.Contains(shortName))
             {
                 continue;
             }
 
-            if (result.TryGetValue(shortName, out var existing))
+            if (claimed.TryGetValue(shortName, out var existing))
             {
                 if (existing != sourceFile)
                 {
-                    result.Remove(shortName);
+                    claimed.Remove(shortName);
                     conflicts.Add(shortName);
                 }
             }
             else
             {
-                result[shortName] = sourceFile;
+                claimed[shortName] = sourceFile;
             }
         }
 
-        return result;
+        // Only the ones that actually move need an entry; a short name that already matches its file is
+        // left alone rather than rewritten to itself.
+        return claimed
+            .Where(_ => _.Key != _.Value)
+            .ToDictionary(_ => _.Key, _ => _.Value, StringComparer.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
## Fixed

- **In source-file grouping mode, two types sharing a short name could have one rewrite the other's imports**, producing TypeScript that does not compile. `BuildImportPathFixups` skipped any type whose file was already named after it — true that it needs no rewrite, but it also took that type out of conflict detection, so the *other* type claimed the short name unopposed and the fixup was applied to every import of either.

---

Found in Cratis Studio, which uses `CratisProxiesUseSourceFileAsOutputFile`. `ScreenTemplate` exists twice there: Scene's model declares one in `ScreenTemplate.cs`, and Studio declares its own in `Projects/Hierarchy/Hierarchy.cs`. Scene's needed no rewrite and so was skipped; Studio's claimed the name; and the generated `SceneApplication.ts` came out with

```ts
import { ScreenTemplate } from '../../../Scene/Model/Screens/Hierarchy';
```

pointing at a file that does not exist, while the type had in fact been emitted to `Screens/ScreenTemplate.ts`.

Such a type now takes part in claiming the name like any other, and entries that would rewrite a name to itself are dropped at the end instead. A short name two types disagree about stays a conflict and gets no fixup — which is what the conflict set was always there to do.

The regression spec (`and_two_types_share_a_short_name`) fails on both of its assertions without the change and passes with it.

Verified: 51 projects build in Release with 0 errors and 0 warnings, and 1227 ProxyGenerator specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)