### PR TITLE
Let a project ask for interface emission from its build

### DIFF
--- a/Documentation/backend/proxy-generation/Configuration/emit-interfaces.md
+++ b/Documentation/backend/proxy-generation/Configuration/emit-interfaces.md
@@ -1,0 +1,64 @@
+# Emit Interfaces
+
+By default the generator emits each type as a **class** carrying `@field` decorators:
+
+```ts
+import { field } from '@cratis/fundamentals';
+
+export class Grid extends Panel {
+    @field(RowDefinition, true)
+    rows!: RowDefinition[];
+}
+```
+
+The decorators carry runtime type information so `@cratis/fundamentals` can reconstruct an instance from JSON — which is what a command or query proxy needs. They also mean every generated file imports `@cratis/fundamentals`.
+
+**Emit-interfaces mode** produces plain TypeScript interfaces instead:
+
+```ts
+export interface Grid extends Panel {
+    rows: RowDefinition[];
+}
+```
+
+Same shape, same documentation, same inheritance, same imports for the types a property refers to — but no class, no decorators, and no import of `@cratis/fundamentals`.
+
+## Enabling it
+
+```xml
+<PropertyGroup>
+    <CratisProxiesEmitInterfaces>true</CratisProxiesEmitInterfaces>
+</PropertyGroup>
+```
+
+### CLI
+
+```bash
+proxygenerator assembly.dll output-path --library-mode --emit-interfaces
+```
+
+## When to use it
+
+Use it for a model that is **built and read but never deserialized** through Fundamentals' `JsonSerializer` — and, in particular, for a package that must not take a runtime dependency. A package deliberately published with no dependencies cannot accept one just to describe its own shapes, which otherwise rules out generating its TypeScript at all and leaves it hand-maintained.
+
+Do **not** use it for command and query proxies. Those are deserialized from HTTP responses, and without the decorators the deserializer has no type information to reconstruct with.
+
+## What it does not remove
+
+Only the decorators and the import they need. A model that uses types **Fundamentals provides** still imports those, because they are the TypeScript representation of the C# types:
+
+```ts
+import { TimeOnly } from '@cratis/fundamentals';
+
+export interface ScheduleTriggerSourceSyntax extends TriggerSourceSyntax {
+    at: TimeOnly;
+}
+```
+
+That import is a type, not a decorator, and no emission mode can remove it — the property genuinely is a `TimeOnly`.
+
+## Combining with library mode
+
+The two are usually used together: [library mode](library-mode.md) is what makes the generator emit a model that no command or query references, and emit-interfaces is what lets the result stay dependency-free.
+
+Neither implies the other. Emit-interfaces on its own changes how the types reached from commands and queries are rendered, which is rarely what you want — see the warning above.

--- a/Documentation/backend/proxy-generation/Configuration/index.md
+++ b/Documentation/backend/proxy-generation/Configuration/index.md
@@ -4,6 +4,7 @@ The proxy generator is configured through MSBuild properties and item groups in 
 
 - [Basic Options](basic.md) — output path, segments to skip, source file output, decorator metadata
 - [Library Mode](library-mode.md) — generate TypeScript for every public type in the assembly
+- [Emit Interfaces](emit-interfaces.md) — plain interfaces with no decorators and no runtime dependency
 - [Type Exclusions](type-exclusions.md) — exclude specific types or namespaces from generation
 - [Namespace Roots](namespace-roots.md) — pin a namespace as the folder root
 - [Assembly-to-Package Mappings](assembly-package-mappings.md) — import from external npm packages instead of regenerating
@@ -18,6 +19,7 @@ The proxy generator is configured through MSBuild properties and item groups in 
 | `CratisProxiesSegmentsToSkip` | `0` | [Basic](basic.md) |
 | `CratisProxiesUseSourceFileAsOutputFile` | `false` | [Basic](basic.md) |
 | `CratisProxiesLibraryMode` | `false` | [Library Mode](library-mode.md) |
+| `CratisProxiesEmitInterfaces` | `false` | [Emit Interfaces](emit-interfaces.md) |
 | `<ExcludeType TypeName="..."/>` | — | [Type Exclusions](type-exclusions.md) |
 | `<ExcludeNamespace Namespace="..."/>` | — | [Type Exclusions](type-exclusions.md) |
 | `<NamespaceRoot Namespace="..."/>` | — | [Namespace Roots](namespace-roots.md) |

--- a/Documentation/backend/proxy-generation/Configuration/library-mode.md
+++ b/Documentation/backend/proxy-generation/Configuration/library-mode.md
@@ -25,7 +25,11 @@ When library mode is on:
 - All public, non-abstract classes and records in every project assembly are collected and generated as TypeScript interfaces.
 - All public interfaces are included.
 - All public enums are included.
-- Abstract classes are skipped (they cannot be instantiated).
+- Abstract classes are not collected directly, but are still generated when something reachable derives
+  from one - a concrete type's base class is followed, so an inheritance chain arrives intact rather
+  than with its roots missing.
+- Open generic definitions are skipped, along with their type parameters: neither has a concrete shape
+  to emit.
 - Types excluded via [`ExcludeType` or `ExcludeNamespace`](type-exclusions.md) are still skipped.
 - Types from assemblies mapped via [`AssemblyToPackageMapping`](assembly-package-mappings.md) are still imported from their package rather than regenerated.
 

--- a/Documentation/backend/proxy-generation/Configuration/toc.yml
+++ b/Documentation/backend/proxy-generation/Configuration/toc.yml
@@ -4,6 +4,8 @@
   href: basic.md
 - name: Library Mode
   href: library-mode.md
+- name: Emit Interfaces
+  href: emit-interfaces.md
 - name: Type Exclusions
   href: type-exclusions.md
 - name: Namespace Roots

--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
@@ -33,6 +33,7 @@
             <SkipFileIndexTracking Condition=" '$(CratisProxiesSkipFileIndexTracking)' == 'true' ">--skip-file-index-tracking</SkipFileIndexTracking>
             <SkipIndexGeneration Condition=" '$(CratisProxiesSkipIndexGeneration)' == 'true' ">--skip-index-generation</SkipIndexGeneration>
             <UseSourceFileAsOutputFile Condition=" '$(CratisProxiesUseSourceFileAsOutputFile)' == 'true' ">--use-source-file-as-output-file</UseSourceFileAsOutputFile>
+            <EmitInterfaces Condition=" '$(CratisProxiesEmitInterfaces)' == 'true' ">--emit-interfaces</EmitInterfaces>
             <AssemblyPackageMappings>@(AssemblyToPackageMapping -> '--assembly-to-package=%(Assembly)=%(Package)', ' ')</AssemblyPackageMappings>
             <ExcludeTypes>@(ExcludeType -> '--exclude-type=%(TypeName)', ' ')</ExcludeTypes>
             <ExcludeNamespaces>@(ExcludeNamespace -> '--exclude-namespace=%(Namespace)', ' ')</ExcludeNamespaces>
@@ -46,7 +47,7 @@
         </PropertyGroup>
 
         <Exec ConsoleToMsBuild="true"
-            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(LibraryMode) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile) $(AssemblyPackageMappings) $(ExcludeTypes) $(ExcludeNamespaces) $(NamespaceRoots) $(TypeMappings)"
+            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(LibraryMode) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile) $(EmitInterfaces) $(AssemblyPackageMappings) $(ExcludeTypes) $(ExcludeNamespaces) $(NamespaceRoots) $(TypeMappings)"
             WorkingDirectory="$(CratisProxyGeneratorAssemblyDirectory)" />
     </Target>
 </Project>


### PR DESCRIPTION
## Fixed

- **`--emit-interfaces` had no MSBuild property**, which left it unusable for the thing it exists for: a package generating its own TypeScript model as part of its build cannot reach a flag only the command line accepts. `CratisProxiesEmitInterfaces` now maps to it, alongside every other option.

## Added

- **Documentation for the mode** — what it emits, when to use it, when not to, and that it removes the decorators and their import but *not* an import of a type Fundamentals genuinely provides, such as `TimeOnly`. Wired into the configuration index and table of contents.

## Changed

- **The library-mode page no longer claims abstract classes are skipped.** They are not collected directly, but a concrete type's base class is followed — so an inheritance chain arrives intact rather than with its roots missing, which is what makes the mode usable for a model with an abstract hierarchy at all. Open generic definitions and their type parameters are the things actually skipped.

---

Follow-up to #2636, which added the flag and the emission mode but stopped at the CLI. Found while trying to adopt it in Cratis/Scene, whose `Cratis.Scene.Model` is exactly the intended consumer: a deliberately dependency-free package that has been hand-maintaining its TypeScript mirror because generation was not available to it.

The targets file is packed into both `build` and `buildTransitive`, so the single edit covers direct and transitive consumers.

Verified: 51 projects build in Release with 0 errors and 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)