### PR TITLE
Adopt the shared local-work-artifacts corpus rule

### DIFF
--- a/.claude/rules/local-work-artifacts.md
+++ b/.claude/rules/local-work-artifacts.md
@@ -1,0 +1,1 @@
+../../.ai/rules/local-work-artifacts.md


### PR DESCRIPTION
Adds `.claude/rules/local-work-artifacts.md`, the corpus rule already tracked in `Components` and `AI`.

AI session work records — plans, handovers, session notes, continuation prompts, status boards — belong in the gitignored `.ai-work/` folder, never at the repository root and never under documentation folders. Durable follow-ups become GitHub issues rather than planning files left in the tree.

This file was sitting untracked in the local Arc checkout; committing it brings Arc in line with the repos that already enforce the rule.