### PR TITLE
Fix positional-record [Key] resolution and read-model resolver registration

### DIFF
--- a/Documentation/backend/chronicle/resolving-event-source-id.md
+++ b/Documentation/backend/chronicle/resolving-event-source-id.md
@@ -1,6 +1,6 @@
 ---
 title: Resolving EventSourceId
-description: "The conventions Chronicle uses to find an entity identity on a command or query argument — [Key], EventSourceId-convertible types, and ICanProvideEventSourceId."
+description: 'The conventions Chronicle uses to find an entity identity on a command or query argument — [Key], EventSourceId-convertible types, and ICanProvideEventSourceId.'
 ---
 
 Chronicle resolves an `EventSourceId` anywhere it needs an identity for an aggregate, event append, or read model lookup. The same conventions work whether the value comes from a command record or from query arguments bound from the HTTP request.
@@ -22,7 +22,7 @@ When Chronicle inspects a command, it resolves the event source id in this order
 
 1. Implement `ICanProvideEventSourceId` and return the id from `GetEventSourceId()`.
 2. Add a property whose type is `EventSourceId` or derives from it.
-3. Mark a property with `[Key]` and let Chronicle convert that value to `EventSourceId`.
+3. Mark a property with `[Key]` and let Chronicle convert that value to `EventSourceId`. On a positional record, `[Key]` can be placed directly on the matching constructor parameter, as shown below.
 
 If none of these are present, Chronicle creates a new `EventSourceId` so automatic event appends still have a valid identity.
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelForCommandServiceCollectionExtensions/when_adding_read_models_for_command.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelForCommandServiceCollectionExtensions/when_adding_read_models_for_command.cs
@@ -8,17 +8,28 @@ namespace Cratis.Arc.Queries.for_ReadModelForCommandServiceCollectionExtensions;
 public class when_adding_read_models_for_command : Specification
 {
     IServiceCollection _services;
+    ICanResolveReadModelForCommand _resolver;
     RegisteredReadModelTypes _registeredReadModelTypes;
 
-    void Establish() => _services = new ServiceCollection();
+    void Establish()
+    {
+        _services = new ServiceCollection();
+        _resolver = new a_read_model_resolver([typeof(FirstReadModel)]);
+    }
 
     void Because()
     {
-        _services.AddReadModelsForCommand(new a_read_model_resolver([typeof(FirstReadModel)]));
+        _services.AddReadModelsForCommand(_resolver);
         _registeredReadModelTypes = _services
             .First(descriptor => descriptor.ServiceType == typeof(RegisteredReadModelTypes))
             .ImplementationInstance as RegisteredReadModelTypes;
     }
+
+    [Fact] void should_register_the_provider_resolver() =>
+        _services.ShouldContain(descriptor =>
+            descriptor.ServiceType == typeof(ICanResolveReadModelForCommand) &&
+            descriptor.ImplementationInstance == _resolver &&
+            descriptor.Lifetime == ServiceLifetime.Singleton);
 
     [Fact] void should_register_a_scoped_resolver_for_the_read_model() =>
         _services.ShouldContain(descriptor => descriptor.ServiceType == typeof(FirstReadModel) && descriptor.Lifetime == ServiceLifetime.Scoped);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelForCommandServiceCollectionExtensions/when_resolving_registered_providers.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelForCommandServiceCollectionExtensions/when_resolving_registered_providers.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.for_ReadModelForCommandServiceCollectionExtensions;
+
+public class when_resolving_registered_providers : Specification
+{
+    a_read_model_resolver _firstResolver;
+    a_read_model_resolver _secondResolver;
+    ServiceProvider _serviceProvider;
+    ICanResolveReadModelForCommand[] _result;
+
+    void Establish()
+    {
+        _firstResolver = new([typeof(FirstReadModel)]);
+        _secondResolver = new([typeof(SecondReadModel)]);
+        _serviceProvider = new ServiceCollection()
+            .AddReadModelsForCommand(_firstResolver)
+            .AddReadModelsForCommand(_secondResolver)
+            .BuildServiceProvider();
+    }
+
+    void Because() => _result = _serviceProvider.GetServices<ICanResolveReadModelForCommand>().ToArray();
+
+    void Destroy() => _serviceProvider.Dispose();
+
+    [Fact] void should_resolve_the_first_provider() => _result.ShouldContain(_firstResolver);
+    [Fact] void should_resolve_the_second_provider() => _result.ShouldContain(_secondResolver);
+    [Fact] void should_resolve_each_provider_once() => _result.Length.ShouldEqual(2);
+}

--- a/Source/DotNET/Arc.Core/Queries/ReadModelForCommandServiceCollectionExtensions.cs
+++ b/Source/DotNET/Arc.Core/Queries/ReadModelForCommandServiceCollectionExtensions.cs
@@ -19,10 +19,11 @@ public static class ReadModelForCommandServiceCollectionExtensions
     /// <param name="resolver">The <see cref="ICanResolveReadModelForCommand"/> that owns and resolves the read model types.</param>
     /// <returns>The service collection for continuation.</returns>
     /// <remarks>
-    /// For each read model type the resolver claims, a scoped factory is registered that delegates to the resolver, so the
-    /// command pipeline resolves the read model from DI by type like any other dependency. The set of registered read
-    /// model types is additive: multiple providers can contribute their own types and the classification of a missing
-    /// read model as invalid client input sees the union across all of them.
+    /// The resolver is registered as an <see cref="ICanResolveReadModelForCommand"/> and, for each read model type it
+    /// claims, a scoped factory is registered that delegates to it, so the command pipeline resolves the read model from
+    /// DI by type like any other dependency. The set of registered read model types is additive: multiple providers can
+    /// contribute their own types and the classification of a missing read model as invalid client input sees the union
+    /// across all of them.
     /// <para>
     /// Which types a provider claims follows from its <see cref="ICanResolveReadModelForCommand.Ownership"/> rather than
     /// from the order the application registers its providers in. A <see cref="ReadModelForCommandOwnership.Declared"/>
@@ -47,6 +48,8 @@ public static class ReadModelForCommandServiceCollectionExtensions
     /// </remarks>
     public static IServiceCollection AddReadModelsForCommand(this IServiceCollection services, ICanResolveReadModelForCommand resolver)
     {
+        services.AddSingleton<ICanResolveReadModelForCommand>(resolver);
+
         var claimed = new List<Type>();
         foreach (var readModelType in resolver.ReadModelTypes)
         {

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_checking_has_event_source_id_for_command/with_key_attribute_positional_parameter.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_checking_has_event_source_id_for_command/with_key_attribute_positional_parameter.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceExtensions.when_checking_has_event_source_id_for_command;
+
+public class with_key_attribute_positional_parameter : Specification
+{
+    CommandWithKeyAttribute _command;
+    bool _result;
+
+    void Establish() => _command = new("some-id");
+
+    void Because() => _result = _command.HasEventSourceId();
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+
+    public record CommandWithKeyAttribute([Key] string Id);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_key_attribute_positional_parameter.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_key_attribute_positional_parameter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceExtensions.when_getting_event_source_id;
+
+public class from_command_with_key_attribute_positional_parameter : Specification
+{
+    CommandWithKeyAttribute _command;
+    string _keyValue;
+    EventSourceId _result;
+
+    void Establish()
+    {
+        _keyValue = "some-key-value";
+        _command = new(_keyValue);
+    }
+
+    void Because() => _result = _command.GetEventSourceId();
+
+    [Fact] void should_return_the_key_value_as_event_source_id() => _result.ShouldEqual((EventSourceId)_keyValue);
+
+    public record CommandWithKeyAttribute([Key] string Id);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_positional_command_parameter_marked_as_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_positional_command_parameter_marked_as_key.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_providing;
+
+public class with_a_positional_command_parameter_marked_as_key : Specification
+{
+    EventSourceValuesProvider _provider;
+    CommandContextValues _result;
+    Guid _id;
+
+    void Establish()
+    {
+        _provider = new EventSourceValuesProvider(new RecordingLogger<EventSourceValuesProvider>());
+        _id = Guid.NewGuid();
+    }
+
+    void Because() => _result = _provider.Provide(new CommandWithKey(_id));
+
+    [Fact] void should_resolve_the_event_source_id_from_the_parameter() =>
+        ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).Value.ShouldEqual(_id.ToString());
+
+    [Fact] void should_expose_the_key_for_read_model_resolution() =>
+        _result[CommandContextKeys.ResolvedKey].ShouldEqual(_id.ToString());
+
+    record CommandWithKey([Key] Guid Id);
+}

--- a/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
+++ b/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
@@ -84,14 +84,16 @@ public static class EventSourceExtensions
 
     /// <summary>
     /// Determines whether the given property is the command's event source key — an <see cref="EventSourceId"/>, a
-    /// generic <see cref="EventSourceId{T}"/> subtype, or a property carrying the <see cref="KeyAttribute"/>.
+    /// generic <see cref="EventSourceId{T}"/> subtype, or a property carrying the <see cref="KeyAttribute"/>. For a
+    /// positional record, the key attribute can be carried by the matching primary-constructor parameter instead.
     /// </summary>
     /// <param name="property">The property to check.</param>
     /// <returns>True if the property is the event source key; otherwise, false.</returns>
     internal static bool IsEventSourceKeyProperty(this PropertyInfo property) =>
         property.PropertyType.IsAssignableTo(typeof(EventSourceId)) ||
         IsGenericEventSourceIdType(property.PropertyType) ||
-        property.HasAttribute<KeyAttribute>();
+        property.HasAttribute<KeyAttribute>() ||
+        HasKeyAttributeOnMatchingConstructorParameter(property);
 
     /// <summary>
     /// Determines whether the given value is an <see cref="EventSourceId"/> or a generic <see cref="EventSourceId{T}"/> subtype.
@@ -134,6 +136,15 @@ public static class EventSourceExtensions
 
         return value.ToString()!;
     }
+
+    static bool HasKeyAttributeOnMatchingConstructorParameter(PropertyInfo property) =>
+        property.DeclaringType?
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .SelectMany(_ => _.GetParameters())
+            .Any(_ =>
+                _.Name == property.Name &&
+                _.ParameterType == property.PropertyType &&
+                _.GetCustomAttribute<KeyAttribute>() is not null) == true;
 
     /// <summary>
     /// Converts a value to an <see cref="EventSourceId"/>, returning <see cref="EventSourceId.Unspecified"/> when the


### PR DESCRIPTION
# Summary

A command that marks its key positionally — `record Foo([Key] Guid Id)` — compiled cleanly but silently failed to resolve, because the Chronicle key attribute lives on the constructor parameter, not the generated property, and nothing looked there. Chronicle fabricated a fresh, unrelated event source id instead, so a DCB read-model dependency injected into `Handle()`/`Provide()`/a validator always resolved to `null` — with no exception and `isSuccess: true` — for any command using this style, including with `WithMongoDB()`-only setups.

## Fixed

- Recognize `[Key]` on a positional record's primary-constructor parameter when resolving a command's event source id, so it behaves the same as `[Key]` on a property (#2645)
- Register each `ICanResolveReadModelForCommand` provider itself in DI (not just its per-type factories), so `IEnumerable<ICanResolveReadModelForCommand>` reflects every registered provider (#2645)
