### PR TITLE
Align command read-model eligibility and key diagnostics

### DIFF
--- a/Documentation/backend/chronicle/code-analysis/index.md
+++ b/Documentation/backend/chronicle/code-analysis/index.md
@@ -11,18 +11,21 @@ All rules follow the identifier format `ARCCHR####` where the numbers are sequen
 
 ## Rules Overview
 
-| Rule ID | Title | Severity | Description |
-| --- | --- | --- | --- |
-| [ARCCHR0001](ARCCHR0001.md) | Incorrect aggregate root event handler signature | Error | Aggregate root event handlers must follow allowed `On` method signatures. |
-| [ARCCHR0003](ARCCHR0003.md) | Reactor must not reach the default event log | Warning | A reactor appends to the default event log directly instead of returning the events. |
-| [ARCCHR0005](ARCCHR0005.md) | Chronicle is used but not wired up | Warning | A project uses Chronicle features but sets up Arc without `WithChronicle()` or `AddCratis()`. |
-| [ARCCHR0008](ARCCHR0008.md) | Command key marked with the data annotations Key attribute | Warning | A command marks its key with an attribute Chronicle does not resolve keys from. |
-| [ARCCHR0009](ARCCHR0009.md) | Command property reads as a secret and should be marked `[NotAudited]` | Warning | A command carries a property whose name reads like a secret, whose value is written to the causation of every event it appends. |
+| Rule ID                     | Title                                                                  | Severity | Description                                                                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [ARCCHR0001](ARCCHR0001.md) | Incorrect aggregate root event handler signature                       | Error    | Aggregate root event handlers must follow allowed `On` method signatures.                                                                                              |
+| ARCCHR0002                  | Ambiguous command event source id                                      | Warning  | A command has multiple candidate identities without specifying which to use. Positional `[Key]` parameters count alongside keyed properties and event-source-id types. |
+| [ARCCHR0003](ARCCHR0003.md) | Reactor must not reach the default event log                           | Warning  | A reactor appends to the default event log directly instead of returning the events.                                                                                   |
+| [ARCCHR0005](ARCCHR0005.md) | Chronicle is used but not wired up                                     | Warning  | A project uses Chronicle features but sets up Arc without `WithChronicle()` or `AddCratis()`.                                                                          |
+| [ARCCHR0008](ARCCHR0008.md) | Command key marked with the data annotations Key attribute             | Warning  | A command marks its key with an attribute Chronicle does not resolve keys from.                                                                                        |
+| [ARCCHR0009](ARCCHR0009.md) | Command property reads as a secret and should be marked `[NotAudited]` | Warning  | A command carries a property whose name reads like a secret, whose value is written to the causation of every event it appends.                                        |
+
+For example, `record Change([Key] Guid First, [Key] Guid Second)` has two candidates for ARCCHR0002. Use `Cratis.Chronicle.Keys.KeyAttribute` to mark only the intended key, or implement `ICanProvideEventSourceId` to choose explicitly. Marking both the parameter and its matching property counts as one candidate, not two. Existing exemptions for handlers returning explicit event-source identities still apply.
 
 ## Quick Fixes
 
-| Rule ID | Quick fix |
-| --- | --- |
+| Rule ID                     | Quick fix                                                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
 | [ARCCHR0008](ARCCHR0008.md) | **Use the Chronicle Key attribute** — rewrites the attribute to the one Chronicle resolves keys from. |
 
 The other rules have no automatic code fix.

--- a/Documentation/backend/chronicle/read-models/failures.md
+++ b/Documentation/backend/chronicle/read-models/failures.md
@@ -3,41 +3,48 @@ title: When read model resolution fails
 description: Every failure mode for a command-scoped Chronicle read model — what the client sees, what it means, and how to fix it.
 ---
 
-Resolving a read model for a command can fail in a small number of well-defined ways. Each one is a distinct type, and each one is deliberately surfaced as a **validation failure (HTTP 400)** rather than a server error, because every one of them is caused by the request rather than by the server.
+Read-model resolution distinguishes invalid input from missing infrastructure. An unusable key or an absent required read model is a **validation failure (HTTP 400)**. Missing service registrations and execution outside the command pipeline are configuration problems, not evidence that an entity does not exist.
 
-| Failure | Cause | Client sees |
-|---|---|---|
-| [`UnableToResolveReadModelFromCommandContext`](#unabletoresolvereadmodelfromcommandcontext) | The command carries no usable key | HTTP 400 — "The command is missing the identifier required to load its current state." |
-| [`ReadModelDoesNotExistForCommand`](#readmodeldoesnotexistforcommand) | Valid key, but a required (non-nullable) read model does not exist | HTTP 400 — "The command targets an entity that does not exist." |
-| [`ReadModelValidatorRequiresCommandPipeline`](#readmodelvalidatorrequirescommandpipeline) | The validator ran through MVC model binding, before a command context existed | Request fails |
-| [`CannotResolveCommandDependency` / `CannotResolveValidatorDependency`](#cannotresolvecommanddependency-and-cannotresolvevalidatordependency) | A required non-nullable dependency could not be resolved | Depends on the dependency |
+| Failure                                                                                                                                       | Cause                                                                         | Client sees                                                                            |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`UnableToResolveReadModelFromCommandContext`](#unabletoresolvereadmodelfromcommandcontext)                                                   | The command carries no usable key                                             | HTTP 400 — "The command is missing the identifier required to load its current state." |
+| [`ReadModelDoesNotExistForCommand`](#readmodeldoesnotexistforcommand)                                                                         | Valid key, but a required (non-nullable) read model does not exist            | HTTP 400 — "The command targets an entity that does not exist."                        |
+| [`ReadModelValidatorRequiresCommandPipeline`](#readmodelvalidatorrequirescommandpipeline)                                                     | The validator ran through MVC model binding, before a command context existed | Request fails                                                                          |
+| [`CannotResolveCommandDependency` / `CannotResolveValidatorDependency`](#cannotresolvecommanddependency-and-cannotresolvevalidatordependency) | A required non-nullable dependency could not be resolved                      | Depends on the dependency                                                              |
 
 In every case the detailed message — which names the read model type — goes to the server log only. The client sees a generic message, so the type never leaks over the wire.
 
 ## UnableToResolveReadModelFromCommandContext
 
-The command carried no usable key, so there is nothing to resolve a read model by. With Chronicle that means the resolved identity is `EventSourceId.Unspecified`; without it, that no rule recognized a key on the command.
+The resolved key is unusable, so there is nothing to resolve a read model by. With Chronicle, this means `EventSourceId.Unspecified` — for example, a declared key whose value is null, or an `ICanProvideEventSourceId` implementation that cannot compose an identity. Without Chronicle, it also includes commands on which no key is declared.
 
 ```csharp
-// No key: nothing marks one, and the command composes none —
-// so there is nothing to resolve a read model by.
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Keys;
+
 [Command]
-public record InvalidCommand(string SomeProperty)
+public record CheckCustomer([Key] string? CustomerId)
 {
-    public SomethingHappened Handle(Customer customer) => new();
+    // A null CustomerId leaves the declared key unspecified.
+    // Making the read-model dependency nullable does not permit an unusable key.
+    public bool Handle(Customer? customer) => customer is not null;
 }
 ```
 
-This is not "the entity does not exist" — it is a command that could never resolve one, for a nullable and a non-nullable parameter alike. Making the parameter nullable does **not** suppress it.
+### Keyless creation commands are different
+
+When a Chronicle command declares **no** event-source key and does not implement `ICanProvideEventSourceId`, Chronicle generates a new identity so the command can create an entity. That is a usable key, not `EventSourceId.Unspecified`. If no read model exists for the generated identity, a nullable dependency receives `null`; a required dependency produces `ReadModelDoesNotExistForCommand`. A command targeting an existing entity must declare that entity's identity instead of relying on this creation fallback.
+
+For an unusable declared key, the failure is not "the entity does not exist" — the lookup cannot be performed, for a nullable and a non-nullable parameter alike. Making the parameter nullable does **not** suppress `UnableToResolveReadModelFromCommandContext`.
 
 **Fix:** give the command a key. What counts as one depends on whether the application has Chronicle:
 
-| Setup | Declare the key by |
-|---|---|
-| With Chronicle | marking a property with `Cratis.Chronicle.Keys.KeyAttribute`, using a property whose type converts to `EventSourceId` (typically a `ConceptAs<Guid>` with an `implicit operator EventSourceId`), or implementing `ICanProvideEventSourceId` — see [Resolving EventSourceId](../resolving-event-source-id.md) |
-| Without Chronicle | marking a property with `System.ComponentModel.DataAnnotations.KeyAttribute`, or implementing `ICanProvideKeyForCommand` — see [Declaring the key without Chronicle](./other-providers.md#declaring-the-key-without-chronicle) |
+| Setup             | Declare the key by                                                                                                                                                                                                                                                          |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| With Chronicle    | marking a property or matching positional parameter with `Cratis.Chronicle.Keys.KeyAttribute`, using an `EventSourceId` or `EventSourceId<T>`-derived property, or implementing `ICanProvideEventSourceId` — see [Resolving EventSourceId](../resolving-event-source-id.md) |
+| Without Chronicle | marking a property with `System.ComponentModel.DataAnnotations.KeyAttribute`, or implementing `ICanProvideKeyForCommand` — see [Declaring the key without Chronicle](./other-providers.md#declaring-the-key-without-chronicle)                                              |
 
-A command that marks the data annotations attribute in a Chronicle application fails this way while looking correct — [ARCCHR0008](../code-analysis/ARCCHR0008.md) reports it at build time.
+The data annotations attribute does not declare a Chronicle key. Unless another identity source is present, using it triggers the generated-ID fallback, not the missing-key error. [ARCCHR0008](../code-analysis/ARCCHR0008.md) reports that attribute mismatch at build time.
 
 ## ReadModelDoesNotExistForCommand
 
@@ -49,17 +56,17 @@ This is the runtime counterpart of the choice [ARC0006](../../code-analysis/ARC0
 
 - **Absence is a business condition.** Make the parameter nullable and write the rule around `null`:
 
-  ```csharp
-  public class RemoveContactValidator : CommandValidator<RemoveContact>
-  {
-      public RemoveContactValidator(Customer? customer) =>
-          RuleFor(_ => customer)
-              .NotNull()
-              .WithMessage("Customer is not registered");
-  }
-  ```
+    ```csharp
+    public class RemoveContactValidator : CommandValidator<RemoveContact>
+    {
+        public RemoveContactValidator(Customer? customer) =>
+            RuleFor(_ => customer)
+                .NotNull()
+                .WithMessage("Customer is not registered");
+    }
+    ```
 
-  You get a specific message instead of the generic one, which is almost always the better experience.
+    You get a specific message instead of the generic one, which is almost always the better experience.
 
 - **The projection really is required.** Leave it non-nullable — the HTTP 400 is the intended behavior, and nothing needs to change.
 
@@ -79,10 +86,10 @@ The general case: Arc needed to invoke `Provide()`, `Handle()`, or construct a d
 
 For a registered read model with a valid event source id, Arc classifies the failure as `ReadModelDoesNotExistForCommand` instead — so if you are seeing these types for a read model parameter, the cause is usually one of:
 
-- **The read model has no Chronicle backing artifact.** `[ReadModel]` alone does not register a type for command-scope injection. Add an `IProjectionFor<T>`, a model-bound projection, or an `IReducerFor<T>`. See [what makes a read model injectable](./index.md#what-makes-a-read-model-injectable).
+- **No provider registered the read model for command-scope injection.** Chronicle requires a backing projection or reducer; `[ReadModel]` alone does not make Chronicle own it. MongoDB and Entity Framework Core supply their own registrations. See [what makes a read model injectable](./index.md#what-makes-a-read-model-injectable) and [other providers](./other-providers.md).
 - **The parameter is not a read model at all** — an ordinary service that is not registered.
 
-Arc deliberately leaves these as server errors rather than masking them as validation failures, so genuine misconfiguration is not hidden behind an HTTP 400.
+Arc deliberately leaves these as server errors rather than masking them as validation failures, so genuine misconfiguration is not hidden behind an HTTP 400. A nullable dependency can also receive `null` when its type is not registered at all: nullable DI alone does not prove that a read-model lookup took place. Verify provider registration before interpreting that null as an absent entity.
 
 ## See also
 

--- a/Documentation/backend/chronicle/read-models/index.md
+++ b/Documentation/backend/chronicle/read-models/index.md
@@ -5,17 +5,25 @@ description: How Chronicle read models become command-scoped dependencies in Arc
 
 A Chronicle read model is current state folded out of events. Arc makes that state available to a command as an ordinary constructor or method parameter, resolved for the key the command already carries — no query, no repository, no manual lookup.
 
-This section explains the mechanism. To *use* it, start with [Use current state in a command](../../../scenarios/use-current-state-in-a-command.md) for the recipe, or [Read models in commands](./injecting-into-commands.md) for the full reference on each position.
+This section explains the mechanism. To _use_ it, start with [Use current state in a command](../../../scenarios/use-current-state-in-a-command.md) for the recipe, or [Read models in commands](./injecting-into-commands.md) for the full reference on each position.
 
 ## What makes a read model injectable
 
 A read model can be injected into command-scoped code because it is **resolvable by key** — the event source id Arc resolved from the command — through Chronicle's read model store. That resolvability comes from a Chronicle backing artifact, so a read model is registered when it has one of:
 
 - a fluent [`IProjectionFor<T>`](/chronicle/projections/) projection
-- a model-bound projection (`[FromEvent<T>]`, `[SetFrom<T>]`, `[SetValue<T>]`)
+- a standalone model-bound projection (`[FromEvent<T>]`, `[SetFrom<T>]`, `[SetValue<T>]`)
 - an [`IReducerFor<T>`](/chronicle/reducers/) reducer
 
 You declare the dependency identically in every case — which artifact materializes the state is an implementation detail Arc hides.
+
+### Children and nested objects are not standalone read models
+
+A type used only as a child or complex subobject of a model-bound projection is part of its parent's document. Its mapping attributes do not give it an independent Chronicle lookup by key. Arc excludes those types from Chronicle's model-bound command registrations, matching Chronicle's projection discovery.
+
+Inject the parent and select the child from its state, or define a separate standalone read model for the command. A type that also has an explicit fluent projection or reducer remains eligible through that backing artifact. A self-referencing root is still eligible unless another candidate uses it as a child or subobject.
+
+This restriction concerns Chronicle ownership only. Arc leaves registrations from MongoDB, Entity Framework Core, or your application intact; those providers may independently own the same CLR type. Without such a registration, a required dependency fails resolution and a nullable dependency can receive null without a lookup. Making a child parameter nullable does not make it independently resolvable.
 
 ### `[ReadModel]` alone is not enough
 
@@ -55,7 +63,7 @@ Resolution happens exactly once per command. The same instance is handed to the 
 
 ### The key does not prove existence
 
-A `[Key]` or event source id tells Arc *which* instance to resolve; it does not prove that instance exists. A projection may never have been created, may have been removed, or may be mid-rebuild. Whether that is a normal business condition or a fault is yours to declare — see [nullable versus required](./injecting-into-commands.md#nullable-means-you-handle-absence).
+A `[Key]` or event source id tells Arc _which_ instance to resolve; it does not prove that instance exists. A projection may never have been created, may have been removed, or may be mid-rebuild. Whether that is a normal business condition or a fault is yours to declare — see [nullable versus required](./injecting-into-commands.md#nullable-means-you-handle-absence).
 
 ## Lifetime and mutability
 
@@ -71,24 +79,24 @@ And they are **read-only snapshots**:
 - **Eventually consistent** — the state reflects events processed so far, not necessarily every event appended.
 - **Current as of the command** — the fetch happens when the command runs.
 
-To *change* state, return events from `Handle()` or use an [aggregate root](../aggregates/index.md). A read model is an input to a decision, never the place a decision is recorded.
+To _change_ state, return events from `Handle()` or use an [aggregate root](../aggregates/index.md). A read model is an input to a decision, never the place a decision is recorded.
 
 ## Read models or aggregate roots
 
 Both give a command access to current state, and they answer different questions.
 
-| Reach for | When |
-|---|---|
-| **Read model** | You need projected, possibly denormalized state to validate against or compute from, and eventual consistency is acceptable |
-| **Aggregate root** | You need to emit events, enforce an invariant inside a consistency boundary, or work from source-of-truth stream state |
-| **Both** | Validate against projected state, then make the change through the aggregate |
+| Reach for          | When                                                                                                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| **Read model**     | You need projected, possibly denormalized state to validate against or compute from, and eventual consistency is acceptable |
+| **Aggregate root** | You need to emit events, enforce an invariant inside a consistency boundary, or work from source-of-truth stream state      |
+| **Both**           | Validate against projected state, then make the change through the aggregate                                                |
 
 If correctness depends on source-of-truth state under concurrency, prefer aggregate or event-stream state over a read model — or enforce it with a Chronicle [constraint](/chronicle/constraints/), which is checked at append time.
 
 ## Topics
 
-| Topic | Description |
-| ----- | ----------- |
-| [Read models in commands](./injecting-into-commands.md) | Injecting into a validator, `Provide()`, and `Handle()`, and what nullability means. |
+| Topic                                                    | Description                                                                                        |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [Read models in commands](./injecting-into-commands.md)  | Injecting into a validator, `Provide()`, and `Handle()`, and what nullability means.               |
 | [Read models from other providers](./other-providers.md) | Injecting one backed by Entity Framework Core or MongoDB, and declaring the key without Chronicle. |
-| [When resolution fails](./failures.md) | Every failure mode, what it means, and how to fix it. |
+| [When resolution fails](./failures.md)                   | Every failure mode, what it means, and how to fix it.                                              |

--- a/Documentation/backend/code-analysis/ARC0006.md
+++ b/Documentation/backend/code-analysis/ARC0006.md
@@ -44,7 +44,7 @@ public class Customer
 }
 ```
 
-`Customer` is a command-scoped read model. If it does not exist for the command's event source id, Arc cannot inject a value into the non-nullable validator parameter, so the command fails with a dependency-resolution error.
+When `Customer` is registered for command-scoped resolution and the command has a usable key, an absent instance produces `ReadModelDoesNotExistForCommand` — a validation failure (HTTP 400). Arc cannot inject a value into the non-nullable validator parameter.
 
 ### Option 1: Handle Missing State
 
@@ -71,7 +71,7 @@ public class RegisterCustomerValidator : CommandValidator<RegisterCustomer>
 
 ### Option 2: Require Existing State
 
-Keep the parameter non-nullable when the command really requires the read model to exist and absence should fail as a programming, configuration, projection, or consistency error. In that case, no code change is needed; the warning exists so the required-state choice is reviewed deliberately.
+Keep the parameter non-nullable when the command requires the read model to exist and absence should reject the command. For a registered read model and a usable key, Arc reports `ReadModelDoesNotExistForCommand` (HTTP 400), not a programming or configuration error. No code change is needed; the warning exists so the required-state choice is reviewed deliberately.
 
 For example, a command that submits an existing order may require the order projection before any state rules can be evaluated:
 
@@ -104,7 +104,11 @@ The same rule applies if a command's `Provide()` or `Handle()` method takes a co
 
 Chronicle read models represent current projected state. Missing projected state can be meaningful: an entity may not be registered yet, may already have been removed, or may not have reached a state represented by that projection. It can also be exceptional: the command may target an event source that should already have a projection.
 
-Before the command runs, Arc resolves command-scoped read models from the command context. Nullable read model parameters allow validators, `Provide()`, and `Handle()` to receive `null` and make an explicit decision. Non-nullable parameters require Arc to throw `CannotResolveCommandDependency` or `CannotResolveValidatorDependency` when the read model cannot be resolved or resolves to `null`.
+Before the command runs, Arc resolves command-scoped read models from the command context. For a registered read model with a usable key, nullable parameters allow validators, `Provide()`, and `Handle()` to receive `null` and make an explicit decision; non-nullable parameters instead produce `ReadModelDoesNotExistForCommand` (HTTP 400).
+
+An unusable resolved key produces `UnableToResolveReadModelFromCommandContext` (HTTP 400), even for a nullable dependency. A Chronicle command that declares no identity is different: it receives a generated key for creating an entity, so missing state for that new key follows the normal nullable/required rules.
+
+An unregistered required dependency still produces `CannotResolveCommandDependency` or `CannotResolveValidatorDependency` as a server error. An unregistered nullable dependency can receive `null` without any lookup occurring. Verify the read model's provider registration rather than using nullability to hide missing wiring.
 
 If correctness depends on source-of-truth state, prefer aggregate or event-stream state over a read-model validator. Read models are best used for projected-state checks where the projection is the right input to the decision.
 

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_positional_keys.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_positional_keys.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_multiple_positional_keys : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Keys;
+
+namespace TestNamespace
+{
+    [Command]
+    public record {|#0:Change|}([Key] Guid First, [Key] Guid Second)
+    {
+        public void Handle() { }
+    }
+}",
+        VerifyCS.Diagnostic("ARCCHR0002")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Change", "First, Second")));
+
+    [Fact] void should_report_both_candidates() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_positional_keys_with_provider.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_positional_keys_with_provider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_multiple_positional_keys_with_provider : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace TestNamespace
+{
+    [Command]
+    public record Change([Key] Guid First, [Key] Guid Second) : ICanProvideEventSourceId
+    {
+        public EventSourceId GetEventSourceId() => First.ToString();
+        public void Handle() { }
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_positional_key_and_event_source_id.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_positional_key_and_event_source_id.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_positional_key_and_event_source_id : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace TestNamespace
+{
+    [Command]
+    public record {|#0:Change|}([Key] Guid First, EventSourceId Second)
+    {
+        public void Handle() { }
+    }
+}",
+        VerifyCS.Diagnostic("ARCCHR0002")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Change", "First, Second")));
+
+    [Fact] void should_report_both_candidates() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_same_key_marked_on_parameter_and_property.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_same_key_marked_on_parameter_and_property.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_same_key_marked_on_parameter_and_property : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Keys;
+
+namespace TestNamespace
+{
+    [Command]
+    public record Change([Key][property: Key] Guid Id)
+    {
+        public void Handle() { }
+    }
+}"));
+
+    [Fact] void should_not_count_the_same_property_twice() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/CommandEventSourceIdAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/CommandEventSourceIdAnalyzer.cs
@@ -81,8 +81,17 @@ public class CommandEventSourceIdAnalyzer : DiagnosticAnalyzer
 
     static bool IsEventSourceIdCandidate(IPropertySymbol property) =>
         HasAttribute(property, KeysNamespace, KeyAttributeName) ||
+        HasKeyAttributeOnMatchingConstructorParameter(property) ||
         IsOrDerivesFromEventSourceId(property.Type) ||
         HasImplicitConversionToEventSourceId(property.Type);
+
+    static bool HasKeyAttributeOnMatchingConstructorParameter(IPropertySymbol property) =>
+        property.ContainingType.InstanceConstructors
+            .SelectMany(constructor => constructor.Parameters)
+            .Any(parameter =>
+                parameter.Name == property.Name &&
+                SymbolEqualityComparer.Default.Equals(parameter.Type, property.Type) &&
+                HasAttribute(parameter, KeysNamespace, KeyAttributeName));
 
     static bool IsOrDerivesFromEventSourceId(ITypeSymbol? type)
     {

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_constructor_parameters_shadow_properties.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_constructor_parameters_shadow_properties.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_constructor_parameters_shadow_properties : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Parent), typeof(PropertyOnlyChild), typeof(ParameterChild), typeof(PropertyDetails)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_ignore_children_from_on_a_same_named_property() => _roots.ShouldContain(typeof(PropertyOnlyChild));
+    [Fact] void should_use_children_from_on_the_constructor_parameter() => _roots.ShouldNotContain(typeof(ParameterChild));
+    [Fact] void should_ignore_a_complex_property_shadowed_case_insensitively() => _roots.ShouldContain(typeof(PropertyDetails));
+    [Fact] void should_keep_the_parent() => _roots.ShouldContain(typeof(Parent));
+
+    class Parent(
+        IEnumerable<PropertyOnlyChild> children,
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<ParameterChild> selected,
+        string details)
+    {
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))]
+        public IEnumerable<PropertyOnlyChild> Children { get; } = children;
+
+        public IEnumerable<ParameterChild> Selected { get; } = selected;
+
+        public PropertyDetails Details { get; } = new(details);
+    }
+
+    record PropertyOnlyChild(string Name);
+    record ParameterChild(string Name);
+    record PropertyDetails(string Name);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_children_from_constructor_parameters.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_children_from_constructor_parameters.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_children_from_constructor_parameters : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Parent), typeof(Child), typeof(Unrelated)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_keep_only_the_parent_and_unrelated_root() => _roots.ShouldContainOnly(typeof(Parent), typeof(Unrelated));
+
+    record Parent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<Child> Children);
+    record Child(string Name);
+    record Unrelated(string Name);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_children_from_properties.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_children_from_properties.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_children_from_properties : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Parent), typeof(ArrayChild), typeof(ListChild), typeof(EnumerableChild)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_keep_only_the_parent() => _roots.ShouldContainOnly(typeof(Parent));
+
+    record Parent
+    {
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))]
+        public ArrayChild[] ArrayChildren { get; init; }
+
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))]
+        public List<ListChild> ListChildren { get; init; }
+
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))]
+        public IEnumerable<EnumerableChild> EnumerableChildren { get; init; }
+    }
+
+    record ArrayChild(string Name);
+    record ListChild(string Name);
+    record EnumerableChild(string Name);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_collections_without_children_from.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_collections_without_children_from.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_collections_without_children_from : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Parent), typeof(EnumerableChild), typeof(ArrayChild), typeof(ListChild)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_not_unwrap_an_unannotated_enumerable_interface() => _roots.ShouldContain(typeof(EnumerableChild));
+    [Fact] void should_not_unwrap_an_unannotated_array() => _roots.ShouldContain(typeof(ArrayChild));
+    [Fact] void should_traverse_a_concrete_list_as_a_complex_object_through_its_indexer() => _roots.ShouldNotContain(typeof(ListChild));
+    [Fact] void should_keep_the_parent() => _roots.ShouldContain(typeof(Parent));
+
+    record Parent(IEnumerable<EnumerableChild> EnumerableChildren, ArrayChild[] ArrayChildren, List<ListChild> ListChildren);
+    record EnumerableChild(string Name);
+    record ArrayChild(string Name);
+    record ListChild(string Name);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_grandchildren_through_a_non_candidate.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_grandchildren_through_a_non_candidate.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_grandchildren_through_a_non_candidate : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Parent), typeof(Grandchild), typeof(Details)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_traverse_the_child_even_when_it_is_not_a_candidate() => _roots.ShouldContainOnly(typeof(Parent));
+
+    record Parent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<Child> Children);
+    record Child([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<Grandchild> Children);
+    record Grandchild(Details Details);
+    record Details(string Name);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_nested_complex_objects.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_nested_complex_objects.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_nested_complex_objects : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Parent), typeof(Details), typeof(Address), typeof(Location)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_remove_unannotated_constructor_and_property_subobjects() => _roots.ShouldContainOnly(typeof(Parent));
+
+    record Parent(Details Details);
+    record Details
+    {
+        public Address Address { get; init; }
+    }
+
+    record Address(Location Location);
+    record Location(string Name);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_primitive_and_nullable_members.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_primitive_and_nullable_members.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_primitive_and_nullable_members : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates =
+    [
+        typeof(Parent), typeof(int), typeof(bool), typeof(string), typeof(decimal), typeof(DateTime),
+        typeof(DateTimeOffset), typeof(TimeSpan), typeof(Guid), typeof(DayOfWeek), typeof(int?), typeof(OptionalValue?)
+    ];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_not_remove_scalar_or_nullable_value_candidates_referenced_by_the_parent() => _roots.ShouldContainOnly(_candidates);
+
+    record Parent(
+        int Count,
+        bool Enabled,
+        string Name,
+        decimal Amount,
+        DateTime Date,
+        DateTimeOffset Timestamp,
+        TimeSpan Duration,
+        Guid Id,
+        DayOfWeek Day,
+        int? OptionalCount,
+        OptionalValue? Optional);
+
+    record struct OptionalValue(int Value);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_recursive_children.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_recursive_children.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_recursive_children : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Node), typeof(Details)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_retain_the_self_referencing_root_and_exclude_its_subobject() => _roots.ShouldContainOnly(typeof(Node));
+
+    record Node(Details Details, [ChildrenFrom<NodeAdded>(key: nameof(NodeAdded.Id))] IEnumerable<Node> Children);
+    record Details(string Name);
+    record NodeAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_shared_children.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_discovering_shared_children.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_discovering_shared_children : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Child), typeof(FirstParent), typeof(SecondParent)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_keep_both_parents_but_not_the_shared_child() => _roots.ShouldContainOnly(typeof(FirstParent), typeof(SecondParent));
+
+    record FirstParent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] Child[] Children);
+    record SecondParent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] List<Child> Children);
+    record Child(string Name);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_selecting_the_constructor_with_most_parameters.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ModelBoundReadModelRoots/when_selecting_the_constructor_with_most_parameters.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ModelBoundReadModelRoots;
+
+public class when_selecting_the_constructor_with_most_parameters : Specification
+{
+    Type[] _candidates;
+    IEnumerable<Type> _roots;
+
+    void Establish() => _candidates = [typeof(Parent), typeof(SelectedChild), typeof(ShortConstructorChild), typeof(PrivateConstructorChild)];
+
+    void Because() => _roots = ModelBoundReadModelRoots.Discover(_candidates).ToArray();
+
+    [Fact] void should_traverse_only_the_longest_public_constructor() => _roots.ShouldContainOnly(typeof(Parent), typeof(ShortConstructorChild), typeof(PrivateConstructorChild));
+
+    class Parent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<SelectedChild> children, string name)
+    {
+        public Parent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<ShortConstructorChild> children)
+            : this([], string.Empty)
+        {
+        }
+
+        Parent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<PrivateConstructorChild> children, string name, int count)
+            : this([], name)
+        {
+        }
+    }
+
+    record SelectedChild(string Name);
+    record ShortConstructorChild(string Name);
+    record PrivateConstructorChild(string Name);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_model_bound_parents_and_children.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_model_bound_parents_and_children.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Chronicle;
+using Cratis.Chronicle.Projections.ModelBound;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+public class when_adding_model_bound_parents_and_children : Specification
+{
+    IServiceCollection _services;
+    IClientArtifactsProvider _artifacts;
+    ServiceProvider _provider;
+
+    void Establish()
+    {
+        _services = new ServiceCollection();
+        _artifacts = Substitute.For<IClientArtifactsProvider>();
+        _artifacts.Projections.Returns([]);
+        _artifacts.Reducers.Returns([]);
+        _artifacts.ModelBoundProjections.Returns([typeof(Parent), typeof(Child), typeof(Details), typeof(AbstractRoot), typeof(ValueRoot)]);
+    }
+
+    void Because()
+    {
+        _services.AddReadModels(_artifacts);
+        _provider = _services.BuildServiceProvider();
+    }
+
+    void Destroy() => _provider.Dispose();
+
+    [Fact] void should_register_the_parent_as_scoped() => _services.ShouldContain(_ => _.ServiceType == typeof(Parent) && _.Lifetime == ServiceLifetime.Scoped);
+    [Fact] void should_not_register_the_child_as_a_service() => _services.ShouldNotContain(_ => _.ServiceType == typeof(Child));
+    [Fact] void should_not_register_the_nested_subobject_as_a_service() => _services.ShouldNotContain(_ => _.ServiceType == typeof(Details));
+    [Fact] void should_classify_only_the_concrete_parent_as_a_command_read_model() => _provider.GetRequiredService<RegisteredReadModelTypes>().Types.ShouldContainOnly(typeof(Parent));
+    [Fact] void should_claim_only_the_concrete_parent_for_chronicle_resolution() => _provider.GetServices<ICanResolveReadModelForCommand>().OfType<ChronicleReadModelForCommandResolver>().Single().ReadModelTypes.ShouldContainOnly(typeof(Parent));
+
+    record Parent([ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<Child> Children);
+    record Child(Details Details);
+    record Details(string Name);
+    abstract record AbstractRoot;
+    record struct ValueRoot(int Value);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_children_have_explicit_backing_artifacts.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_children_have_explicit_backing_artifacts.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Chronicle;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.Reducers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+public class when_children_have_explicit_backing_artifacts : Specification
+{
+    IServiceCollection _services;
+    IClientArtifactsProvider _artifacts;
+    ServiceProvider _provider;
+
+    void Establish()
+    {
+        _services = new ServiceCollection();
+        _artifacts = Substitute.For<IClientArtifactsProvider>();
+        _artifacts.Projections.Returns([typeof(ChildProjection)]);
+        _artifacts.Reducers.Returns([typeof(ChildReducer)]);
+        _artifacts.ModelBoundProjections.Returns([typeof(Parent), typeof(ProjectedChild), typeof(ReducedChild), typeof(EmbeddedChild)]);
+    }
+
+    void Because()
+    {
+        _services.AddReadModels(_artifacts);
+        _provider = _services.BuildServiceProvider();
+    }
+
+    void Destroy() => _provider.Dispose();
+
+    [Fact] void should_register_the_explicit_projection_target_as_scoped() => _services.ShouldContain(_ => _.ServiceType == typeof(ProjectedChild) && _.Lifetime == ServiceLifetime.Scoped);
+    [Fact] void should_register_the_explicit_reducer_target_as_scoped() => _services.ShouldContain(_ => _.ServiceType == typeof(ReducedChild) && _.Lifetime == ServiceLifetime.Scoped);
+    [Fact] void should_not_register_a_child_without_explicit_backing() => _services.ShouldNotContain(_ => _.ServiceType == typeof(EmbeddedChild));
+    [Fact] void should_include_explicit_targets_in_the_registered_read_model_types() => _provider.GetRequiredService<RegisteredReadModelTypes>().Types.ShouldContainOnly(typeof(Parent), typeof(ProjectedChild), typeof(ReducedChild));
+    [Fact] void should_include_explicit_targets_in_chronicle_resolution() => _provider.GetServices<ICanResolveReadModelForCommand>().OfType<ChronicleReadModelForCommandResolver>().Single().ReadModelTypes.ShouldContainOnly(typeof(Parent), typeof(ProjectedChild), typeof(ReducedChild));
+
+    record Parent(
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<ProjectedChild> ProjectedChildren,
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<ReducedChild> ReducedChildren,
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<EmbeddedChild> EmbeddedChildren);
+
+    record ProjectedChild(string Name);
+    record ReducedChild(string Name);
+    record EmbeddedChild(string Name);
+    record ChildAdded(Guid Id);
+
+    class ChildProjection : IProjectionFor<ProjectedChild>
+    {
+        public void Define(IProjectionBuilderFor<ProjectedChild> builder)
+        {
+        }
+    }
+
+    class ChildReducer : IReducerFor<ReducedChild>;
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_model_bound_children_are_registered_elsewhere.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_model_bound_children_are_registered_elsewhere.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Chronicle;
+using Cratis.Chronicle.Projections.ModelBound;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+public class when_model_bound_children_are_registered_elsewhere : Specification
+{
+    IServiceCollection _services;
+    IClientArtifactsProvider _artifacts;
+    ICanResolveReadModelForCommand _otherResolver;
+    ServiceDescriptor _otherRegistration;
+    ApplicationChild _applicationChild;
+    ServiceProvider _provider;
+
+    void Establish()
+    {
+        _services = new ServiceCollection();
+        _otherResolver = Substitute.For<ICanResolveReadModelForCommand>();
+        _otherResolver.ReadModelTypes.Returns([typeof(ProviderChild)]);
+        _otherResolver.Ownership.Returns(ReadModelForCommandOwnership.Declared);
+        _services.AddReadModelsForCommand(_otherResolver);
+        _otherRegistration = _services.Single(_ => _.ServiceType == typeof(ProviderChild));
+        _applicationChild = new("Application-owned");
+        _services.AddSingleton(_applicationChild);
+
+        _artifacts = Substitute.For<IClientArtifactsProvider>();
+        _artifacts.Projections.Returns([]);
+        _artifacts.Reducers.Returns([]);
+        _artifacts.ModelBoundProjections.Returns([typeof(Parent), typeof(ProviderChild), typeof(ApplicationChild)]);
+    }
+
+    void Because()
+    {
+        _services.AddReadModels(_artifacts);
+        _provider = _services.BuildServiceProvider();
+    }
+
+    void Destroy() => _provider.Dispose();
+
+    [Fact] void should_preserve_the_other_providers_service_registration() => _services.Single(_ => _.ServiceType == typeof(ProviderChild)).ShouldEqual(_otherRegistration);
+    [Fact] void should_preserve_the_other_resolver() => _provider.GetServices<ICanResolveReadModelForCommand>().ShouldContain(_otherResolver);
+    [Fact] void should_preserve_the_application_instance() => _provider.GetRequiredService<ApplicationChild>().ShouldEqual(_applicationChild);
+    [Fact] void should_preserve_the_application_registration_lifetime() => _services.Single(_ => _.ServiceType == typeof(ApplicationChild)).Lifetime.ShouldEqual(ServiceLifetime.Singleton);
+    [Fact] void should_keep_the_other_providers_types_in_the_additive_registry() => _provider.GetRequiredService<RegisteredReadModelTypes>().Types.ShouldContainOnly(typeof(ProviderChild), typeof(Parent));
+    [Fact] void should_not_claim_either_child_for_chronicle() => _provider.GetServices<ICanResolveReadModelForCommand>().OfType<ChronicleReadModelForCommandResolver>().Single().ReadModelTypes.ShouldContainOnly(typeof(Parent));
+
+    record Parent(
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<ProviderChild> ProviderChildren,
+        [ChildrenFrom<ChildAdded>(key: nameof(ChildAdded.Id))] IEnumerable<ApplicationChild> ApplicationChildren);
+
+    record ProviderChild(string Name);
+    record ApplicationChild(string Name);
+    record ChildAdded(Guid Id);
+}

--- a/Source/DotNET/Chronicle/ReadModels/ModelBoundReadModelRoots.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ModelBoundReadModelRoots.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Arc.Chronicle.ReadModels;
+
+/// <summary>
+/// Identifies model-bound read models that Chronicle discovers as standalone projections.
+/// </summary>
+/// <remarks>
+/// Mirrors the root-selection traversal in Chronicle's internal ModelBoundProjections discovery. The client artifacts
+/// provider exposes candidates, not roots; keep this traversal aligned when upgrading Chronicle until it exposes a
+/// shared discovery API. Explicit fluent projection and reducer targets are registered separately.
+/// </remarks>
+static class ModelBoundReadModelRoots
+{
+    /// <summary>
+    /// Gets the candidate types that are not used as children or subobjects by another candidate.
+    /// </summary>
+    /// <param name="candidates">All model-bound projection candidates.</param>
+    /// <returns>The standalone model-bound read model types.</returns>
+    public static IEnumerable<Type> Discover(IEnumerable<Type> candidates)
+    {
+        var types = candidates.ToArray();
+        var referencedTypes = new HashSet<Type>();
+        foreach (var type in types)
+        {
+            var referencedByType = new HashSet<Type>();
+            CollectReferences(type, referencedByType);
+            referencedByType.Remove(type);
+            referencedTypes.UnionWith(referencedByType);
+        }
+
+        return types.Except(referencedTypes);
+    }
+
+    static void CollectReferences(Type type, HashSet<Type> referencedTypes)
+    {
+        var constructor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(_ => _.GetParameters().Length)
+            .FirstOrDefault();
+        var parameters = constructor?.GetParameters() ?? [];
+        foreach (var parameter in parameters)
+        {
+            CollectMemberReferences(parameter.ParameterType, parameter.GetCustomAttributes(), referencedTypes);
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (parameters.Any(_ => string.Equals(_.Name, property.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            CollectMemberReferences(property.PropertyType, property.GetCustomAttributes(), referencedTypes);
+        }
+    }
+
+    static void CollectMemberReferences(Type type, IEnumerable<Attribute> attributes, HashSet<Type> referencedTypes)
+    {
+        var hasChildren = attributes.Any(_ => _.GetType().IsGenericType &&
+            _.GetType().GetGenericTypeDefinition() == typeof(ChildrenFromAttribute<>));
+        var referencedType = hasChildren ? GetChildType(type) : IsComplexType(type) ? type : null;
+        if (referencedType is not null && referencedTypes.Add(referencedType))
+        {
+            CollectReferences(referencedType, referencedTypes);
+        }
+    }
+
+    static Type? GetChildType(Type type)
+    {
+        if (type.IsGenericType)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            if (definition == typeof(IEnumerable<>) || definition.GetInterfaces().Any(IsEnumerable))
+            {
+                return type.GetGenericArguments()[0];
+            }
+        }
+
+        return type.GetInterfaces().FirstOrDefault(IsEnumerable)?.GetGenericArguments()[0];
+    }
+
+    static bool IsEnumerable(Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+    static bool IsComplexType(Type type)
+    {
+        if (type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(decimal) ||
+            type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(TimeSpan) || type == typeof(Guid))
+        {
+            return false;
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+        {
+            return false;
+        }
+
+        return type.IsClass || type.IsValueType;
+    }
+}

--- a/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ public static class ReadModelServiceCollectionExtensions
     /// A read model is injectable into command-scoped code (a <c>CommandValidator&lt;&gt;</c>, <c>Provide()</c>, or
     /// <c>Handle()</c>) because it is resolvable by key (the resolved event source id) through <see cref="IReadModels"/>.
     /// What makes a read model resolvable that way is a Chronicle backing artifact, so this registers every read model
-    /// that has a projection, model-bound projection, or reducer — independent of whether it also carries the Arc-level
+    /// that has a projection, standalone model-bound projection, or reducer — independent of whether it also carries the Arc-level
     /// <c>[ReadModel]</c> attribute. It deliberately does not register read models by <c>[ReadModel]</c> alone: that
     /// attribute is an Arc concept that does not imply Chronicle key resolution, and a read model backed by another
     /// provider (for example Entity Framework Core) is registered by that provider, not here.
@@ -51,7 +51,7 @@ public static class ReadModelServiceCollectionExtensions
     {
         services.TryAddEnumerable(ServiceDescriptor.Transient(typeof(IInterceptReadModel<>), typeof(ReadModelInterceptor<>)));
 
-        var modelBoundReadModels = clientArtifactsProvider.ModelBoundProjections
+        var modelBoundReadModels = ModelBoundReadModelRoots.Discover(clientArtifactsProvider.ModelBoundProjections)
             .Where(type => type.IsClass && !type.IsAbstract);
 
         // A read model is registered for command-scope resolution because it is resolvable by key through


### PR DESCRIPTION
# Summary

Align command-side read-model registration and identity diagnostics with Chronicle's runtime behavior. Child-only models are no longer advertised as independently resolvable through Chronicle; existing fluent projections, reducers, and other storage providers retain their registrations.

## Fixed

- Exclude child and nested model-bound types from standalone Chronicle command read-model registration, matching Chronicle's projection discovery (#2587)
- Detect ambiguous command identities declared through positional `[Key]` parameters, without counting the same property twice (#2645)
- Correct read-model failure guidance to distinguish generated creation keys, unusable declared keys, absent state, and missing provider registrations
