### PR TITLE
fix(arc-core): take the type universe after generated providers register

### DIFF
--- a/Arc.slnx
+++ b/Arc.slnx
@@ -4,6 +4,8 @@
     <Folder Name="/Source/DotNET/">
         <Project Path="Source\DotNET\Arc.Core\Arc.Core.csproj" />
         <Project Path="Source\DotNET\Arc.Core.Specs\Arc.Core.Specs.csproj" />
+        <Project Path="Source\DotNET\Arc.Core.TypeDiscovery.Specs\Arc.Core.TypeDiscovery.Specs.csproj" />
+        <Project Path="Source\DotNET\Arc.Core.TypeDiscovery.Specs.Plugin\Arc.Core.TypeDiscovery.Specs.Plugin.csproj" />
         <Project Path="Source\DotNET\Arc.Core.CodeAnalysis\Arc.Core.CodeAnalysis.csproj" />
         <Project Path="Source\DotNET\Arc.Core.CodeAnalysis.CodeFixes\Arc.Core.CodeAnalysis.CodeFixes.csproj" />
         <Project Path="Source\DotNET\Arc.Core.CodeAnalysis.Package\Arc.Core.CodeAnalysis.Package.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="Cratis.Chronicle" Version="17.0.4" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="17.0.4" />
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="17.0.4" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.2" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.2" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.5" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.5" />
     <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
     <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.17.0" />
     <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.17.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="Cratis.Chronicle" Version="17.0.4" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="17.0.4" />
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="17.0.4" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.5" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.5" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.19.1" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.19.1" />
     <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
     <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.17.0" />
     <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.17.0" />

--- a/Source/DotNET/Arc.Core.Specs/MutatesTypeDiscoveryCollection.cs
+++ b/Source/DotNET/Arc.Core.Specs/MutatesTypeDiscoveryCollection.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc;
+
+/// <summary>
+/// Collection definition for specs that add to the process-wide <see cref="GeneratedTypeDiscoveryRegistry"/> or
+/// assert on the type universe <c>AddCratisArcCore</c> leaves behind in the equally process-wide
+/// <c>Internals.Types</c>.
+/// </summary>
+/// <remarks>
+/// Every spec that configures Arc writes <c>Internals.Types</c>, so a spec reading it back races with any test
+/// class running in parallel - including on assertions that hold for the value its own call wrote.
+/// </remarks>
+[CollectionDefinition("MutatesTypeDiscovery", DisableParallelization = true)]
+public class MutatesTypeDiscoveryCollection;

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/TheLateProvider.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/TheLateProvider.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
+
+/// <summary>
+/// Stands in for a generated type discovery provider whose module constructor runs during the assembly closure
+/// walk - after a universe has already been built from the providers registered up to that point.
+/// </summary>
+/// <remarks>
+/// The one type it reports is a nested type with no accessibility modifier, so private - and the type discovery
+/// generator emits nothing it could not reference by name, so this assembly's own generated provider does not
+/// report it. Finding it in a universe therefore means that universe was built after this provider registered,
+/// which is the whole point of the specification. Widening it would quietly take that meaning away.
+/// </remarks>
+public class TheLateProvider : ICanProvideAssembliesForDiscovery
+{
+    /// <summary>
+    /// Gets the type no other provider reports.
+    /// </summary>
+    public static Type OnlyTypeItReports => typeof(ReportedByNothingElse);
+
+    /// <inheritdoc/>
+    public IEnumerable<Assembly> Assemblies => [];
+
+    /// <inheritdoc/>
+    public IEnumerable<Type> DefinedTypes => [OnlyTypeItReports];
+
+    /// <inheritdoc/>
+    public void Initialize()
+    {
+    }
+
+    class ReportedByNothingElse;
+}

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/TheLateProvider.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/TheLateProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using Cratis.Serialization;
 
 namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
 
@@ -10,10 +11,10 @@ namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
 /// walk - after a universe has already been built from the providers registered up to that point.
 /// </summary>
 /// <remarks>
-/// The one type it reports is a nested type with no accessibility modifier, so private - and the type discovery
+/// The types it reports are nested types with no accessibility modifier, so private - and the type discovery
 /// generator emits nothing it could not reference by name, so this assembly's own generated provider does not
-/// report it. Finding it in a universe therefore means that universe was built after this provider registered,
-/// which is the whole point of the specification. Widening it would quietly take that meaning away.
+/// report them. Finding one in a universe therefore means that universe was built after this provider registered,
+/// which is the whole point of the specification. Widening them would quietly take that meaning away.
 /// </remarks>
 public class TheLateProvider : ICanProvideAssembliesForDiscovery
 {
@@ -22,16 +23,36 @@ public class TheLateProvider : ICanProvideAssembliesForDiscovery
     /// </summary>
     public static Type OnlyTypeItReports => typeof(ReportedByNothingElse);
 
+    /// <summary>
+    /// Gets the derived type no other provider reports.
+    /// </summary>
+    /// <remarks>
+    /// A universe alone cannot say whether the derived types were read off it: <c>IDerivedTypes</c> indexes only
+    /// what carries <see cref="DerivedTypeAttribute"/>, so proving the derived types are not a separate narrower
+    /// snapshot needs a late type this provider reports and that attribute marks.
+    /// </remarks>
+    public static Type OnlyDerivedTypeItReports => typeof(DerivedFromWhatNothingElseReports);
+
+    /// <summary>
+    /// Gets the target type <see cref="OnlyDerivedTypeItReports"/> is a derivative of.
+    /// </summary>
+    public static Type TargetOfTheOnlyDerivedTypeItReports => typeof(IReportedByNothingElseEither);
+
     /// <inheritdoc/>
     public IEnumerable<Assembly> Assemblies => [];
 
     /// <inheritdoc/>
-    public IEnumerable<Type> DefinedTypes => [OnlyTypeItReports];
+    public IEnumerable<Type> DefinedTypes => [OnlyTypeItReports, OnlyDerivedTypeItReports];
 
     /// <inheritdoc/>
     public void Initialize()
     {
     }
 
+    interface IReportedByNothingElseEither;
+
     class ReportedByNothingElse;
+
+    [DerivedType("f3c5b0d4-5a3f-4a2a-9d1e-6c9f2b7a41e8")]
+    class DerivedFromWhatNothingElseReports : IReportedByNothingElseEither;
 }

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/TheProviderThatBringsInTheLateOne.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/TheProviderThatBringsInTheLateOne.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
+
+/// <summary>
+/// A provider that registers <see cref="TheLateProvider"/> while it is being initialized.
+/// </summary>
+/// <remarks>
+/// Providers are initialized from the <c>Types</c> constructor, after it has captured the set it is building
+/// from - so a provider registered here lands in the registry too late for the universe being built and in time
+/// for the next one. That produces the same observable ordering the assembly closure walk in
+/// <c>AddBindingsByConvention</c> and <c>AddSelfBindings</c> produces for a universe built earlier in the same
+/// <c>AddCratisArcCore</c> call: the provider set grows between the two reads. It gets there by a different
+/// route - the public registry from inside a construction, rather than a module constructor outside one - which
+/// is what makes it reachable from a specification at all.
+/// </remarks>
+public class TheProviderThatBringsInTheLateOne : ICanProvideAssembliesForDiscovery
+{
+    /// <inheritdoc/>
+    public IEnumerable<Assembly> Assemblies => [];
+
+    /// <inheritdoc/>
+    public IEnumerable<Type> DefinedTypes => [];
+
+    /// <inheritdoc/>
+    public void Initialize() => GeneratedTypeDiscoveryRegistry.Register(new TheLateProvider());
+}

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_registers_while_the_universe_is_built.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_registers_while_the_universe_is_built.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
@@ -10,7 +11,10 @@ public class and_a_generated_provider_registers_while_the_universe_is_built : Sp
 {
     ITypes _typesFromTheContainer;
     ITypes _typesFromInternals;
+    IDerivedTypes _derivedTypesFromTheContainer;
+    IDerivedTypes _derivedTypesFromInternals;
     int _registeredUniverses;
+    int _registeredDerivedTypes;
 
     void Establish() => GeneratedTypeDiscoveryRegistry.Register(new TheProviderThatBringsInTheLateOne());
 
@@ -23,11 +27,32 @@ public class and_a_generated_provider_registers_while_the_universe_is_built : Sp
         _typesFromTheContainer = serviceProvider.GetRequiredService<ITypes>();
         _registeredUniverses = serviceProvider.GetServices<ITypes>().Count();
         _typesFromInternals = Internals.Types;
+
+        _derivedTypesFromTheContainer = serviceProvider.GetRequiredService<IDerivedTypes>();
+        _registeredDerivedTypes = serviceProvider.GetServices<IDerivedTypes>().Count();
+        _derivedTypesFromInternals = Internals.DerivedTypes;
     }
 
     [Fact] void should_expose_the_late_type_to_the_container() => _typesFromTheContainer.All.ShouldContain(TheLateProvider.OnlyTypeItReports);
     [Fact] void should_expose_the_late_type_internally() => _typesFromInternals.All.ShouldContain(TheLateProvider.OnlyTypeItReports);
     [Fact] void should_hold_the_universe_the_container_resolves() => _typesFromInternals.ShouldBeSame(_typesFromTheContainer);
     [Fact] void should_leave_the_container_with_one_universe() => _registeredUniverses.ShouldEqual(1);
-    [Fact] void should_not_be_the_static_snapshot() => Cratis.Types.Types.Instance.All.ShouldNotContain(TheLateProvider.OnlyTypeItReports);
+
+    /// <summary>
+    /// Compares references rather than contents: nothing in <c>AddCratisArcCore</c> touches <c>Types.Instance</c>
+    /// any more, so whether that static holds the late type depends only on when some test first reads it, and a
+    /// content comparison would pass or fail on test order.
+    /// </summary>
+    [Fact] void should_not_be_the_static_snapshot() => _typesFromInternals.ShouldNotBeSame(Cratis.Types.Types.Instance);
+    [Fact] void should_expose_the_late_derived_type_to_the_container() => _derivedTypesFromTheContainer.IsDerivedType(TheLateProvider.OnlyDerivedTypeItReports).ShouldBeTrue();
+    [Fact] void should_expose_the_late_derived_type_internally() => _derivedTypesFromInternals.IsDerivedType(TheLateProvider.OnlyDerivedTypeItReports).ShouldBeTrue();
+    [Fact] void should_expose_the_late_target_type_as_having_derivatives() => _derivedTypesFromInternals.TypesWithDerivatives.ShouldContain(TheLateProvider.TargetOfTheOnlyDerivedTypeItReports);
+    [Fact] void should_hold_the_derived_types_the_container_resolves() => _derivedTypesFromInternals.ShouldBeSame(_derivedTypesFromTheContainer);
+    [Fact] void should_leave_the_container_with_one_set_of_derived_types() => _registeredDerivedTypes.ShouldEqual(1);
+
+    /// <summary>
+    /// Compares references for the same reason <c>should_not_be_the_static_snapshot</c> does, and reading
+    /// <see cref="DerivedTypes.Instance"/> is what would pin <c>Types.Instance</c> early if production code did it.
+    /// </summary>
+    [Fact] void should_not_be_the_static_derived_types_snapshot() => _derivedTypesFromInternals.ShouldNotBeSame(DerivedTypes.Instance);
 }

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_registers_while_the_universe_is_built.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_registers_while_the_universe_is_built.cs
@@ -37,22 +37,9 @@ public class and_a_generated_provider_registers_while_the_universe_is_built : Sp
     [Fact] void should_expose_the_late_type_internally() => _typesFromInternals.All.ShouldContain(TheLateProvider.OnlyTypeItReports);
     [Fact] void should_hold_the_universe_the_container_resolves() => _typesFromInternals.ShouldBeSame(_typesFromTheContainer);
     [Fact] void should_leave_the_container_with_one_universe() => _registeredUniverses.ShouldEqual(1);
-
-    /// <summary>
-    /// Compares references rather than contents: nothing in <c>AddCratisArcCore</c> touches <c>Types.Instance</c>
-    /// any more, so whether that static holds the late type depends only on when some test first reads it, and a
-    /// content comparison would pass or fail on test order.
-    /// </summary>
-    [Fact] void should_not_be_the_static_snapshot() => _typesFromInternals.ShouldNotBeSame(Cratis.Types.Types.Instance);
     [Fact] void should_expose_the_late_derived_type_to_the_container() => _derivedTypesFromTheContainer.IsDerivedType(TheLateProvider.OnlyDerivedTypeItReports).ShouldBeTrue();
     [Fact] void should_expose_the_late_derived_type_internally() => _derivedTypesFromInternals.IsDerivedType(TheLateProvider.OnlyDerivedTypeItReports).ShouldBeTrue();
     [Fact] void should_expose_the_late_target_type_as_having_derivatives() => _derivedTypesFromInternals.TypesWithDerivatives.ShouldContain(TheLateProvider.TargetOfTheOnlyDerivedTypeItReports);
     [Fact] void should_hold_the_derived_types_the_container_resolves() => _derivedTypesFromInternals.ShouldBeSame(_derivedTypesFromTheContainer);
     [Fact] void should_leave_the_container_with_one_set_of_derived_types() => _registeredDerivedTypes.ShouldEqual(1);
-
-    /// <summary>
-    /// Compares references for the same reason <c>should_not_be_the_static_snapshot</c> does, and reading
-    /// <see cref="DerivedTypes.Instance"/> is what would pin <c>Types.Instance</c> early if production code did it.
-    /// </summary>
-    [Fact] void should_not_be_the_static_derived_types_snapshot() => _derivedTypesFromInternals.ShouldNotBeSame(DerivedTypes.Instance);
 }

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_registers_while_the_universe_is_built.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_registers_while_the_universe_is_built.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
+
+[Collection("MutatesTypeDiscovery")]
+public class and_a_generated_provider_registers_while_the_universe_is_built : Specification
+{
+    ITypes _typesFromTheContainer;
+    ITypes _typesFromInternals;
+    int _registeredUniverses;
+
+    void Establish() => GeneratedTypeDiscoveryRegistry.Register(new TheProviderThatBringsInTheLateOne());
+
+    void Because()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddCratisArcCore()
+            .BuildServiceProvider();
+
+        _typesFromTheContainer = serviceProvider.GetRequiredService<ITypes>();
+        _registeredUniverses = serviceProvider.GetServices<ITypes>().Count();
+        _typesFromInternals = Internals.Types;
+    }
+
+    [Fact] void should_expose_the_late_type_to_the_container() => _typesFromTheContainer.All.ShouldContain(TheLateProvider.OnlyTypeItReports);
+    [Fact] void should_expose_the_late_type_internally() => _typesFromInternals.All.ShouldContain(TheLateProvider.OnlyTypeItReports);
+    [Fact] void should_hold_the_universe_the_container_resolves() => _typesFromInternals.ShouldBeSame(_typesFromTheContainer);
+    [Fact] void should_leave_the_container_with_one_universe() => _registeredUniverses.ShouldEqual(1);
+    [Fact] void should_not_be_the_static_snapshot() => Cratis.Types.Types.Instance.All.ShouldNotContain(TheLateProvider.OnlyTypeItReports);
+}

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/it_should_hold_every_type_the_registered_providers_report.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/it_should_hold_every_type_the_registered_providers_report.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
+
+[Collection("MutatesTypeDiscovery")]
+public class it_should_hold_every_type_the_registered_providers_report : Specification
+{
+    Type[] _typesTheProvidersReport;
+    Type[] _typesTheUniverseIsMissing;
+
+    /// <summary>
+    /// Compares the universe against the registry rather than against a named type, so it holds whatever else has
+    /// registered a provider by the time it runs.
+    /// </summary>
+    /// <remarks>
+    /// In this assembly it passes on very little - nothing here arrives through the assembly closure walk, which
+    /// is what the separate Arc.Core.TypeDiscovery.Specs process exists to cover. It costs one set difference and
+    /// catches the whole class of regression in any host: a universe taken before a provider registered is missing
+    /// that provider's types, and the registry is the only thing that can say so.
+    /// </remarks>
+    void Because()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddCratisArcCore()
+            .BuildServiceProvider();
+
+        _typesTheProvidersReport = [.. GeneratedTypeDiscoveryRegistry.Providers.SelectMany(_ => _.DefinedTypes).Distinct()];
+        _typesTheUniverseIsMissing = [.. _typesTheProvidersReport.Except(Internals.Types.All)];
+    }
+
+    [Fact] void should_have_been_given_something_to_check() => _typesTheProvidersReport.ShouldNotBeEmpty();
+    [Fact] void should_be_missing_none_of_them() => _typesTheUniverseIsMissing.ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/Arc.Core.TypeDiscovery.Specs.Plugin.csproj
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/Arc.Core.TypeDiscovery.Specs.Plugin.csproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <!-- The specification half of this pair is Arc.Core.TypeDiscovery.Specs. This project deliberately does not
+         end in .Specs, so the workflow's spec discovery (find -name "*.Specs.csproj") does not try to run it as
+         a test project. -->
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.Core.TypeDiscovery.Specs.Plugin</AssemblyName>
+        <RootNamespace>Cratis.Arc.TypeDiscovery.Plugin</RootNamespace>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Cratis.Fundamentals" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/IPluginMarker.cs
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/IPluginMarker.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.TypeDiscovery.Plugin;
+
+/// <summary>
+/// The contract <see cref="PluginMarker"/> implements, so a specification can ask a universe for it through
+/// <c>FindMultiple</c> rather than only looking for the type by name.
+/// </summary>
+public interface IPluginMarker;

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/PluginMarker.cs
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/PluginMarker.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.TypeDiscovery.Plugin;
+
+/// <summary>
+/// The one type this assembly exists to have discovered.
+/// </summary>
+/// <remarks>
+/// It reaches a universe only through <see cref="PluginTypeDiscoveryProvider"/>, which only a module initializer
+/// registers - so finding it means the universe was built after this assembly was initialized, and nothing else
+/// about the arrangement can produce that result.
+/// </remarks>
+public class PluginMarker : IPluginMarker;

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/PluginTypeDiscoveryProvider.cs
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/PluginTypeDiscoveryProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Types;
+
+namespace Cratis.Arc.TypeDiscovery.Plugin;
+
+/// <summary>
+/// Reports this assembly and <see cref="PluginMarker"/> to type discovery, in the shape the Fundamentals type
+/// discovery generator emits.
+/// </summary>
+/// <remarks>
+/// Written out by hand rather than left to the generator so the specification does not depend on which analyzers
+/// happened to run over this project, and so the one type that carries the whole point of the arrangement is
+/// visible in source.
+/// </remarks>
+public sealed class PluginTypeDiscoveryProvider : ICanProvideAssembliesForDiscovery
+{
+    /// <inheritdoc/>
+    public IEnumerable<Assembly> Assemblies => [typeof(PluginTypeDiscoveryProvider).Assembly];
+
+    /// <inheritdoc/>
+    public IEnumerable<Type> DefinedTypes => [typeof(IPluginMarker), typeof(PluginMarker)];
+
+    /// <inheritdoc/>
+    public void Initialize()
+    {
+    }
+}

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/PluginTypeDiscoveryRegistration.cs
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs.Plugin/PluginTypeDiscoveryRegistration.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Cratis.Types;
+
+namespace Cratis.Arc.TypeDiscovery.Plugin;
+
+/// <summary>
+/// Registers <see cref="PluginTypeDiscoveryProvider"/> from a module initializer, which is the only route by which
+/// it ever reaches the registry.
+/// </summary>
+/// <remarks>
+/// This is the shape the Fundamentals type discovery generator emits, and the reason a generated provider can
+/// arrive after a universe has already been built: the runtime defers a module initializer until something in the
+/// module is first accessed, and for an assembly reachable only through the reference closure that is the closure
+/// walk in <c>AddBindingsByConvention</c> and <c>AddSelfBindings</c>.
+/// </remarks>
+internal static class PluginTypeDiscoveryRegistration
+{
+    /// <summary>
+    /// Registers the provider with the process-wide registry.
+    /// </summary>
+    [ModuleInitializer]
+    [SuppressMessage("Usage", "CA2255:The 'ModuleInitializer' attribute should not be used in libraries", Justification = "Reproducing what the Fundamentals type discovery generator emits is the entire purpose of this assembly.")]
+    internal static void Register() => GeneratedTypeDiscoveryRegistry.Register(new PluginTypeDiscoveryProvider());
+}

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs/Arc.Core.TypeDiscovery.Specs.csproj
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs/Arc.Core.TypeDiscovery.Specs.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.Core.TypeDiscovery.Specs</AssemblyName>
+        <RootNamespace>Cratis.Arc</RootNamespace>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../Arc.Core/Arc.Core.csproj" />
+
+        <!-- Ordering only. The plugin must NOT be a ProjectReference: that would list it in this project's
+             deps.json as a "project" runtime library, and GeneratedMetadataRegistration runs the module
+             initializer of every one of those at the very top of AddCratisArcCore - before the universe is taken,
+             which is the exact moment this project exists to test. ReferenceOutputAssembly, ExcludeAssets and
+             PrivateAssets keep this to a build-order edge; the assembly itself comes in through the Reference
+             below. -->
+        <ProjectReference Include="../Arc.Core.TypeDiscovery.Specs.Plugin/Arc.Core.TypeDiscovery.Specs.Plugin.csproj"
+                          ReferenceOutputAssembly="false"
+                          ExcludeAssets="all"
+                          PrivateAssets="all" />
+
+        <!-- A raw reference with Private=true puts the plugin in the compile closure and in the output folder
+             without making it a project library. Nothing loads it until the assembly reference closure walk in
+             AddBindingsByConvention reaches it, which is what the specification is about. -->
+        <Reference Include="Cratis.Arc.Core.TypeDiscovery.Specs.Plugin">
+            <HintPath>$(MSBuildThisFileDirectory)../Arc.Core.TypeDiscovery.Specs.Plugin/bin/$(Configuration)/$(TargetFramework)/Cratis.Arc.Core.TypeDiscovery.Specs.Plugin.dll</HintPath>
+            <Private>true</Private>
+        </Reference>
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs/KeepsThePluginInTheReferenceClosure.cs
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs/KeepsThePluginInTheReferenceClosure.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.TypeDiscovery.Plugin;
+
+namespace Cratis.Arc;
+
+/// <summary>
+/// Uses a plugin type so the compiler emits an assembly reference to it, and does so from a method nothing calls
+/// so nothing loads the plugin before the specification does.
+/// </summary>
+/// <remarks>
+/// The C# compiler omits a reference to an assembly whose types the compilation never uses, and the assembly
+/// closure walk this project is about finds candidates through <c>Assembly.GetReferencedAssemblies</c> - so
+/// without a use somewhere, the plugin would be sitting in the output folder unreferenced and unreachable, and
+/// the specification would pass by discovering nothing.
+/// </remarks>
+static class KeepsThePluginInTheReferenceClosure
+{
+    /// <summary>
+    /// Never called.
+    /// </summary>
+    /// <returns>The plugin's marker type.</returns>
+    public static Type TheMarkerTypeNothingAsksFor() => typeof(PluginMarker);
+}

--- a/Source/DotNET/Arc.Core.TypeDiscovery.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_arrives_with_the_reference_closure.cs
+++ b/Source/DotNET/Arc.Core.TypeDiscovery.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/and_a_generated_provider_arrives_with_the_reference_closure.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.TypeDiscovery.Plugin;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
+
+public class and_a_generated_provider_arrives_with_the_reference_closure : Specification
+{
+    ITypes _typesFromInternals;
+    ITypes _typesFromTheContainer;
+    ITypes _typesFromASecondContainer;
+
+    /// <summary>
+    /// Names no plugin type, so nothing forces the plugin's module initializer before
+    /// <c>AddCratisArcCore</c> reaches the assembly closure walk. The facts run afterwards and are free to.
+    /// </summary>
+    void Because()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddCratisArcCore()
+            .BuildServiceProvider();
+
+        _typesFromTheContainer = serviceProvider.GetRequiredService<ITypes>();
+        _typesFromInternals = Internals.Types;
+
+        using var secondServiceProvider = new ServiceCollection()
+            .AddCratisArcCore()
+            .BuildServiceProvider();
+
+        _typesFromASecondContainer = secondServiceProvider.GetRequiredService<ITypes>();
+    }
+
+    [Fact] void should_discover_the_plugins_marker_type() => _typesFromInternals.All.ShouldContain(typeof(PluginMarker));
+    [Fact] void should_find_the_plugins_marker_type_through_its_contract() => _typesFromInternals.FindMultiple<IPluginMarker>().ShouldContain(typeof(PluginMarker));
+    [Fact] void should_hold_the_universe_the_container_resolves() => _typesFromInternals.ShouldBeSame(_typesFromTheContainer);
+    [Fact] void should_hand_a_second_container_the_same_universe() => _typesFromASecondContainer.ShouldBeSame(_typesFromInternals);
+}

--- a/Source/DotNET/Arc.Core/Arc.Core.csproj
+++ b/Source/DotNET/Arc.Core/Arc.Core.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <InternalsVisibleTo Include="Cratis.Arc" />
         <InternalsVisibleTo Include="Cratis.Arc.Core.Specs" />
+        <InternalsVisibleTo Include="Cratis.Arc.Core.TypeDiscovery.Specs" />
         <InternalsVisibleTo Include="Cratis.Arc.MongoDB" />
         <InternalsVisibleTo Include="Cratis.Arc.MongoDB.Specs" />
         <InternalsVisibleTo Include="Cratis.Arc.EntityFrameworkCore" />

--- a/Source/DotNET/Arc.Core/GeneratedMetadataRegistration.cs
+++ b/Source/DotNET/Arc.Core/GeneratedMetadataRegistration.cs
@@ -2,28 +2,40 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyModel;
 
 namespace Cratis.Arc;
 
 /// <summary>
-/// Performs startup registration of generated metadata from project assemblies.
+/// Runs the module initializers that register compile-time generated metadata, for every project assembly in the
+/// application's dependency context.
 /// </summary>
+/// <remarks>
+/// Generators such as <c>QueryMetadataGenerator</c> emit a <c>[ModuleInitializer]</c> that registers what they
+/// generated. The runtime runs a module initializer on first access to something in the module, not on load - so an
+/// assembly nothing has touched yet has registered nothing, however many of them are sitting in the dependency
+/// context.
+/// </remarks>
 static class GeneratedMetadataRegistration
 {
-    static int _hasLoadedProjectAssemblies;
+    static int _hasRunProjectModuleInitializers;
 
     /// <summary>
-    /// Ensures generated metadata has been registered for all project assemblies.
+    /// Ensures the module initializers of every project assembly have run, so the metadata they register is
+    /// available.
     /// </summary>
+    /// <remarks>
+    /// Runs once per process; subsequent calls return immediately.
+    /// </remarks>
     public static void EnsureGeneratedMetadataRegistered()
     {
-        EnsureProjectAssembliesLoaded();
+        EnsureProjectModuleInitializersHaveRun();
     }
 
-    static void EnsureProjectAssembliesLoaded()
+    static void EnsureProjectModuleInitializersHaveRun()
     {
-        if (Interlocked.Exchange(ref _hasLoadedProjectAssemblies, 1) == 1)
+        if (Interlocked.Exchange(ref _hasRunProjectModuleInitializers, 1) == 1)
         {
             return;
         }
@@ -38,11 +50,16 @@ static class GeneratedMetadataRegistration
         {
             try
             {
-                _ = Assembly.Load(new AssemblyName(runtimeLibrary.Name));
+                var assembly = Assembly.Load(new AssemblyName(runtimeLibrary.Name));
+
+                // Loading is not enough on its own: the runtime defers the module initializer until something in the
+                // module is first accessed, and merely holding an Assembly is not that. RunModuleConstructor forces
+                // it, and the runtime still guarantees it runs at most once however it was reached.
+                RuntimeHelpers.RunModuleConstructor(assembly.ManifestModule.ModuleHandle);
             }
             catch
             {
-                // Ignore failures and continue with assemblies that can be loaded.
+                // Ignore failures and continue with assemblies that can be loaded and initialized.
             }
         }
     }

--- a/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
+++ b/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
@@ -157,21 +157,18 @@ public static class HostBuilderExtensions
     /// <returns>The <see cref="ITypes"/> the container will hand out.</returns>
     /// <remarks>
     /// <para>
-    /// <c>AddBindingsByConvention</c> and <c>AddSelfBindings</c> walk the assembly reference closure and run module
-    /// constructors, which is where generated providers for assemblies nothing had touched yet register themselves.
-    /// A universe built before that walk is missing everything the walk brings in, and nothing about it says so - a
-    /// shorter <c>ITypes.All</c> is indistinguishable from a feature nobody wrote. That is why the universe is taken
-    /// here rather than at the top of <c>AddCratisArcCore</c>, and why <c>Types.Instance</c> is no longer used for
-    /// it at all: being a static field it snapshots the provider registry the first time anything touches the type,
-    /// so a later provider can never reach it.
+    /// Generated type discovery providers register from module constructors, which run only when something reaches
+    /// their assembly. A universe built before that has happened is missing everything a later provider brings in,
+    /// and nothing about it says so - a shorter <c>ITypes.All</c> is indistinguishable from a feature nobody wrote.
+    /// <see cref="TypesServiceCollectionExtensions.CurrentTypeUniverse"/> runs that provider walk itself and returns
+    /// the one instance <see cref="TypesServiceCollectionExtensions.AddTypeDiscovery"/> registers, which is why
+    /// <c>Types.Instance</c> is not used at all: being a static field it snapshots the provider registry the first
+    /// time anything touches the type, so a later provider can never reach it.
     /// </para>
     /// <para>
-    /// Asking <c>AddTypeDiscovery</c> for the universe - rather than constructing one - is what keeps this instance
-    /// identical to the one a container configured after the walk resolves. Fundamentals 7.18.5 adds to that only
-    /// the cost: it keys its default universe on the registered provider set, so this rebuilds while the set is
-    /// still growing and is a lookup once it has settled, where 7.18.2 built an equally correct universe from
-    /// scratch every call. Correctness comes from taking the universe late; the pin moves so that taking it late
-    /// stays affordable for a host that configures many containers.
+    /// <c>Replace</c> rather than trusting that identity: a provider registering between <c>AddTypeDiscovery</c>
+    /// and this call rebuilds the universe, and the container would otherwise hold the older one. Fundamentals
+    /// 7.19.1 is the floor because earlier versions left running the walk to the caller.
     /// </para>
     /// <para>
     /// Reordering the chain to walk before <c>AddTypeDiscovery</c> would work out to the same universe, but it also
@@ -181,12 +178,8 @@ public static class HostBuilderExtensions
     /// </remarks>
     static ITypes UseCurrentTypeUniverse(this IServiceCollection services)
     {
-        var current = (ITypes)new ServiceCollection()
-            .AddTypeDiscovery()
-            .Single(_ => _.ServiceType == typeof(ITypes))
-            .ImplementationInstance!;
-
-        services.Replace(ServiceDescriptor.Singleton<ITypes>(current));
+        var current = TypesServiceCollectionExtensions.CurrentTypeUniverse();
+        services.Replace(ServiceDescriptor.Singleton(current));
         return current;
     }
 

--- a/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
+++ b/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Cratis.Conversion;
 using Cratis.DependencyInjection;
 using Cratis.Execution;
 using Cratis.Serialization;
+using Cratis.Types;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -79,8 +80,6 @@ public static class HostBuilderExtensions
     {
         GeneratedMetadataRegistration.EnsureGeneratedMetadataRegistered();
 
-        Internals.Types = Types.Types.Instance;
-        Internals.Types.RegisterTypeConvertersForConcepts();
         Internals.DerivedTypes = DerivedTypes.Instance;
         TypeConverters.Register();
 
@@ -114,6 +113,9 @@ public static class HostBuilderExtensions
             .AddBindingsByConvention()
             .AddSelfBindings();
 
+        Internals.Types = services.UseCurrentTypeUniverse();
+        Internals.Types.RegisterTypeConvertersForConcepts();
+
         services.AddCratisCommands();
         services.AddCratisQueries();
 
@@ -145,5 +147,47 @@ public static class HostBuilderExtensions
             .AddActivitySource<QueryFilters>(Internals.ActivitySourceName)
             .AddActivitySource<QueryPipeline>(Internals.ActivitySourceName)
             .AddActivitySource<IdentityProvider>(Internals.ActivitySourceName);
+    }
+
+    /// <summary>
+    /// Registers the type universe as it stands once every generated type discovery provider has registered,
+    /// replacing the one <see cref="TypesServiceCollectionExtensions.AddTypeDiscovery"/> registered earlier, and
+    /// returns it so the caller holds the same instance the container resolves.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/> to register the universe with.</param>
+    /// <returns>The <see cref="ITypes"/> the container will hand out.</returns>
+    /// <remarks>
+    /// <para>
+    /// <c>AddBindingsByConvention</c> and <c>AddSelfBindings</c> walk the assembly reference closure and run module
+    /// constructors, which is where generated providers for assemblies nothing had touched yet register themselves.
+    /// A universe built before that walk is missing everything the walk brings in, and nothing about it says so - a
+    /// shorter <c>ITypes.All</c> is indistinguishable from a feature nobody wrote. That is why the universe is taken
+    /// here rather than at the top of <c>AddCratisArcCore</c>, and why <c>Types.Instance</c> is no longer used for
+    /// it at all: being a static field it snapshots the provider registry the first time anything touches the type,
+    /// so a later provider can never reach it.
+    /// </para>
+    /// <para>
+    /// Asking <c>AddTypeDiscovery</c> for the universe - rather than constructing one - is what keeps this instance
+    /// identical to the one a container configured after the walk resolves. Fundamentals 7.18.5 adds to that only
+    /// the cost: it keys its default universe on the registered provider set, so this rebuilds while the set is
+    /// still growing and is a lookup once it has settled, where 7.18.2 built an equally correct universe from
+    /// scratch every call. Correctness comes from taking the universe late; the pin moves so that taking it late
+    /// stays affordable for a host that configures many containers.
+    /// </para>
+    /// <para>
+    /// Reordering the chain to walk before <c>AddTypeDiscovery</c> would work out to the same universe, but it also
+    /// exposes <c>ITypes</c> and <c>IDerivedTypes</c> to convention binding, and a conventionally bound
+    /// <c>ITypes</c> constructs a whole new universe per resolution.
+    /// </para>
+    /// </remarks>
+    static ITypes UseCurrentTypeUniverse(this IServiceCollection services)
+    {
+        var current = (ITypes)new ServiceCollection()
+            .AddTypeDiscovery()
+            .Single(_ => _.ServiceType == typeof(ITypes))
+            .ImplementationInstance!;
+
+        services.Replace(ServiceDescriptor.Singleton<ITypes>(current));
+        return current;
     }
 }

--- a/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
+++ b/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
@@ -80,7 +80,6 @@ public static class HostBuilderExtensions
     {
         GeneratedMetadataRegistration.EnsureGeneratedMetadataRegistered();
 
-        Internals.DerivedTypes = DerivedTypes.Instance;
         TypeConverters.Register();
 
         services.AddSingleton<ICorrelationIdAccessor, CorrelationIdAccessor>();
@@ -109,12 +108,12 @@ public static class HostBuilderExtensions
             .AddCratisArcMeter()
             .AddCratisArcActivitySource()
             .AddTypeDiscovery()
-            .AddSingleton(Internals.DerivedTypes)
             .AddBindingsByConvention()
             .AddSelfBindings();
 
         Internals.Types = services.UseCurrentTypeUniverse();
         Internals.Types.RegisterTypeConvertersForConcepts();
+        Internals.DerivedTypes = services.UseDerivedTypesFrom(Internals.Types);
 
         services.AddCratisCommands();
         services.AddCratisQueries();
@@ -176,8 +175,8 @@ public static class HostBuilderExtensions
     /// </para>
     /// <para>
     /// Reordering the chain to walk before <c>AddTypeDiscovery</c> would work out to the same universe, but it also
-    /// exposes <c>ITypes</c> and <c>IDerivedTypes</c> to convention binding, and a conventionally bound
-    /// <c>ITypes</c> constructs a whole new universe per resolution.
+    /// exposes <c>ITypes</c> to convention binding, and a conventionally bound <c>ITypes</c> constructs a whole new
+    /// universe per resolution.
     /// </para>
     /// </remarks>
     static ITypes UseCurrentTypeUniverse(this IServiceCollection services)
@@ -188,6 +187,39 @@ public static class HostBuilderExtensions
             .ImplementationInstance!;
 
         services.Replace(ServiceDescriptor.Singleton<ITypes>(current));
+        return current;
+    }
+
+    /// <summary>
+    /// Registers the derived types read off the given universe, replacing whatever else claimed
+    /// <see cref="IDerivedTypes"/> while the collection was being built, and returns it so the caller holds the same
+    /// instance the container resolves.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/> to register the derived types with.</param>
+    /// <param name="types">The <see cref="ITypes"/> universe to read derived types off.</param>
+    /// <returns>The <see cref="DerivedTypes"/> the container will hand out.</returns>
+    /// <remarks>
+    /// <para>
+    /// <see cref="DerivedTypes.Instance"/> is built from <c>Types.Instance</c>, so it carries the same narrowed
+    /// universe taking <c>Internals.Types</c> late exists to avoid - and merely reading it pins that static to
+    /// whatever the provider registry held at that moment, for the rest of the process and for every other Cratis
+    /// product sharing it. Building from the universe Arc just took keeps polymorphic JSON and the MongoDB
+    /// discriminator conventions seeing the same types everything else in the host sees, at the cost of no longer
+    /// sharing Fundamentals' global singleton. The cost is one more pass over a universe
+    /// <c>RegisterTypeConvertersForConcepts</c> has already walked in the same call.
+    /// </para>
+    /// <para>
+    /// <c>Replace</c> rather than <c>AddSingleton</c> because <c>AddBindingsByConvention</c> binds
+    /// <see cref="IDerivedTypes"/> to <see cref="DerivedTypes"/> by convention unless the service type is already
+    /// registered, and it now runs first. A conventionally bound one would resolve off the container's
+    /// <see cref="ITypes"/> to an instance that is equivalent but not the one Arc itself holds, which is the
+    /// divergence between <c>Internals</c> and the container this whole sequence exists to close.
+    /// </para>
+    /// </remarks>
+    static DerivedTypes UseDerivedTypesFrom(this IServiceCollection services, ITypes types)
+    {
+        var current = new DerivedTypes(types);
+        services.Replace(ServiceDescriptor.Singleton<IDerivedTypes>(current));
         return current;
     }
 }

--- a/Source/DotNET/MongoDB/MongoDBBuilder.cs
+++ b/Source/DotNET/MongoDB/MongoDBBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Serialization;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Arc.MongoDB;
 
@@ -15,7 +16,7 @@ public class MongoDBBuilder : IMongoDBBuilder
     /// </summary>
     public MongoDBBuilder()
     {
-        var types = Types.Types.Instance;
+        var types = TypesServiceCollectionExtensions.CurrentTypeUniverse();
         ClassMaps = [.. types.FindMultiple(typeof(IBsonClassMapFor<>))];
         ConventionPackFilters = [.. types.FindMultiple<ICanFilterMongoDBConventionPacksForType>()];
         ConventionPackProviders = [.. types.FindMultiple<ICanProvideMongoDBConventionPacks>()];

--- a/Source/DotNET/MongoDB/ServiceCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/ServiceCollectionExtensions.cs
@@ -117,7 +117,7 @@ public static class ServiceCollectionExtensions
     static void AddReadModelCommandResolution(IServiceCollection services)
     {
         var readModelTypes = MongoDBReadModelForCommandResolver
-            .DiscoverReadModelTypes(Cratis.Types.Types.Instance.All)
+            .DiscoverReadModelTypes(TypesServiceCollectionExtensions.CurrentTypeUniverse().All)
             .ToArray();
 
         if (readModelTypes.Length == 0)

--- a/Source/DotNET/Testing/Commands/CommandResultAssertionPolicies.cs
+++ b/Source/DotNET/Testing/Commands/CommandResultAssertionPolicies.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using Cratis.Arc.Commands;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Arc.Testing.Commands;
 
@@ -42,7 +43,7 @@ public static class CommandResultAssertionPolicies
 
     static IReadOnlyList<ICommandResultAssertionPolicy> Discover() =>
     [
-        .. Cratis.Types.Types.Instance.FindMultiple<ICommandResultAssertionPolicy>()
+        .. TypesServiceCollectionExtensions.CurrentTypeUniverse().FindMultiple<ICommandResultAssertionPolicy>()
             .Select(policyType => Activator.CreateInstance(policyType) as ICommandResultAssertionPolicy
                 ?? throw new InvalidOperationException(
                     $"Failed to create an instance of command result assertion policy '{policyType.FullName}'. " +

--- a/Source/DotNET/Testing/Commands/CommandScenario.cs
+++ b/Source/DotNET/Testing/Commands/CommandScenario.cs
@@ -79,7 +79,7 @@ public class CommandScenario<TCommand> : IDisposable, IAsyncDisposable
 
         Context = new Dictionary<string, object>();
 
-        foreach (var extender in Cratis.Types.Types.Instance.FindMultiple<ICommandScenarioExtender>()
+        foreach (var extender in TypesServiceCollectionExtensions.CurrentTypeUniverse().FindMultiple<ICommandScenarioExtender>()
                      .Select(extenderType => Activator.CreateInstance(extenderType) as ICommandScenarioExtender
                          ?? throw new InvalidOperationException(
                              $"Failed to create an instance of command scenario extender '{extenderType.FullName}'. " +
@@ -250,7 +250,7 @@ public class CommandScenario<TCommand> : IDisposable, IAsyncDisposable
         // command scope (see DiscoverableValidators.TryGet), so a validator taking a read model resolves the same
         // way a command handler does — no registration required.
         var discoverableValidators = new DiscoverableValidators(
-            Cratis.Types.Types.Instance,
+            TypesServiceCollectionExtensions.CurrentTypeUniverse(),
             () => serviceProvider ?? throw new InvalidOperationException("The command scenario service provider has not been built."));
 
         if (!hasExplicitDiscoverableValidatorsRegistration)


### PR DESCRIPTION
## Changed

- `Cratis.Fundamentals` floor raised to 7.19.1, which shares one type universe per provider set and runs the generated-provider walk inside its `CurrentTypeUniverse()` accessor (#2666)

## Fixed

- Arc no longer captures the type universe before generated type discovery providers register, so controller discovery, the `IArcBuilder` handed to `configureBuilder` and concept type converters see every type the binding-convention assembly walk brings in (#2666)
- The `ITypes` resolved from the container is now the same instance Arc uses during setup, built from the complete provider set (#2666)
- `IDerivedTypes` is built from that same complete universe instead of the process-wide snapshot, so polymorphic JSON and the MongoDB discriminator conventions recognize `[DerivedType]` types the assembly walk brings in, and the container resolves the same instance Arc uses (#2668)
- Compile-time generated query metadata is now reliably registered at startup: Arc loaded project assemblies without running their module initializers, so metadata from an assembly nothing had touched yet was never registered (#2666)
- `CommandScenario` extenders and discoverable validators, command result assertion policies, the MongoDB builder's class maps and convention packs, and MongoDB read-model command resolution are discovered from the complete type universe instead of the process-wide snapshot (#2666)
