### PR TITLE
Group Chronicle under integrations navigation

### DIFF
--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -20,8 +20,10 @@
   href: scenarios/toc.yml
 - name: Backend
   href: backend/toc.yml
-- name: Integrate with Chronicle
-  href: backend/chronicle/toc.yml
+- name: Integrations
+  items:
+    - name: Chronicle
+      href: backend/chronicle/toc.yml
 - name: Frontend
   href: frontend/toc.yml
 - name: General


### PR DESCRIPTION
## Changed

- Group Chronicle beneath an extensible Integrations section in the Arc documentation navigation.
