### PR TITLE
Fix cross-agent project concern links

### DIFF
--- a/.cratis/ai/rules/project.md
+++ b/.cratis/ai/rules/project.md
@@ -10,6 +10,6 @@ event-sourced application patterns here.
 
 Read every concern below before working in this repository. Together they are the project-owned instructions and override conflicting shared guidance.
 
-- [What Arc owns](project/what-arc-owns.md)
-- [Commands](project/commands.md)
-- [AI-assisted development](project/ai-assisted-development.md)
+- [What Arc owns](.cratis/ai/rules/project/what-arc-owns.md)
+- [Commands](.cratis/ai/rules/project/commands.md)
+- [AI-assisted development](.cratis/ai/rules/project/ai-assisted-development.md)


### PR DESCRIPTION
## Fixed
- Make every project concern link repository-root-relative so it resolves through symlinked `AGENTS.md`, `CLAUDE.md`, and native harness adapters.
- Keep every concern file project-owned and outside the managed manifest.

## Verification
- Every linked concern exists.
- `git diff --check` passes.
